### PR TITLE
reset the error handler before throwing a GDALError

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -9,6 +9,7 @@ function GDALError()
     class = cplgetlasterrortype()
     code = cplgetlasterrorno()
     msg = cplgetlasterrormsg()
+    cplerrorreset()
     GDALError(class, code, msg)
 end
 
@@ -23,7 +24,9 @@ function gdaljl_errorhandler(class::CPLErr, errno::Cint, errmsg::Cstring)
     # function signature needs to match the one in __init__, and the signature
     # of the callback for a custom error handler in the GDAL docs
     if class in throw_class
-        throw(GDALError(class, errno, unsafe_string(errmsg)))
+        msg = unsafe_string(errmsg)
+        cplerrorreset()
+        throw(GDALError(class, errno, msg))
     end
     return C_NULL
 end

--- a/test/error.jl
+++ b/test/error.jl
@@ -1,0 +1,56 @@
+@testset "GDAL errors" begin
+    # throw errors on non existing files
+    @test_throws GDAL.GDALError GDAL.gdalopen("NonExistent", GDAL.GA_ReadOnly)
+    # if a driver is not found it doesn't throw a GDALError
+    @test GDAL.gdalgetdriverbyname("NonExistent") === C_NULL
+
+    @testset "error reset" begin
+        # everything ok, no errors
+        @test GDAL.gdalgetdriverbyname("NoSuchDriver") == C_NULL
+        @test GDAL.cplgetlasterrorno() === Int32(0)
+        @test GDAL.cplgetlasterrortype() === GDAL.CE_None
+        @test GDAL.cplgetlasterrormsg() === ""
+        @test GDAL.cplgeterrorcounter() === UInt32(0)
+        # Throws a GDALError, but since we call cplerrorreset in our error handler
+        # we cannot get the error information via the API after the throw.
+        @test_throws GDAL.GDALError GDAL.gdalgetdrivershortname(C_NULL)
+        @test GDAL.cplgetlasterrorno() === Int32(0)
+        @test GDAL.cplgetlasterrortype() === GDAL.CE_None
+        @test GDAL.cplgetlasterrormsg() === ""
+        @test GDAL.cplgeterrorcounter() === UInt32(0)
+        # however all this information is in the GDALError struct
+        try
+            GDAL.gdalgetdrivershortname(C_NULL)
+        catch err
+            @test err.class === GDAL.CE_Failure
+            @test err.code === Int32(10)
+            @test err.msg === "Pointer 'hDriver' is NULL in 'GDALGetDriverShortName'.\n"
+        end
+    end
+
+    # infooptionsnew checks if the options are valid
+    @test_throws GDAL.GDALError GDAL.gdalinfooptionsnew(["-novalidoption"], C_NULL)
+    # check not only that a GDALError is thrown, but also its contents
+    try
+        GDAL.gdalinfooptionsnew(["-novalidoption"], C_NULL)
+    catch err
+        @test err.class === GDAL.CE_Failure
+        @test err.code === Cint(6)
+        @test err.msg === "Unknown option name '-novalidoption'"
+    end
+
+    # Quoting cpl_error.cpp regarding CE_Fatal:
+    # > The default behaviour of CPLError() is to report errors to stderr,
+    # > and to abort() after reporting a CE_Fatal error.  It is expected that
+    # > some applications will want to suppress error reporting, and will want to
+    # > install a C++ exception, or longjmp() approach to no local fatal error
+    # > recovery.
+    # The abort means we cannot catch CE_Fatal GDALErrors.
+    # Interestingly, the following works once:
+    # @test_throws GDAL.GDALError GDAL.cplemergencyerror("things are bad")
+    # But if you run that line a second time, it quits julia with:
+    # FATAL: things are bad
+    # signal (22): SIGABRT
+    # So let's not even test it once to be safe
+
+end # testset "GDAL errors"

--- a/test/gdal_utils.jl
+++ b/test/gdal_utils.jl
@@ -2,17 +2,6 @@ ds_small = GDAL.gdalopen("data/utmsmall.tif", GDAL.GA_ReadOnly)
 ds_point = GDAL.gdalopenex("data/point.geojson", GDAL.GDAL_OF_VECTOR, C_NULL, C_NULL, C_NULL)
 
 # GDALInfo
-# infooptionsnew checks if the options are valid
-@test_throws GDAL.GDALError GDAL.gdalinfooptionsnew(["-novalidoption"], C_NULL)
-# check not only that a GDALError is thrown, but also its contents
-try
-    GDAL.gdalinfooptionsnew(["-novalidoption"], C_NULL)
-catch err
-    @test err.class === GDAL.CE_Failure
-    @test err.code === Cint(6)
-    @test err.msg == "Unknown option name '-novalidoption'"
-end
-
 options = GDAL.gdalinfooptionsnew(["-checksum"], C_NULL)
 infostr = GDAL.gdalinfo(ds_small, options)
 @test occursin("Checksum=50054", infostr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,15 +18,6 @@ using Test
     @test n_gdal_driver > 0
     @test n_ogr_driver > 0
 
-    # test if the registered error handler also handles CE_Fatal
-    @test_throws GDAL.GDALError GDAL.cplemergencyerror("we've got a problem")
-    GDAL.cplerrorreset()
-
-    # throw errors on non existing files
-    @test_throws GDAL.GDALError GDAL.gdalopen("NonExistent", GDAL.GA_ReadOnly)
-    # if a driver is not found it throws a GDALError
-    @test_throws GDAL.GDALError GDAL.gdalgetdriverbyname("NonExistent")
-
     srs = GDAL.osrnewspatialreference(C_NULL)
     GDAL.osrimportfromepsg(srs, 4326) # fails if GDAL_DATA is not set correctly
 
@@ -56,6 +47,7 @@ using Test
         include("tutorial_vrt.jl")
         include("gdal_utils.jl")
         include("drivers.jl")
+        include("error.jl")
     end
 
     GDAL.gdaldestroydrivermanager()


### PR DESCRIPTION
Fixes #68. This means we cannot use `cplgetlasterror`* functions after an error anymore, but we can just get this information from the GDALError struct, as shown in the tests.

It seems quite neccesary to me to do this, since otherwise you get old error reports back, any time you call a new function that calls `failsafe` to check for errors, as shown in the issue.

Also expands and concentrates the error testing code.