### PR TITLE
handle Ptr{Cstring} better

### DIFF
--- a/gen/rewriter.jl
+++ b/gen/rewriter.jl
@@ -163,8 +163,6 @@ function rewriter(ex::Expr)
         if intype in opaquepointers
             # in C the opaque pointers are all typedef void *, i.e. Ptr{Void}
             intypes[i] = :(Ptr{Void})
-        elseif intype == :(Ptr{Cstring})
-            intypes[i] = :StringList  # see misc.jl
         end
     end
     # modify ccall return type or wrap entire ccall based on return type

--- a/gen/rewriter.jl
+++ b/gen/rewriter.jl
@@ -38,6 +38,7 @@ const custom_rename = Dict{String, String}(
     # prevent overwriting Base functions
     "gdalinfo" => "Base.info",
     "ogr_g_isempty" => "Base.isempty",
+    "ogr_g_length" => "Base.length",
 
     # prevent automatic renaming
     "ogrgetdrivercount" => "ogrgetdrivercount",

--- a/gen/rewriter.jl
+++ b/gen/rewriter.jl
@@ -172,8 +172,7 @@ function rewriter(ex::Expr)
     if rettype == :(Cstring)
         ex.args[2].args[1] = :(unsafe_string($ccall_call))
     elseif rettype == :(Ptr{Cstring})
-        # TODO: this only unpacks the first of a list of strings
-        ex.args[2].args[1] = :(unsafe_string(unsafe_load($ccall_call)))
+        ex.args[2].args[1] = :(unsafe_loadstringlist($ccall_call))
     elseif rettype in opaquepointers
         # wrap output type in Ptr{} since memory is managed by GDAL
         ccall_call.args[3] = :(Ptr{$rettype})

--- a/src/C/misc.jl
+++ b/src/C/misc.jl
@@ -1,6 +1,2 @@
 const FILE = Void # not sure if this works
 const time_t = Void # not sure if this works
-
-# C functions that take an argument of the type char** can be called
-# by using a Ptr{Ptr{UInt8}} type within Julia.
-const StringList = Ptr{Ptr{UInt8}}

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -73,4 +73,23 @@ function __init__()
     ccall(fconf, Void, (Cstring, Cstring), "GDAL_DATA", GDAL_DATA)
 end
 
+"""
+Load a null-terminated list of strings
+
+That is it expects a `StringList`, in the sense of the CPL functions,
+as a null-terminated array of strings.
+"""
+function unsafe_loadstringlist(ptr::Ptr{Cstring})
+    strings = Vector{String}()
+    (ptr == C_NULL) && return strings
+    i = 1
+    cstring = unsafe_load(ptr, i)
+    while cstring != C_NULL
+        push!(strings, unsafe_string(cstring))
+        i += 1
+        cstring = unsafe_load(ptr, i)
+    end
+    strings
 end
+
+end # module

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -568,7 +568,7 @@ end
     RPCInfoToMD(GDALRPCInfo * psRPCInfo) -> char **
 """
 function rpcinfotomd(psRPCInfo)
-    unsafe_string(unsafe_load(ccall((:RPCInfoToMD, libgdal), Ptr{Cstring}, (Ptr{GDALRPCInfo},), psRPCInfo)))
+    unsafe_loadstringlist(ccall((:RPCInfoToMD, libgdal), Ptr{Cstring}, (Ptr{GDALRPCInfo},), psRPCInfo))
 end
 
 

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -92,7 +92,7 @@ end
 Compute the proximity of all pixels in the image to a set of pixels in the source image.
 """
 function computeproximity(hSrcBand::Ref{GDALRasterBandH}, hProximityBand::Ref{GDALRasterBandH}, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALComputeProximity, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), hSrcBand, hProximityBand, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALComputeProximity, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcBand, hProximityBand, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -122,7 +122,7 @@ Fill selected raster regions by interpolation from the edges.
 CE_None on success or CE_Failure if something goes wrong.
 """
 function fillnodata(hTargetBand::Ref{GDALRasterBandH}, hMaskBand::Ref{GDALRasterBandH}, dfMaxSearchDist::Real, bDeprecatedOption::Integer, nSmoothingIterations::Integer, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALFillNodata, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Cdouble, Cint, Cint, StringList, Ptr{Void}, Ptr{Void}), hTargetBand, hMaskBand, dfMaxSearchDist, bDeprecatedOption, nSmoothingIterations, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALFillNodata, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Cdouble, Cint, Cint, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hTargetBand, hMaskBand, dfMaxSearchDist, bDeprecatedOption, nSmoothingIterations, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -151,7 +151,7 @@ Create polygon coverage from raster data.
 CE_None on success or CE_Failure on a failure.
 """
 function polygonize(hSrcBand::Ref{GDALRasterBandH}, hMaskBand::Ref{GDALRasterBandH}, hOutLayer::Ref{OGRLayerH}, iPixValField::Integer, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALPolygonize, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, StringList, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALPolygonize, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -180,7 +180,7 @@ Create polygon coverage from raster data.
 CE_None on success or CE_Failure on a failure.
 """
 function fpolygonize(hSrcBand::Ref{GDALRasterBandH}, hMaskBand::Ref{GDALRasterBandH}, hOutLayer::Ref{OGRLayerH}, iPixValField::Integer, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALFPolygonize, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, StringList, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALFPolygonize, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -210,7 +210,7 @@ Removes small raster polygons.
 CE_None on success or CE_Failure if an error occurs.
 """
 function sievefilter(hSrcBand::Ref{GDALRasterBandH}, hMaskBand::Ref{GDALRasterBandH}, hDstBand::Ref{GDALRasterBandH}, nSizeThreshold::Integer, nConnectedness::Integer, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALSieveFilter, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, Cint, StringList, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hDstBand, nSizeThreshold, nConnectedness, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALSieveFilter, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cint, Cint, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcBand, hMaskBand, hDstBand, nSizeThreshold, nConnectedness, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -290,7 +290,7 @@ Create image to image transformer.
 handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
 """
 function creategenimgprojtransformer2(hSrcDS::Ref{<:GDALDatasetH}, hDstDS::Ref{<:GDALDatasetH}, papszOptions)
-    ccall((:GDALCreateGenImgProjTransformer2, libgdal), Ptr{Void}, (Ptr{Void}, Ptr{Void}, StringList), hSrcDS, hDstDS, papszOptions)
+    ccall((:GDALCreateGenImgProjTransformer2, libgdal), Ptr{Void}, (Ptr{Void}, Ptr{Void}, Ptr{Cstring}), hSrcDS, hDstDS, papszOptions)
 end
 
 
@@ -590,7 +590,7 @@ Create an RPC based transformer.
 transformer callback data (deallocate with GDALDestroyTransformer()).
 """
 function createrpctransformer(psRPC, bReversed::Integer, dfPixErrThreshold::Real, papszOptions)
-    ccall((:GDALCreateRPCTransformer, libgdal), Ptr{Void}, (Ptr{GDALRPCInfo}, Cint, Cdouble, StringList), psRPC, bReversed, dfPixErrThreshold, papszOptions)
+    ccall((:GDALCreateRPCTransformer, libgdal), Ptr{Void}, (Ptr{GDALRPCInfo}, Cint, Cdouble, Ptr{Cstring}), psRPC, bReversed, dfPixErrThreshold, papszOptions)
 end
 
 
@@ -628,7 +628,7 @@ end
 Create GeoLocation transformer.
 """
 function creategeoloctransformer(hBaseDS::Ref{<:GDALDatasetH}, papszGeolocationInfo, bReversed::Integer)
-    ccall((:GDALCreateGeoLocTransformer, libgdal), Ptr{Void}, (Ptr{Void}, StringList, Cint), hBaseDS, papszGeolocationInfo, bReversed)
+    ccall((:GDALCreateGeoLocTransformer, libgdal), Ptr{Void}, (Ptr{Void}, Ptr{Cstring}, Cint), hBaseDS, papszGeolocationInfo, bReversed)
 end
 
 
@@ -746,7 +746,7 @@ Perform simple image warp.
 TRUE if the operation completes, or FALSE if an error occurs.
 """
 function simpleimagewarp(hSrcDS::Ref{<:GDALDatasetH}, hDstDS::Ref{<:GDALDatasetH}, nBandCount::Integer, panBandList, pfnTransform::Ref{GDALTransformerFunc}, pTransformArg, pfnProgress::Any, pProgressArg, papszWarpOptions)
-    ccall((:GDALSimpleImageWarp, libgdal), Cint, (Ptr{Void}, Ptr{Void}, Cint, Ptr{Cint}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList), hSrcDS, hDstDS, nBandCount, panBandList, pfnTransform, pTransformArg, pfnProgress, pProgressArg, papszWarpOptions)
+    ccall((:GDALSimpleImageWarp, libgdal), Cint, (Ptr{Void}, Ptr{Void}, Cint, Ptr{Cint}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}), hSrcDS, hDstDS, nBandCount, panBandList, pfnTransform, pTransformArg, pfnProgress, pProgressArg, papszWarpOptions)
 end
 
 
@@ -851,7 +851,7 @@ Transform locations held in bands.
 CE_None on success or CE_Failure if an error occurs.
 """
 function transformgeolocations(hXBand::Ref{GDALRasterBandH}, hYBand::Ref{GDALRasterBandH}, hZBand::Ref{GDALRasterBandH}, pfnTransformer::Ref{GDALTransformerFunc}, pTransformArg, pfnProgress::Any, pProgressArg, papszOptions)
-    ccall((:GDALTransformGeolocations, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList), hXBand, hYBand, hZBand, pfnTransformer, pTransformArg, pfnProgress, pProgressArg, papszOptions)
+    ccall((:GDALTransformGeolocations, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}), hXBand, hYBand, hZBand, pfnTransformer, pTransformArg, pfnProgress, pProgressArg, papszOptions)
 end
 
 
@@ -981,7 +981,7 @@ Burn geometries into raster.
 CE_None on success or CE_Failure on error.
 """
 function rasterizegeometries(hDS::Ref{<:GDALDatasetH}, nBandCount::Integer, panBandList, nGeomCount::Integer, pahGeometries, pfnTransformer::Ref{GDALTransformerFunc}, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALRasterizeGeometries, libgdal), CPLErr, (Ptr{Void}, Cint, Ptr{Cint}, Cint, Ptr{OGRGeometryH}, Ptr{Void}, Ptr{Void}, Ptr{Cdouble}, StringList, Ptr{Void}, Ptr{Void}), hDS, nBandCount, panBandList, nGeomCount, pahGeometries, pfnTransformer, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALRasterizeGeometries, libgdal), CPLErr, (Ptr{Void}, Cint, Ptr{Cint}, Cint, Ptr{OGRGeometryH}, Ptr{Void}, Ptr{Void}, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hDS, nBandCount, panBandList, nGeomCount, pahGeometries, pfnTransformer, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -1027,7 +1027,7 @@ Burn geometries from the specified list of layers into raster.
 CE_None on success or CE_Failure on error.
 """
 function rasterizelayers(hDS::Ref{<:GDALDatasetH}, nBandCount::Integer, panBandList, nLayerCount::Integer, pahLayers, pfnTransformer::Ref{GDALTransformerFunc}, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALRasterizeLayers, libgdal), CPLErr, (Ptr{Void}, Cint, Ptr{Cint}, Cint, Ptr{OGRLayerH}, Ptr{Void}, Ptr{Void}, Ptr{Cdouble}, StringList, Ptr{Void}, Ptr{Void}), hDS, nBandCount, panBandList, nLayerCount, pahLayers, pfnTransformer, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALRasterizeLayers, libgdal), CPLErr, (Ptr{Void}, Cint, Ptr{Cint}, Cint, Ptr{OGRLayerH}, Ptr{Void}, Ptr{Void}, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hDS, nBandCount, panBandList, nLayerCount, pahLayers, pfnTransformer, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -1081,7 +1081,7 @@ Burn geometries from the specified list of layer into raster.
 CE_None on success or CE_Failure on error.
 """
 function rasterizelayersbuf(pData, nBufXSize::Integer, nBufYSize::Integer, eBufType::GDALDataType, nPixelSpace::Integer, nLineSpace::Integer, nLayerCount::Integer, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer::Ref{GDALTransformerFunc}, pTransformArg, dfBurnValue::Real, papszOptions, pfnProgress::Any, pProgressArg)
-    ccall((:GDALRasterizeLayersBuf, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, GDALDataType, Cint, Cint, Cint, Ptr{OGRLayerH}, Cstring, Ptr{Cdouble}, Ptr{Void}, Ptr{Void}, Cdouble, StringList, Ptr{Void}, Ptr{Void}), pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nLayerCount, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer, pTransformArg, dfBurnValue, papszOptions, pfnProgress, pProgressArg)
+    ccall((:GDALRasterizeLayersBuf, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, GDALDataType, Cint, Cint, Cint, Ptr{OGRLayerH}, Cstring, Ptr{Cdouble}, Ptr{Void}, Ptr{Void}, Cdouble, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nLayerCount, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer, pTransformArg, dfBurnValue, papszOptions, pfnProgress, pProgressArg)
 end
 
 
@@ -1217,7 +1217,7 @@ end
 GDALComputeMatchingPoints.
 """
 function computematchingpoints(hFirstImage::Ref{<:GDALDatasetH}, hSecondImage::Ref{<:GDALDatasetH}, papszOptions, pnGCPCount)
-    ccall((:GDALComputeMatchingPoints, libgdal), Ptr{GDAL_GCP}, (Ptr{Void}, Ptr{Void}, StringList, Ptr{Cint}), hFirstImage, hSecondImage, papszOptions, pnGCPCount)
+    ccall((:GDALComputeMatchingPoints, libgdal), Ptr{GDAL_GCP}, (Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Cint}), hFirstImage, hSecondImage, papszOptions, pnGCPCount)
 end
 
 
@@ -1419,5 +1419,5 @@ SRC_SRS=srs_def. Override projection on hSrcDataset;
 a new dataset corresponding to hSrcDataset adjusted with hGridDataset, or NULL. If not NULL, it must be closed with GDALClose().
 """
 function applyverticalshiftgrid(hSrcDataset::Ref{<:GDALDatasetH}, hGridDataset::Ref{<:GDALDatasetH}, bInverse::Integer, dfSrcUnitToMeter::Real, dfDstUnitToMeter::Real, papszOptions)
-    checknull(ccall((:GDALApplyVerticalShiftGrid, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Ptr{Void}, Cint, Cdouble, Cdouble, StringList), hSrcDataset, hGridDataset, bInverse, dfSrcUnitToMeter, dfDstUnitToMeter, papszOptions))
+    checknull(ccall((:GDALApplyVerticalShiftGrid, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Ptr{Void}, Cint, Cdouble, Cdouble, Ptr{Cstring}), hSrcDataset, hGridDataset, bInverse, dfSrcUnitToMeter, dfDstUnitToMeter, papszOptions))
 end

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -251,7 +251,7 @@ end
 Create a new dataset with this driver.
 """
 function create(hDriver::Ref{<:GDALDriverH}, arg1, arg2::Integer, arg3::Integer, arg4::Integer, arg5::GDALDataType, arg6)
-    checknull(ccall((:GDALCreate, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Cstring, Cint, Cint, Cint, GDALDataType, StringList), hDriver, arg1, arg2, arg3, arg4, arg5, arg6))
+    checknull(ccall((:GDALCreate, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Cstring, Cint, Cint, Cint, GDALDataType, Ptr{Cstring}), hDriver, arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 
@@ -267,7 +267,7 @@ end
 Create a copy of a dataset.
 """
 function createcopy(arg1::Ref{<:GDALDriverH}, arg2, arg3::Ref{<:GDALDatasetH}, arg4::Integer, arg5, arg6::Any, arg7)
-    checknull(ccall((:GDALCreateCopy, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Cstring, Ptr{Void}, Cint, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6, arg7))
+    checknull(ccall((:GDALCreateCopy, libgdal), Ptr{GDALDatasetH}, (Ptr{Void}, Cstring, Ptr{Void}, Cint, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6, arg7))
 end
 
 
@@ -285,7 +285,7 @@ Identify the driver that can open a raster file.
 A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
 """
 function identifydriver(pszFilename, papszFileList)
-    checknull(ccall((:GDALIdentifyDriver, libgdal), Ptr{GDALDriverH}, (Cstring, StringList), pszFilename, papszFileList))
+    checknull(ccall((:GDALIdentifyDriver, libgdal), Ptr{GDALDriverH}, (Cstring, Ptr{Cstring}), pszFilename, papszFileList))
 end
 
 
@@ -307,7 +307,7 @@ Identify the driver that can open a raster file.
 A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
 """
 function identifydriverex(pszFilename, nIdentifyFlags::Integer, papszAllowedDrivers, papszFileList)
-    checknull(ccall((:GDALIdentifyDriverEx, libgdal), Ptr{GDALDriverH}, (Cstring, UInt32, StringList, StringList), pszFilename, nIdentifyFlags, papszAllowedDrivers, papszFileList))
+    checknull(ccall((:GDALIdentifyDriverEx, libgdal), Ptr{GDALDriverH}, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nIdentifyFlags, papszAllowedDrivers, papszFileList))
 end
 
 
@@ -375,7 +375,7 @@ Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file 
 A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
 """
 function openex(pszFilename, nOpenFlags::Integer, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles)
-    checknull(ccall((:GDALOpenEx, libgdal), Ptr{GDALDatasetH}, (Cstring, UInt32, StringList, StringList, StringList), pszFilename, nOpenFlags, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles))
+    checknull(ccall((:GDALOpenEx, libgdal), Ptr{GDALDatasetH}, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nOpenFlags, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles))
 end
 
 
@@ -519,7 +519,7 @@ Validate the list of creation options that are handled by a driver.
 TRUE if the list of creation options is compatible with the Create() and CreateCopy() method of the driver, FALSE otherwise.
 """
 function validatecreationoptions(arg1::Ref{<:GDALDriverH}, papszCreationOptions)
-    ccall((:GDALValidateCreationOptions, libgdal), Cint, (Ptr{Void}, StringList), arg1, papszCreationOptions)
+    ccall((:GDALValidateCreationOptions, libgdal), Cint, (Ptr{Void}, Ptr{Cstring}), arg1, papszCreationOptions)
 end
 
 
@@ -739,7 +739,7 @@ end
 Set metadata.
 """
 function setmetadata(arg1::Ref{<:GDALMajorObjectH}, arg2, arg3)
-    ccall((:GDALSetMetadata, libgdal), CPLErr, (Ptr{Void}, StringList, Cstring), arg1, arg2, arg3)
+    ccall((:GDALSetMetadata, libgdal), CPLErr, (Ptr{Void}, Ptr{Cstring}, Cstring), arg1, arg2, arg3)
 end
 
 
@@ -871,7 +871,7 @@ end
 Add a band to a dataset.
 """
 function addband(hDS::Ref{<:GDALDatasetH}, eType::GDALDataType, papszOptions)
-    ccall((:GDALAddBand, libgdal), CPLErr, (Ptr{Void}, GDALDataType, StringList), hDS, eType, papszOptions)
+    ccall((:GDALAddBand, libgdal), CPLErr, (Ptr{Void}, GDALDataType, Ptr{Cstring}), hDS, eType, papszOptions)
 end
 
 
@@ -915,7 +915,7 @@ Sets up an asynchronous data request.
 handle representing the request.
 """
 function beginasyncreader(hDS::Ref{<:GDALDatasetH}, nXOff::Integer, nYOff::Integer, nXSize::Integer, nYSize::Integer, pBuf, nBufXSize::Integer, nBufYSize::Integer, eBufType::GDALDataType, nBandCount::Integer, panBandMap, nPixelSpace::Integer, nLineSpace::Integer, nBandSpace::Integer, papszOptions)
-    checknull(ccall((:GDALBeginAsyncReader, libgdal), Ptr{GDALAsyncReaderH}, (Ptr{Void}, Cint, Cint, Cint, Cint, Ptr{Void}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, StringList), hDS, nXOff, nYOff, nXSize, nYSize, pBuf, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, papszOptions))
+    checknull(ccall((:GDALBeginAsyncReader, libgdal), Ptr{GDALAsyncReaderH}, (Ptr{Void}, Cint, Cint, Cint, Cint, Ptr{Void}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, Ptr{Cstring}), hDS, nXOff, nYOff, nXSize, nYSize, pBuf, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, papszOptions))
 end
 
 
@@ -999,7 +999,7 @@ end
 Advise driver of upcoming read requests.
 """
 function datasetadviseread(hDS::Ref{<:GDALDatasetH}, nDSXOff::Integer, nDSYOff::Integer, nDSXSize::Integer, nDSYSize::Integer, nBXSize::Integer, nBYSize::Integer, eBDataType::GDALDataType, nBandCount::Integer, panBandCount, papszOptions)
-    ccall((:GDALDatasetAdviseRead, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, StringList), hDS, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, papszOptions)
+    ccall((:GDALDatasetAdviseRead, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Ptr{Cstring}), hDS, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, papszOptions)
 end
 
 
@@ -1209,7 +1209,7 @@ Copy all dataset raster data.
 CE_None on success, or CE_Failure on failure.
 """
 function datasetcopywholeraster(hSrcDS::Ref{<:GDALDatasetH}, hDstDS::Ref{<:GDALDatasetH}, papszOptions, pfnProgress::Any, pProgressData)
-    ccall((:GDALDatasetCopyWholeRaster, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), hSrcDS, hDstDS, papszOptions, pfnProgress, pProgressData)
+    ccall((:GDALDatasetCopyWholeRaster, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcDS, hDstDS, papszOptions, pfnProgress, pProgressData)
 end
 
 
@@ -1233,7 +1233,7 @@ Copy all raster band raster data.
 CE_None on success, or CE_Failure on failure.
 """
 function rasterbandcopywholeraster(hSrcBand::Ref{GDALRasterBandH}, hDstBand::Ref{GDALRasterBandH}, constpapszOptions, pfnProgress::Any, pProgressData)
-    ccall((:GDALRasterBandCopyWholeRaster, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), hSrcBand, hDstBand, constpapszOptions, pfnProgress, pProgressData)
+    ccall((:GDALRasterBandCopyWholeRaster, libgdal), CPLErr, (Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), hSrcBand, hDstBand, constpapszOptions, pfnProgress, pProgressData)
 end
 
 
@@ -1353,7 +1353,7 @@ This function attempts to create a new layer on the dataset with the indicated n
 NULL is returned on failure, or a new OGRLayer handle on success.
 """
 function datasetcreatelayer(arg1::Ref{<:GDALDatasetH}, arg2, arg3::Ref{OGRSpatialReferenceH}, arg4::OGRwkbGeometryType, arg5)
-    checknull(ccall((:GDALDatasetCreateLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Cstring, Ptr{Void}, OGRwkbGeometryType, StringList), arg1, arg2, arg3, arg4, arg5))
+    checknull(ccall((:GDALDatasetCreateLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Cstring, Ptr{Void}, OGRwkbGeometryType, Ptr{Cstring}), arg1, arg2, arg3, arg4, arg5))
 end
 
 
@@ -1375,7 +1375,7 @@ Duplicate an existing layer.
 an handle to the layer, or NULL if an error occurs.
 """
 function datasetcopylayer(arg1::Ref{<:GDALDatasetH}, arg2::Ref{OGRLayerH}, arg3, arg4)
-    checknull(ccall((:GDALDatasetCopyLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Ptr{Void}, Cstring, StringList), arg1, arg2, arg3, arg4))
+    checknull(ccall((:GDALDatasetCopyLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Ptr{Void}, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
 end
 
 
@@ -1611,7 +1611,7 @@ end
 Advise driver of upcoming read requests.
 """
 function rasteradviseread(hRB::Ref{GDALRasterBandH}, nDSXOff::Integer, nDSYOff::Integer, nDSXSize::Integer, nDSYSize::Integer, nBXSize::Integer, nBYSize::Integer, eBDataType::GDALDataType, papszOptions)
-    ccall((:GDALRasterAdviseRead, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, StringList), hRB, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, papszOptions)
+    ccall((:GDALRasterAdviseRead, libgdal), CPLErr, (Ptr{Void}, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Ptr{Cstring}), hRB, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, papszOptions)
 end
 
 
@@ -1856,7 +1856,7 @@ end
 Set the category names for this band.
 """
 function setrastercategorynames(arg1::Ref{GDALRasterBandH}, arg2)
-    ccall((:GDALSetRasterCategoryNames, libgdal), CPLErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:GDALSetRasterCategoryNames, libgdal), CPLErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -2561,7 +2561,7 @@ Helper function for translator implementer wanting support for MapInfo .tab file
 TRUE in case of success, FALSE otherwise.
 """
 function loadtabfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALLoadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, StringList, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    ccall((:GDALLoadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
 end
 
 
@@ -2585,7 +2585,7 @@ Helper function for translator implementer wanting support for MapInfo .tab file
 TRUE in case of success, FALSE otherwise.
 """
 function readtabfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALReadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, StringList, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    ccall((:GDALReadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
 end
 
 
@@ -2609,7 +2609,7 @@ Helper function for translator implementer wanting support for OZI .map.
 TRUE in case of success, FALSE otherwise.
 """
 function loadozimapfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALLoadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, StringList, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    ccall((:GDALLoadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
 end
 
 
@@ -2633,7 +2633,7 @@ Helper function for translator implementer wanting support for OZI .map.
 TRUE in case of success, FALSE otherwise.
 """
 function readozimapfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALReadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, StringList, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    ccall((:GDALReadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
 end
 
 
@@ -2683,7 +2683,7 @@ Extract RPC info from metadata, and apply to an RPCInfo structure.
 TRUE in case of success. FALSE in case of failure.
 """
 function extractrpcinfo(arg1, arg2)
-    ccall((:GDALExtractRPCInfo, libgdal), Cint, (StringList, Ptr{GDALRPCInfo}), arg1, arg2)
+    ccall((:GDALExtractRPCInfo, libgdal), Cint, (Ptr{Cstring}, Ptr{GDALRPCInfo}), arg1, arg2)
 end
 
 
@@ -3023,7 +3023,7 @@ end
 Read or Write a block of strings to/from the Attribute Table.
 """
 function ratvaluesioasstring(hRAT::Ref{GDALRasterAttributeTableH}, eRWFlag::GDALRWFlag, iField::Integer, iStartRow::Integer, iLength::Integer, papszStrList)
-    ccall((:GDALRATValuesIOAsString, libgdal), CPLErr, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, StringList), hRAT, eRWFlag, iField, iStartRow, iLength, papszStrList)
+    ccall((:GDALRATValuesIOAsString, libgdal), CPLErr, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Ptr{Cstring}), hRAT, eRWFlag, iField, iStartRow, iLength, papszStrList)
 end
 
 
@@ -3280,7 +3280,7 @@ Create a CPLVirtualMem object from a GDAL dataset object.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function datasetgetvirtualmem(hDS::Ref{<:GDALDatasetH}, eRWFlag::GDALRWFlag, nXOff::Integer, nYOff::Integer, nXSize::Integer, nYSize::Integer, nBufXSize::Integer, nBufYSize::Integer, eBufType::GDALDataType, nBandCount::Integer, panBandMap, nPixelSpace::Integer, nLineSpace::Integer, nBandSpace::Integer, nCacheSize::Csize_t, nPageSizeHint::Csize_t, bSingleThreadUsage::Integer, papszOptions)
-    ccall((:GDALDatasetGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, GIntBig, GIntBig, Csize_t, Csize_t, Cint, StringList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
+    ccall((:GDALDatasetGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, GIntBig, GIntBig, Csize_t, Csize_t, Cint, Ptr{Cstring}), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
 end
 
 
@@ -3324,7 +3324,7 @@ Create a CPLVirtualMem object from a GDAL raster band object.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function rasterbandgetvirtualmem(hBand::Ref{GDALRasterBandH}, eRWFlag::GDALRWFlag, nXOff::Integer, nYOff::Integer, nXSize::Integer, nYSize::Integer, nBufXSize::Integer, nBufYSize::Integer, eBufType::GDALDataType, nPixelSpace::Integer, nLineSpace::Integer, nCacheSize::Csize_t, nPageSizeHint::Csize_t, bSingleThreadUsage::Integer, papszOptions)
-    ccall((:GDALRasterBandGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, GIntBig, Csize_t, Csize_t, Cint, StringList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
+    ccall((:GDALRasterBandGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, GIntBig, Csize_t, Csize_t, Cint, Ptr{Cstring}), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
 end
 
 
@@ -3338,7 +3338,7 @@ end
 Create a CPLVirtualMem object from a GDAL raster band object.
 """
 function getvirtualmemauto(hBand::Ref{GDALRasterBandH}, eRWFlag::GDALRWFlag, pnPixelSpace, pnLineSpace, papszOptions)
-    ccall((:GDALGetVirtualMemAuto, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Ptr{Cint}, Ptr{GIntBig}, StringList), hBand, eRWFlag, pnPixelSpace, pnLineSpace, papszOptions)
+    ccall((:GDALGetVirtualMemAuto, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Ptr{Cint}, Ptr{GIntBig}, Ptr{Cstring}), hBand, eRWFlag, pnPixelSpace, pnLineSpace, papszOptions)
 end
 
 
@@ -3382,7 +3382,7 @@ Create a CPLVirtualMem object from a GDAL dataset object, with tiling organizati
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function datasetgettiledvirtualmem(hDS::Ref{<:GDALDatasetH}, eRWFlag::GDALRWFlag, nXOff::Integer, nYOff::Integer, nXSize::Integer, nYSize::Integer, nTileXSize::Integer, nTileYSize::Integer, eBufType::GDALDataType, nBandCount::Integer, panBandMap, eTileOrganization::GDALTileOrganization, nCacheSize::Csize_t, bSingleThreadUsage::Integer, papszOptions)
-    ccall((:GDALDatasetGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GDALTileOrganization, Csize_t, Cint, StringList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nBandCount, panBandMap, eTileOrganization, nCacheSize, bSingleThreadUsage, papszOptions)
+    ccall((:GDALDatasetGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GDALTileOrganization, Csize_t, Cint, Ptr{Cstring}), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nBandCount, panBandMap, eTileOrganization, nCacheSize, bSingleThreadUsage, papszOptions)
 end
 
 
@@ -3420,7 +3420,7 @@ Create a CPLVirtualMem object from a GDAL rasterband object, with tiling organiz
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function rasterbandgettiledvirtualmem(hBand::Ref{GDALRasterBandH}, eRWFlag::GDALRWFlag, nXOff::Integer, nYOff::Integer, nXSize::Integer, nYSize::Integer, nTileXSize::Integer, nTileYSize::Integer, eBufType::GDALDataType, nCacheSize::Csize_t, bSingleThreadUsage::Integer, papszOptions)
-    ccall((:GDALRasterBandGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Csize_t, Cint, StringList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nCacheSize, bSingleThreadUsage, papszOptions)
+    ccall((:GDALRasterBandGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (Ptr{Void}, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Csize_t, Cint, Ptr{Cstring}), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nCacheSize, bSingleThreadUsage, papszOptions)
 end
 
 
@@ -3460,5 +3460,5 @@ Dump the structure of a JPEG2000 file as a XML tree.
 XML tree (to be freed with CPLDestroyXMLNode()) or NULL in case of error
 """
 function getjpeg2000structure(pszFilename, papszOptions)
-    ccall((:GDALGetJPEG2000Structure, libgdal), Ptr{CPLXMLNode}, (Cstring, StringList), pszFilename, papszOptions)
+    ccall((:GDALGetJPEG2000Structure, libgdal), Ptr{CPLXMLNode}, (Cstring, Ptr{Cstring}), pszFilename, papszOptions)
 end

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -716,7 +716,7 @@ end
 Fetch list of metadata domains.
 """
 function getmetadatadomainlist(hObject::Ref{<:GDALMajorObjectH})
-    unsafe_string(unsafe_load(ccall((:GDALGetMetadataDomainList, libgdal), Ptr{Cstring}, (Ptr{Void},), hObject)))
+    unsafe_loadstringlist(ccall((:GDALGetMetadataDomainList, libgdal), Ptr{Cstring}, (Ptr{Void},), hObject))
 end
 
 
@@ -727,7 +727,7 @@ end
 Fetch metadata.
 """
 function getmetadata(arg1::Ref{<:GDALMajorObjectH}, arg2)
-    unsafe_string(unsafe_load(ccall((:GDALGetMetadata, libgdal), Ptr{Cstring}, (Ptr{Void}, Cstring), arg1, arg2)))
+    unsafe_loadstringlist(ccall((:GDALGetMetadata, libgdal), Ptr{Cstring}, (Ptr{Void}, Cstring), arg1, arg2))
 end
 
 
@@ -805,7 +805,7 @@ end
 Fetch files forming dataset.
 """
 function getfilelist(arg1::Ref{<:GDALDatasetH})
-    unsafe_string(unsafe_load(ccall((:GDALGetFileList, libgdal), Ptr{Cstring}, (Ptr{Void},), arg1)))
+    unsafe_loadstringlist(ccall((:GDALGetFileList, libgdal), Ptr{Cstring}, (Ptr{Void},), arg1))
 end
 
 
@@ -1845,7 +1845,7 @@ end
 Fetch the list of category names for this raster.
 """
 function getrastercategorynames(arg1::Ref{GDALRasterBandH})
-    unsafe_string(unsafe_load(ccall((:GDALGetRasterCategoryNames, libgdal), Ptr{Cstring}, (Ptr{Void},), arg1)))
+    unsafe_loadstringlist(ccall((:GDALGetRasterCategoryNames, libgdal), Ptr{Cstring}, (Ptr{Void},), arg1))
 end
 
 

--- a/src/gdal_utils.jl
+++ b/src/gdal_utils.jl
@@ -14,7 +14,7 @@ Allocates a GDALInfoOptions struct.
 pointer to the allocated GDALInfoOptions struct. Must be freed with GDALInfoOptionsFree().
 """
 function infooptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALInfoOptionsNew, libgdal), Ptr{GDALInfoOptions}, (StringList, Ptr{GDALInfoOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALInfoOptionsNew, libgdal), Ptr{GDALInfoOptions}, (Ptr{Cstring}, Ptr{GDALInfoOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -63,7 +63,7 @@ Allocates a GDALTranslateOptions struct.
 pointer to the allocated GDALTranslateOptions struct. Must be freed with GDALTranslateOptionsFree().
 """
 function translateoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALTranslateOptionsNew, libgdal), Ptr{GDALTranslateOptions}, (StringList, Ptr{GDALTranslateOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALTranslateOptionsNew, libgdal), Ptr{GDALTranslateOptions}, (Ptr{Cstring}, Ptr{GDALTranslateOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -133,7 +133,7 @@ Allocates a GDALWarpAppOptions struct.
 pointer to the allocated GDALWarpAppOptions struct. Must be freed with GDALWarpAppOptionsFree().
 """
 function warpappoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALWarpAppOptionsNew, libgdal), Ptr{GDALWarpAppOptions}, (StringList, Ptr{GDALWarpAppOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALWarpAppOptionsNew, libgdal), Ptr{GDALWarpAppOptions}, (Ptr{Cstring}, Ptr{GDALWarpAppOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -224,7 +224,7 @@ allocates a GDALVectorTranslateOptions struct.
 pointer to the allocated GDALVectorTranslateOptions struct. Must be freed with GDALVectorTranslateOptionsFree().
 """
 function vectortranslateoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALVectorTranslateOptionsNew, libgdal), Ptr{GDALVectorTranslateOptions}, (StringList, Ptr{GDALVectorTranslateOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALVectorTranslateOptionsNew, libgdal), Ptr{GDALVectorTranslateOptions}, (Ptr{Cstring}, Ptr{GDALVectorTranslateOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -298,7 +298,7 @@ Allocates a GDALDEMProcessingOptions struct.
 pointer to the allocated GDALDEMProcessingOptions struct. Must be freed with GDALDEMProcessingOptionsFree().
 """
 function demprocessingoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALDEMProcessingOptionsNew, libgdal), Ptr{GDALDEMProcessingOptions}, (StringList, Ptr{GDALDEMProcessingOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALDEMProcessingOptionsNew, libgdal), Ptr{GDALDEMProcessingOptions}, (Ptr{Cstring}, Ptr{GDALDEMProcessingOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -372,7 +372,7 @@ Allocates a GDALNearblackOptions struct.
 pointer to the allocated GDALNearblackOptions struct. Must be freed with GDALNearblackOptionsFree().
 """
 function nearblackoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALNearblackOptionsNew, libgdal), Ptr{GDALNearblackOptions}, (StringList, Ptr{GDALNearblackOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALNearblackOptionsNew, libgdal), Ptr{GDALNearblackOptions}, (Ptr{Cstring}, Ptr{GDALNearblackOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -444,7 +444,7 @@ Allocates a GDALGridOptions struct.
 pointer to the allocated GDALGridOptions struct. Must be freed with GDALGridOptionsFree().
 """
 function gridoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALGridOptionsNew, libgdal), Ptr{GDALGridOptions}, (StringList, Ptr{GDALGridOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALGridOptionsNew, libgdal), Ptr{GDALGridOptions}, (Ptr{Cstring}, Ptr{GDALGridOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -514,7 +514,7 @@ Allocates a GDALRasterizeOptions struct.
 pointer to the allocated GDALRasterizeOptions struct. Must be freed with GDALRasterizeOptionsFree().
 """
 function rasterizeoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALRasterizeOptionsNew, libgdal), Ptr{GDALRasterizeOptions}, (StringList, Ptr{GDALRasterizeOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALRasterizeOptionsNew, libgdal), Ptr{GDALRasterizeOptions}, (Ptr{Cstring}, Ptr{GDALRasterizeOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -586,7 +586,7 @@ Allocates a GDALBuildVRTOptions struct.
 pointer to the allocated GDALBuildVRTOptions struct. Must be freed with GDALBuildVRTOptionsFree().
 """
 function buildvrtoptionsnew(papszArgv, psOptionsForBinary)
-    ccall((:GDALBuildVRTOptionsNew, libgdal), Ptr{GDALBuildVRTOptions}, (StringList, Ptr{GDALBuildVRTOptionsForBinary}), papszArgv, psOptionsForBinary)
+    ccall((:GDALBuildVRTOptionsNew, libgdal), Ptr{GDALBuildVRTOptions}, (Ptr{Cstring}, Ptr{GDALBuildVRTOptionsForBinary}), papszArgv, psOptionsForBinary)
 end
 
 
@@ -642,5 +642,5 @@ Build a VRT from a list of datasets.
 the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
 """
 function buildvrt(pszDest, nSrcCount::Integer, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError)
-    checknull(ccall((:GDALBuildVRT, libgdal), Ptr{GDALDatasetH}, (Cstring, Cint, Ptr{GDALDatasetH}, StringList, Ptr{GDALBuildVRTOptions}, Ptr{Cint}), pszDest, nSrcCount, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError))
+    checknull(ccall((:GDALBuildVRT, libgdal), Ptr{GDALDatasetH}, (Cstring, Cint, Ptr{GDALDatasetH}, Ptr{Cstring}, Ptr{GDALBuildVRTOptions}, Ptr{Cint}), pszDest, nSrcCount, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError))
 end

--- a/src/gdal_vrt.jl
+++ b/src/gdal_vrt.jl
@@ -32,7 +32,7 @@ end
                char **) -> int
 """
 function vrtaddband(arg1::Ref{VRTDatasetH}, arg2::GDALDataType, arg3)
-    ccall((:VRTAddBand, libgdal), Cint, (Ptr{Void}, GDALDataType, StringList), arg1, arg2, arg3)
+    ccall((:VRTAddBand, libgdal), Cint, (Ptr{Void}, GDALDataType, Ptr{Cstring}), arg1, arg2, arg3)
 end
 
 

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -1220,7 +1220,7 @@ Compute length of a geometry.
 ### Returns
 the length or 0.0 for unsupported geometry types.
 """
-function length(arg1::Ref{OGRGeometryH})
+function Base.length(arg1::Ref{OGRGeometryH})
     ccall((:OGR_G_Length, libgdal), Cdouble, (Ptr{Void},), arg1)
 end
 

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -38,7 +38,7 @@ Create a geometry object of the appropriate type from it's well known text repre
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function createfromwkt(arg1, arg2::Ref{OGRSpatialReferenceH}, arg3)
-    ccall((:OGR_G_CreateFromWkt, libgdal), OGRErr, (StringList, Ptr{Void}, Ptr{OGRGeometryH}), arg1, arg2, arg3)
+    ccall((:OGR_G_CreateFromWkt, libgdal), OGRErr, (Ptr{Cstring}, Ptr{Void}, Ptr{OGRGeometryH}), arg1, arg2, arg3)
 end
 
 
@@ -213,7 +213,7 @@ Convert to another geometry type.
 new geometry.
 """
 function forceto(hGeom::Ref{OGRGeometryH}, eTargetType::OGRwkbGeometryType, papszOptions)
-    checknull(ccall((:OGR_G_ForceTo, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, OGRwkbGeometryType, StringList), hGeom, eTargetType, papszOptions))
+    checknull(ccall((:OGR_G_ForceTo, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, OGRwkbGeometryType, Ptr{Cstring}), hGeom, eTargetType, papszOptions))
 end
 
 
@@ -478,7 +478,7 @@ Assign geometry from well known text data.
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function importfromwkt(arg1::Ref{OGRGeometryH}, arg2)
-    ccall((:OGR_G_ImportFromWkt, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OGR_G_ImportFromWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -496,7 +496,7 @@ Convert a geometry into well known text format.
 Currently OGRERR_NONE is always returned.
 """
 function exporttowkt(arg1::Ref{OGRGeometryH}, arg2)
-    ccall((:OGR_G_ExportToWkt, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OGR_G_ExportToWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -514,7 +514,7 @@ Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
 Currently OGRERR_NONE is always returned.
 """
 function exporttoisowkt(arg1::Ref{OGRGeometryH}, arg2)
-    ccall((:OGR_G_ExportToIsoWkt, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OGR_G_ExportToIsoWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -639,7 +639,7 @@ Convert a geometry into GML format.
 A GML fragment or NULL in case of error.
 """
 function exporttogmlex(arg1::Ref{OGRGeometryH}, papszOptions)
-    unsafe_string(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (Ptr{Void}, StringList), arg1, papszOptions))
+    unsafe_string(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (Ptr{Void}, Ptr{Cstring}), arg1, papszOptions))
 end
 
 
@@ -721,7 +721,7 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 function exporttojsonex(arg1::Ref{OGRGeometryH}, papszOptions)
-    unsafe_string(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (Ptr{Void}, StringList), arg1, papszOptions))
+    unsafe_string(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (Ptr{Void}, Ptr{Cstring}), arg1, papszOptions))
 end
 
 
@@ -1956,7 +1956,7 @@ Return, possibly approximate, linear version of this geometry.
 a new geometry.
 """
 function getlineargeometry(hGeom::Ref{OGRGeometryH}, dfMaxAngleStepSizeDegrees::Real, papszOptions)
-    checknull(ccall((:OGR_G_GetLinearGeometry, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, Cdouble, StringList), hGeom, dfMaxAngleStepSizeDegrees, papszOptions))
+    checknull(ccall((:OGR_G_GetLinearGeometry, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, Cdouble, Ptr{Cstring}), hGeom, dfMaxAngleStepSizeDegrees, papszOptions))
 end
 
 
@@ -1974,7 +1974,7 @@ Return curve version of this geometry.
 a new geometry.
 """
 function getcurvegeometry(hGeom::Ref{OGRGeometryH}, papszOptions)
-    checknull(ccall((:OGR_G_GetCurveGeometry, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, StringList), hGeom, papszOptions))
+    checknull(ccall((:OGR_G_GetCurveGeometry, libgdal), Ptr{OGRGeometryH}, (Ptr{Void}, Ptr{Cstring}), hGeom, papszOptions))
 end
 
 
@@ -3758,7 +3758,7 @@ Set field to list of strings value.
 * **papszValues**: the values to assign.
 """
 function setfieldstringlist(arg1::Ref{OGRFeatureH}, arg2::Integer, arg3)
-    ccall((:OGR_F_SetFieldStringList, libgdal), Void, (Ptr{Void}, Cint, StringList), arg1, arg2, arg3)
+    ccall((:OGR_F_SetFieldStringList, libgdal), Void, (Ptr{Void}, Cint, Ptr{Cstring}), arg1, arg2, arg3)
 end
 
 
@@ -4210,7 +4210,7 @@ Fill unset fields with default values that might be defined.
 * **papszOptions**: unused currently. Must be set to NULL.
 """
 function fillunsetwithdefault(hFeat::Ref{OGRFeatureH}, bNotNullableOnly::Integer, papszOptions)
-    ccall((:OGR_F_FillUnsetWithDefault, libgdal), Void, (Ptr{Void}, Cint, StringList), hFeat, bNotNullableOnly, papszOptions)
+    ccall((:OGR_F_FillUnsetWithDefault, libgdal), Void, (Ptr{Void}, Cint, Ptr{Cstring}), hFeat, bNotNullableOnly, papszOptions)
 end
 
 
@@ -4911,7 +4911,7 @@ Set which fields can be omitted when retrieving features from the layer.
 OGRERR_NONE if all field names have been resolved (even if the driver does not support this method)
 """
 function setignoredfields(arg1::Ref{OGRLayerH}, arg2)
-    ccall((:OGR_L_SetIgnoredFields, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OGR_L_SetIgnoredFields, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -4937,7 +4937,7 @@ Intersection of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function intersection(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Intersection, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Intersection, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -4963,7 +4963,7 @@ Union of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function union(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Union, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Union, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -4989,7 +4989,7 @@ Symmetrical difference of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function symdifference(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_SymDifference, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_SymDifference, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -5015,7 +5015,7 @@ Identify the features of this layer with the ones from the identity layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function identity(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Identity, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Identity, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -5041,7 +5041,7 @@ Update this layer with features from the update layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function update(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Update, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Update, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -5067,7 +5067,7 @@ Clip off areas that are not covered by the method layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function clip(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Clip, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Clip, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -5093,7 +5093,7 @@ Remove areas that are covered by the method layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function erase(arg1::Ref{OGRLayerH}, arg2::Ref{OGRLayerH}, arg3::Ref{OGRLayerH}, arg4, arg5::Any, arg6)
-    ccall((:OGR_L_Erase, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, StringList, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
+    ccall((:OGR_L_Erase, libgdal), OGRErr, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Cstring}, Ptr{Void}, Ptr{Void}), arg1, arg2, arg3, arg4, arg5, arg6)
 end
 
 
@@ -5232,7 +5232,7 @@ This function attempts to create a new layer on the data source with the indicat
 NULL is returned on failure, or a new OGRLayer handle on success.
 """
 function createlayer(arg1::Ref{OGRDataSourceH}, arg2, arg3::Ref{OGRSpatialReferenceH}, arg4::OGRwkbGeometryType, arg5)
-    checknull(ccall((:OGR_DS_CreateLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Cstring, Ptr{Void}, OGRwkbGeometryType, StringList), arg1, arg2, arg3, arg4, arg5))
+    checknull(ccall((:OGR_DS_CreateLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Cstring, Ptr{Void}, OGRwkbGeometryType, Ptr{Cstring}), arg1, arg2, arg3, arg4, arg5))
 end
 
 
@@ -5254,7 +5254,7 @@ Duplicate an existing layer.
 an handle to the layer, or NULL if an error occurs.
 """
 function copylayer(arg1::Ref{OGRDataSourceH}, arg2::Ref{OGRLayerH}, arg3, arg4)
-    checknull(ccall((:OGR_DS_CopyLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Ptr{Void}, Cstring, StringList), arg1, arg2, arg3, arg4))
+    checknull(ccall((:OGR_DS_CopyLayer, libgdal), Ptr{OGRLayerH}, (Ptr{Void}, Ptr{Void}, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
 end
 
 
@@ -5457,7 +5457,7 @@ This function attempts to create a new data source based on the passed driver.
 NULL is returned on failure, or a new OGRDataSource handle on success.
 """
 function createdatasource(arg1::Ref{OGRSFDriverH}, arg2, arg3)
-    checknull(ccall((:OGR_Dr_CreateDataSource, libgdal), Ptr{OGRDataSourceH}, (Ptr{Void}, Cstring, StringList), arg1, arg2, arg3))
+    checknull(ccall((:OGR_Dr_CreateDataSource, libgdal), Ptr{OGRDataSourceH}, (Ptr{Void}, Cstring, Ptr{Cstring}), arg1, arg2, arg3))
 end
 
 
@@ -5479,7 +5479,7 @@ This function creates a new datasource by copying all the layers from the source
 NULL is returned on failure, or a new OGRDataSource handle on success.
 """
 function copydatasource(arg1::Ref{OGRSFDriverH}, arg2::Ref{OGRDataSourceH}, arg3, arg4)
-    checknull(ccall((:OGR_Dr_CopyDataSource, libgdal), Ptr{OGRDataSourceH}, (Ptr{Void}, Ptr{Void}, Cstring, StringList), arg1, arg2, arg3, arg4))
+    checknull(ccall((:OGR_Dr_CopyDataSource, libgdal), Ptr{OGRDataSourceH}, (Ptr{Void}, Ptr{Void}, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
 end
 
 

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -3532,7 +3532,7 @@ Fetch field value as a list of strings.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
 """
 function getfieldasstringlist(arg1::Ref{OGRFeatureH}, arg2::Integer)
-    unsafe_string(unsafe_load(ccall((:OGR_F_GetFieldAsStringList, libgdal), Ptr{Cstring}, (Ptr{Void}, Cint), arg1, arg2)))
+    unsafe_loadstringlist(ccall((:OGR_F_GetFieldAsStringList, libgdal), Ptr{Cstring}, (Ptr{Void}, Cint), arg1, arg2))
 end
 
 

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -155,7 +155,7 @@ end
 Import from WKT string.
 """
 function importfromwkt(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRImportFromWkt, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRImportFromWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -177,7 +177,7 @@ end
 Import coordinate system from ESRI .prj format(s).
 """
 function importfromesri(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRImportFromESRI, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRImportFromESRI, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -267,7 +267,7 @@ Import coordinate system from OziExplorer projection definition.
 OGRERR_NONE on success or an error code in case of failure.
 """
 function importfromozi(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRImportFromOzi, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRImportFromOzi, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -313,7 +313,7 @@ end
 Convert this SRS into WKT format.
 """
 function exporttowkt(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRExportToWkt, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRExportToWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -325,7 +325,7 @@ end
 Convert this SRS into a nicely formatted WKT string for display to a person.
 """
 function exporttoprettywkt(arg1::Ref{OGRSpatialReferenceH}, arg2, arg3::Integer)
-    ccall((:OSRExportToPrettyWkt, libgdal), OGRErr, (Ptr{Void}, StringList, Cint), arg1, arg2, arg3)
+    ccall((:OSRExportToPrettyWkt, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}, Cint), arg1, arg2, arg3)
 end
 
 
@@ -336,7 +336,7 @@ end
 Export coordinate system in PROJ.4 format.
 """
 function exporttoproj4(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRExportToProj4, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRExportToProj4, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -349,7 +349,7 @@ end
 Export coordinate system in PCI projection definition.
 """
 function exporttopci(arg1::Ref{OGRSpatialReferenceH}, arg2, arg3, arg4)
-    ccall((:OSRExportToPCI, libgdal), OGRErr, (Ptr{Void}, StringList, StringList, Ptr{Ptr{Cdouble}}), arg1, arg2, arg3, arg4)
+    ccall((:OSRExportToPCI, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}, Ptr{Cstring}, Ptr{Ptr{Cdouble}}), arg1, arg2, arg3, arg4)
 end
 
 
@@ -375,7 +375,7 @@ end
 Export coordinate system in XML format.
 """
 function exporttoxml(arg1::Ref{OGRSpatialReferenceH}, arg2, arg3)
-    ccall((:OSRExportToXML, libgdal), OGRErr, (Ptr{Void}, StringList, Cstring), arg1, arg2, arg3)
+    ccall((:OSRExportToXML, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}, Cstring), arg1, arg2, arg3)
 end
 
 
@@ -401,7 +401,7 @@ end
 Export coordinate system in Mapinfo style CoordSys format.
 """
 function exporttomicoordsys(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRExportToMICoordSys, libgdal), OGRErr, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRExportToMICoordSys, libgdal), OGRErr, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -481,7 +481,7 @@ end
 Fetch angular geographic coordinate system units.
 """
 function getangularunits(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRGetAngularUnits, libgdal), Cdouble, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRGetAngularUnits, libgdal), Cdouble, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -529,7 +529,7 @@ end
 Fetch linear projection units.
 """
 function getlinearunits(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRGetLinearUnits, libgdal), Cdouble, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRGetLinearUnits, libgdal), Cdouble, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -541,7 +541,7 @@ end
 Fetch linear projection units.
 """
 function gettargetlinearunits(arg1::Ref{OGRSpatialReferenceH}, arg2, arg3)
-    ccall((:OSRGetTargetLinearUnits, libgdal), Cdouble, (Ptr{Void}, Cstring, StringList), arg1, arg2, arg3)
+    ccall((:OSRGetTargetLinearUnits, libgdal), Cdouble, (Ptr{Void}, Cstring, Ptr{Cstring}), arg1, arg2, arg3)
 end
 
 
@@ -552,7 +552,7 @@ end
 Fetch prime meridian info.
 """
 function getprimemeridian(arg1::Ref{OGRSpatialReferenceH}, arg2)
-    ccall((:OSRGetPrimeMeridian, libgdal), Cdouble, (Ptr{Void}, StringList), arg1, arg2)
+    ccall((:OSRGetPrimeMeridian, libgdal), Cdouble, (Ptr{Void}, Ptr{Cstring}), arg1, arg2)
 end
 
 
@@ -1906,7 +1906,7 @@ Fetch the parameters for a given projection method.
 returns a NULL terminated list of internal parameter names that should be freed by the caller when no longer needed. Returns NULL if projection method is unknown.
 """
 function optgetparameterlist(pszProjectionMethod, ppszUserName)
-    unsafe_loadstringlist(ccall((:OPTGetParameterList, libgdal), Ptr{Cstring}, (Cstring, StringList), pszProjectionMethod, ppszUserName))
+    unsafe_loadstringlist(ccall((:OPTGetParameterList, libgdal), Ptr{Cstring}, (Cstring, Ptr{Cstring}), pszProjectionMethod, ppszUserName))
 end
 
 
@@ -1930,5 +1930,5 @@ Fetch information about a single parameter of a projection method.
 TRUE if parameter found, or FALSE otherwise.
 """
 function optgetparameterinfo(pszProjectionMethod, pszParameterName, ppszUserName, ppszType, pdfDefaultValue)
-    ccall((:OPTGetParameterInfo, libgdal), Cint, (Cstring, Cstring, StringList, StringList, Ptr{Cdouble}), pszProjectionMethod, pszParameterName, ppszUserName, ppszType, pdfDefaultValue)
+    ccall((:OPTGetParameterInfo, libgdal), Cint, (Cstring, Cstring, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cdouble}), pszProjectionMethod, pszParameterName, ppszUserName, ppszType, pdfDefaultValue)
 end

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -1888,7 +1888,7 @@ Fetch list of possible projection methods.
 Returns NULL terminated list of projection methods. This should be freed with CSLDestroy() when no longer needed.
 """
 function optgetprojectionmethods()
-    unsafe_string(unsafe_load(ccall((:OPTGetProjectionMethods, libgdal), Ptr{Cstring}, ())))
+    unsafe_loadstringlist(ccall((:OPTGetProjectionMethods, libgdal), Ptr{Cstring}, ()))
 end
 
 
@@ -1906,7 +1906,7 @@ Fetch the parameters for a given projection method.
 returns a NULL terminated list of internal parameter names that should be freed by the caller when no longer needed. Returns NULL if projection method is unknown.
 """
 function optgetparameterlist(pszProjectionMethod, ppszUserName)
-    unsafe_string(unsafe_load(ccall((:OPTGetParameterList, libgdal), Ptr{Cstring}, (Cstring, StringList), pszProjectionMethod, ppszUserName)))
+    unsafe_loadstringlist(ccall((:OPTGetParameterList, libgdal), Ptr{Cstring}, (Cstring, StringList), pszProjectionMethod, ppszUserName))
 end
 
 

--- a/test/tutorial_vector.jl
+++ b/test/tutorial_vector.jl
@@ -50,7 +50,7 @@ GDAL.close(dataset)
 
 
 # Writing to OGR
-pointshapefile = "tmp/point_out"
+pointshapefile = joinpath("tmp", "point_out")
 driver = GDAL.getdriverbyname("ESRI Shapefile")
 dataset = GDAL.create(driver, "$pointshapefile.shp", 0, 0, 0, GDAL.GDT_Unknown, C_NULL)
 nosrs = convert(Ptr{GDAL.OGRSpatialReferenceH}, C_NULL)
@@ -68,8 +68,12 @@ point = GDAL.creategeometry(GDAL.wkbPoint)
 GDAL.setpoint_2d(point, 0, 100.123, 0.123)
 @test GDAL.setgeometry(feature, point) == GDAL.OGRERR_NONE
 GDAL.destroygeometry(point)
+
+# test getfilelist with unsafe_loadstringlist
+shp_exts = Set([".shp", ".shx", ".dbf"])
+fileset = map(x -> pointshapefile * x, shp_exts)
+@test Set(GDAL.getfilelist(dataset)) == fileset
+
 GDAL.close(dataset)
 
-rm("$pointshapefile.dbf")
-rm("$pointshapefile.shp")
-rm("$pointshapefile.shx")
+map(rm, fileset)

--- a/test/tutorial_vector.jl
+++ b/test/tutorial_vector.jl
@@ -45,6 +45,12 @@ geometry = GDAL.getgeometryref(feature)
 @test GDAL.getx(geometry, 0) == 100.2785
 @test GDAL.gety(geometry, 0) == 0.0893
 
+# export to WKT
+wkt_ptr = Ref(Cstring(C_NULL))
+@test GDAL.exporttowkt(geometry, wkt_ptr) == GDAL.OGRERR_NONE
+@test unsafe_string(wkt_ptr[]) == "POINT (100.2785 0.0893)"
+GDAL.C.OGRFree(pointer(wkt_ptr[]))
+
 GDAL.destroy(feature)
 GDAL.close(dataset)
 


### PR DESCRIPTION
fixes #13 

Commit 5069a757953e4d07b71fae9c854f6d789a6753f9 is perhaps a bit more controversial, so it would be good if @yeesian could sign off on that change. Not sure why we were using `Ptr{Ptr{UInt8}}` instead of `Ptr{Cstring}`.
