### PR TITLE
return nothing for NULL strings

### DIFF
--- a/gen/wrap.jl
+++ b/gen/wrap.jl
@@ -137,7 +137,7 @@ function rewriter(x::Expr)
         end
 
         cc2 = if rettype == :Cstring
-            :(unsafe_string($cc))
+            :(string_or_nothing($cc))
         elseif rettype == :(Ptr{Cstring})
             :(unsafe_loadstringlist($cc))
         elseif isptrvoid

--- a/gen/wrap.jl
+++ b/gen/wrap.jl
@@ -143,7 +143,9 @@ function rewriter(x::Expr)
         end
 
         cc2 = if occursin(r"^cpl.*error", String(f2))
-            # since we call these in aftercare, no aftercare to prevent calling itself
+            # We will take care of GDAL error states and memory freeing by
+            # calling `aftercare`, except for `cpl*error*` functions, as these
+            # will be called by `aftercare` itself, so we prevent a loop.
             if rettype == :Cstring
                 :(unsafe_string($cc))
             else

--- a/gen/wrap.jl
+++ b/gen/wrap.jl
@@ -78,6 +78,12 @@ const replace_exprs = Dict{Expr,Expr}(
     :(const VSIStatBufL = __stat64) => :(const VSIStatBufL = Cvoid),
 )
 
+# functions that return a Cstring, of which we know we must free them
+# because for instance the documentation says: "Free with CPLFree() or VSIFree()"
+# use the renamed (lowercased) function names here
+# if it is not in this list, it will not be freed, add function names to make it more complete
+const string_free_me = Symbol[:gdalinfo]
+
 """
 Custom rewriter for Clang.jl's C wrapper
 
@@ -136,14 +142,19 @@ function rewriter(x::Expr)
             false
         end
 
-        cc2 = if rettype == :Cstring
-            :(string_or_nothing($cc))
-        elseif rettype == :(Ptr{Cstring})
-            :(unsafe_loadstringlist($cc))
-        elseif isptrvoid
-            :(failsafe($cc))
+        cc2 = if occursin(r"^cpl.*error", String(f2))
+            # since we call these in aftercare, no aftercare to prevent calling itself
+            if rettype == :Cstring
+                :(unsafe_string($cc))
+            else
+                cc
+            end
+        elseif rettype == :Cstring
+            # boolean to let aftercare know if it should call vsifree
+            free = f2 in string_free_me
+            :(aftercare($cc, $free))
         else
-            cc
+            :(aftercare($cc))
         end
 
         # stitch the modified function expression back together

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -59,32 +59,4 @@ function __init__()
     osrsetprojsearchpaths([PROJ_LIB[]])
 end
 
-"Load a Cstring to a string, unless it is NULL, then return nothing"
-function string_or_nothing(cs::Cstring)
-    if cs == C_NULL
-        nothing
-    else
-        unsafe_string(cs)
-    end
-end
-
-"""
-Load a null-terminated list of strings
-
-That is it expects a `StringList`, in the sense of the CPL functions,
-as a null-terminated array of strings.
-"""
-function unsafe_loadstringlist(ptr::Ptr{Cstring})
-    strings = Vector{String}()
-    (ptr == C_NULL) && return strings
-    i = 1
-    cstring = unsafe_load(ptr, i)
-    while cstring != C_NULL
-        push!(strings, unsafe_string(cstring))
-        i += 1
-        cstring = unsafe_load(ptr, i)
-    end
-    strings
-end
-
 end # module

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -59,6 +59,15 @@ function __init__()
     osrsetprojsearchpaths([PROJ_LIB[]])
 end
 
+"Load a Cstring to a string, unless it is NULL, then return nothing"
+function string_or_nothing(cs::Cstring)
+    if cs == C_NULL
+        nothing
+    else
+        unsafe_string(cs)
+    end
+end
+
 """
 Load a null-terminated list of strings
 

--- a/src/cpl_conv.jl
+++ b/src/cpl_conv.jl
@@ -23,7 +23,7 @@ Get the value of a configuration option.
 the value associated to the key, or the default value if not found
 """
 function cplgetconfigoption(arg1, arg2)
-    unsafe_string(ccall((:CPLGetConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    string_or_nothing(ccall((:CPLGetConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -33,7 +33,7 @@ end
 Same as CPLGetConfigOption() but only with options set with CPLSetThreadLocalConfigOption()
 """
 function cplgetthreadlocalconfigoption(arg1, arg2)
-    unsafe_string(ccall((:CPLGetThreadLocalConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    string_or_nothing(ccall((:CPLGetThreadLocalConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -180,7 +180,7 @@ Safe version of strdup() function.
 pointer to a newly allocated copy of the string. Free with CPLFree() or VSIFree().
 """
 function cplstrdup(arg1)
-    unsafe_string(ccall((:CPLStrdup, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLStrdup, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -195,7 +195,7 @@ Convert each characters of the string to lower case.
 pointer to the same string, pszString.
 """
 function cplstrlwr(arg1)
-    unsafe_string(ccall((:CPLStrlwr, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLStrlwr, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -214,7 +214,7 @@ Reads in at most one less than nBufferSize characters from the fp stream and sto
 pointer to the pszBuffer containing a string read from the file or NULL if the error or end of file was encountered.
 """
 function cplfgets(arg1, arg2, arg3)
-    unsafe_string(ccall((:CPLFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
+    string_or_nothing(ccall((:CPLFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -229,7 +229,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered.
 """
 function cplreadline(arg1)
-    unsafe_string(ccall((:CPLReadLine, libgdal), Cstring, (Ptr{Cint},), arg1))
+    string_or_nothing(ccall((:CPLReadLine, libgdal), Cstring, (Ptr{Cint},), arg1))
 end
 
 """
@@ -244,7 +244,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered.
 """
 function cplreadlinel(arg1)
-    unsafe_string(ccall((:CPLReadLineL, libgdal), Cstring, (Ptr{VSILFILE},), arg1))
+    string_or_nothing(ccall((:CPLReadLineL, libgdal), Cstring, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -263,7 +263,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered or the maximum number of characters allowed reached.
 """
 function cplreadline2l(arg1, arg2, arg3)
-    unsafe_string(ccall((:CPLReadLine2L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, CSLConstList), arg1, arg2, arg3))
+    string_or_nothing(ccall((:CPLReadLine2L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, CSLConstList), arg1, arg2, arg3))
 end
 
 """
@@ -284,7 +284,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered or the maximum number of characters allowed reached.
 """
 function cplreadline3l(arg1, arg2, arg3, arg4)
-    unsafe_string(ccall((:CPLReadLine3L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, Ptr{Cint}, CSLConstList), arg1, arg2, arg3, arg4))
+    string_or_nothing(ccall((:CPLReadLine3L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, Ptr{Cint}, CSLConstList), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -424,7 +424,7 @@ Scan up to a maximum number of characters from a given string, allocate a buffer
 Pointer to the resulting string buffer. Caller responsible to free this buffer with CPLFree().
 """
 function cplscanstring(arg1, arg2, arg3, arg4)
-    unsafe_string(ccall((:CPLScanString, libgdal), Cstring, (Cstring, Cint, Cint, Cint), arg1, arg2, arg3, arg4))
+    string_or_nothing(ccall((:CPLScanString, libgdal), Cstring, (Cstring, Cint, Cint, Cint), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -731,7 +731,7 @@ Extract directory path portion of filename.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call. The returned will generally not contain a trailing path separator.
 """
 function cplgetpath(arg1)
-    unsafe_string(ccall((:CPLGetPath, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLGetPath, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -746,7 +746,7 @@ Extract directory path portion of filename.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call. The returned will generally not contain a trailing path separator.
 """
 function cplgetdirname(arg1)
-    unsafe_string(ccall((:CPLGetDirname, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLGetDirname, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -761,7 +761,7 @@ Extract non-directory portion of filename.
 just the non-directory portion of the path (points back into original string).
 """
 function cplgetfilename(arg1)
-    unsafe_string(ccall((:CPLGetFilename, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLGetFilename, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -776,7 +776,7 @@ Extract basename (non-directory, non-extension) portion of filename.
 just the non-directory, non-extension portion of the path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplgetbasename(arg1)
-    unsafe_string(ccall((:CPLGetBasename, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLGetBasename, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -791,7 +791,7 @@ Extract filename extension from full filename.
 just the extension portion of the path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplgetextension(arg1)
-    unsafe_string(ccall((:CPLGetExtension, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLGetExtension, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -803,7 +803,7 @@ Get the current working directory name.
 a pointer to buffer, containing current working directory path or NULL in case of error. User is responsible to free that buffer after usage with CPLFree() function. If HAVE_GETCWD macro is not defined, the function returns NULL.
 """
 function cplgetcurrentdir()
-    unsafe_string(ccall((:CPLGetCurrentDir, libgdal), Cstring, ()))
+    string_or_nothing(ccall((:CPLGetCurrentDir, libgdal), Cstring, ()))
 end
 
 """
@@ -822,7 +822,7 @@ Build a full file path from a passed path, file basename and extension.
 a fully formed filename in an internal static string. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplformfilename(pszPath, pszBasename, pszExtension)
-    unsafe_string(ccall((:CPLFormFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
+    string_or_nothing(ccall((:CPLFormFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
 end
 
 """
@@ -841,7 +841,7 @@ Case insensitive file searching, returning full path.
 a fully formed filename in an internal static string. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplformcifilename(pszPath, pszBasename, pszExtension)
-    unsafe_string(ccall((:CPLFormCIFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
+    string_or_nothing(ccall((:CPLFormCIFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
 end
 
 """
@@ -858,7 +858,7 @@ Replace the extension with the provided one.
 an altered filename with the new extension. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplresetextension(arg1, arg2)
-    unsafe_string(ccall((:CPLResetExtension, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    string_or_nothing(ccall((:CPLResetExtension, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -875,7 +875,7 @@ Find a file relative to a project file.
 a composed path to the secondary file. The returned string is internal and should not be altered, freed, or depending on past the next CPL call.
 """
 function cplprojectrelativefilename(pszProjectDir, pszSecondaryFilename)
-    unsafe_string(ccall((:CPLProjectRelativeFilename, libgdal), Cstring, (Cstring, Cstring), pszProjectDir, pszSecondaryFilename))
+    string_or_nothing(ccall((:CPLProjectRelativeFilename, libgdal), Cstring, (Cstring, Cstring), pszProjectDir, pszSecondaryFilename))
 end
 
 """
@@ -909,7 +909,7 @@ Get relative path from directory to target file.
 an adjusted path or the original if it could not be made relative to the pszBaseFile's path.
 """
 function cplextractrelativepath(arg1, arg2, arg3)
-    unsafe_string(ccall((:CPLExtractRelativePath, libgdal), Cstring, (Cstring, Cstring, Ptr{Cint}), arg1, arg2, arg3))
+    string_or_nothing(ccall((:CPLExtractRelativePath, libgdal), Cstring, (Cstring, Cstring, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -924,7 +924,7 @@ Remove trailing forward/backward slash from the path for UNIX/Windows resp.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplcleantrailingslash(arg1)
-    unsafe_string(ccall((:CPLCleanTrailingSlash, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:CPLCleanTrailingSlash, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -975,7 +975,7 @@ Generate temporary file name.
 a filename which is valid till the next CPL call in this thread.
 """
 function cplgeneratetempfilename(pszStem)
-    unsafe_string(ccall((:CPLGenerateTempFilename, libgdal), Cstring, (Cstring,), pszStem))
+    string_or_nothing(ccall((:CPLGenerateTempFilename, libgdal), Cstring, (Cstring,), pszStem))
 end
 
 """
@@ -990,7 +990,7 @@ Expands ~/ at start of filename.
 an expanded filename.
 """
 function cplexpandtilde(pszFilename)
-    unsafe_string(ccall((:CPLExpandTilde, libgdal), Cstring, (Cstring,), pszFilename))
+    string_or_nothing(ccall((:CPLExpandTilde, libgdal), Cstring, (Cstring,), pszFilename))
 end
 
 """
@@ -1002,7 +1002,7 @@ Return the path to the home directory.
 the home directory, or NULL.
 """
 function cplgethomedir()
-    unsafe_string(ccall((:CPLGetHomeDir, libgdal), Cstring, ()))
+    string_or_nothing(ccall((:CPLGetHomeDir, libgdal), Cstring, ()))
 end
 
 """
@@ -1012,7 +1012,7 @@ end
 CPLFindFile.
 """
 function cplfindfile(pszClass, pszBasename)
-    unsafe_string(ccall((:CPLFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
+    string_or_nothing(ccall((:CPLFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
 end
 
 """
@@ -1022,7 +1022,7 @@ end
 CPLDefaultFindFile.
 """
 function cpldefaultfindfile(pszClass, pszBasename)
-    unsafe_string(ccall((:CPLDefaultFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
+    string_or_nothing(ccall((:CPLDefaultFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
 end
 
 """
@@ -1162,7 +1162,7 @@ end
 Translate a decimal degrees value to a DMS string with hemisphere.
 """
 function cpldectodms(dfAngle, pszAxis, nPrecision)
-    unsafe_string(ccall((:CPLDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), dfAngle, pszAxis, nPrecision))
+    string_or_nothing(ccall((:CPLDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), dfAngle, pszAxis, nPrecision))
 end
 
 """
@@ -1355,7 +1355,7 @@ Prevents parallel executions of setlocale().
 See your compiler's documentation on setlocale.
 """
 function cplsetlocale(category, locale)
-    unsafe_string(ccall((:CPLsetlocale, libgdal), Cstring, (Cint, Cstring), category, locale))
+    string_or_nothing(ccall((:CPLsetlocale, libgdal), Cstring, (Cint, Cstring), category, locale))
 end
 
 """

--- a/src/cpl_conv.jl
+++ b/src/cpl_conv.jl
@@ -6,7 +6,7 @@
     CPLVerifyConfiguration() -> void
 """
 function cplverifyconfiguration()
-    ccall((:CPLVerifyConfiguration, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLVerifyConfiguration, libgdal), Cvoid, ()))
 end
 
 """
@@ -23,7 +23,7 @@ Get the value of a configuration option.
 the value associated to the key, or the default value if not found
 """
 function cplgetconfigoption(arg1, arg2)
-    string_or_nothing(ccall((:CPLGetConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    aftercare(ccall((:CPLGetConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2), false)
 end
 
 """
@@ -33,7 +33,7 @@ end
 Same as CPLGetConfigOption() but only with options set with CPLSetThreadLocalConfigOption()
 """
 function cplgetthreadlocalconfigoption(arg1, arg2)
-    string_or_nothing(ccall((:CPLGetThreadLocalConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    aftercare(ccall((:CPLGetThreadLocalConfigOption, libgdal), Cstring, (Cstring, Cstring), arg1, arg2), false)
 end
 
 """
@@ -47,7 +47,7 @@ Set a configuration option for GDAL/OGR use.
 * **pszValue**: the value of the option, or NULL to clear a setting.
 """
 function cplsetconfigoption(arg1, arg2)
-    ccall((:CPLSetConfigOption, libgdal), Cvoid, (Cstring, Cstring), arg1, arg2)
+    aftercare(ccall((:CPLSetConfigOption, libgdal), Cvoid, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -61,14 +61,14 @@ Set a configuration option for GDAL/OGR use.
 * **pszValue**: the value of the option, or NULL to clear a setting.
 """
 function cplsetthreadlocalconfigoption(pszKey, pszValue)
-    ccall((:CPLSetThreadLocalConfigOption, libgdal), Cvoid, (Cstring, Cstring), pszKey, pszValue)
+    aftercare(ccall((:CPLSetThreadLocalConfigOption, libgdal), Cvoid, (Cstring, Cstring), pszKey, pszValue))
 end
 
 """
     CPLFreeConfig() -> void
 """
 function cplfreeconfig()
-    ccall((:CPLFreeConfig, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLFreeConfig, libgdal), Cvoid, ()))
 end
 
 """
@@ -80,7 +80,7 @@ Return the list of configuration options as KEY=VALUE pairs.
 a copy of the list, to be freed with CSLDestroy().
 """
 function cplgetconfigoptions()
-    unsafe_loadstringlist(ccall((:CPLGetConfigOptions, libgdal), Ptr{Cstring}, ()))
+    aftercare(ccall((:CPLGetConfigOptions, libgdal), Ptr{Cstring}, ()))
 end
 
 """
@@ -92,7 +92,7 @@ Replace the full list of configuration options with the passed list of KEY=VALUE
 * **papszConfigOptions**: the new list (or NULL).
 """
 function cplsetconfigoptions(papszConfigOptions)
-    ccall((:CPLSetConfigOptions, libgdal), Cvoid, (Ptr{Cstring},), papszConfigOptions)
+    aftercare(ccall((:CPLSetConfigOptions, libgdal), Cvoid, (Ptr{Cstring},), papszConfigOptions))
 end
 
 """
@@ -104,7 +104,7 @@ Return the list of thread local configuration options as KEY=VALUE pairs.
 a copy of the list, to be freed with CSLDestroy().
 """
 function cplgetthreadlocalconfigoptions()
-    unsafe_loadstringlist(ccall((:CPLGetThreadLocalConfigOptions, libgdal), Ptr{Cstring}, ()))
+    aftercare(ccall((:CPLGetThreadLocalConfigOptions, libgdal), Ptr{Cstring}, ()))
 end
 
 """
@@ -116,7 +116,7 @@ Replace the full list of thread local configuration options with the passed list
 * **papszConfigOptions**: the new list (or NULL).
 """
 function cplsetthreadlocalconfigoptions(papszConfigOptions)
-    ccall((:CPLSetThreadLocalConfigOptions, libgdal), Cvoid, (Ptr{Cstring},), papszConfigOptions)
+    aftercare(ccall((:CPLSetThreadLocalConfigOptions, libgdal), Cvoid, (Ptr{Cstring},), papszConfigOptions))
 end
 
 """
@@ -131,7 +131,7 @@ Safe version of malloc().
 pointer to newly allocated memory, only NULL if nSize is zero.
 """
 function cplmalloc(arg1)
-    failsafe(ccall((:CPLMalloc, libgdal), Ptr{Cvoid}, (Csize_t,), arg1))
+    aftercare(ccall((:CPLMalloc, libgdal), Ptr{Cvoid}, (Csize_t,), arg1))
 end
 
 """
@@ -148,7 +148,7 @@ Safe version of calloc().
 pointer to newly allocated memory, only NULL if nSize * nCount is NULL.
 """
 function cplcalloc(arg1, arg2)
-    failsafe(ccall((:CPLCalloc, libgdal), Ptr{Cvoid}, (Csize_t, Csize_t), arg1, arg2))
+    aftercare(ccall((:CPLCalloc, libgdal), Ptr{Cvoid}, (Csize_t, Csize_t), arg1, arg2))
 end
 
 """
@@ -165,7 +165,7 @@ Safe version of realloc().
 pointer to allocated memory, only NULL if nNewSize is zero.
 """
 function cplrealloc(arg1, arg2)
-    failsafe(ccall((:CPLRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t), arg1, arg2))
+    aftercare(ccall((:CPLRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t), arg1, arg2))
 end
 
 """
@@ -180,7 +180,7 @@ Safe version of strdup() function.
 pointer to a newly allocated copy of the string. Free with CPLFree() or VSIFree().
 """
 function cplstrdup(arg1)
-    string_or_nothing(ccall((:CPLStrdup, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLStrdup, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -195,7 +195,7 @@ Convert each characters of the string to lower case.
 pointer to the same string, pszString.
 """
 function cplstrlwr(arg1)
-    string_or_nothing(ccall((:CPLStrlwr, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLStrlwr, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -214,7 +214,7 @@ Reads in at most one less than nBufferSize characters from the fp stream and sto
 pointer to the pszBuffer containing a string read from the file or NULL if the error or end of file was encountered.
 """
 function cplfgets(arg1, arg2, arg3)
-    string_or_nothing(ccall((:CPLFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
+    aftercare(ccall((:CPLFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3), false)
 end
 
 """
@@ -229,7 +229,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered.
 """
 function cplreadline(arg1)
-    string_or_nothing(ccall((:CPLReadLine, libgdal), Cstring, (Ptr{Cint},), arg1))
+    aftercare(ccall((:CPLReadLine, libgdal), Cstring, (Ptr{Cint},), arg1), false)
 end
 
 """
@@ -244,7 +244,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered.
 """
 function cplreadlinel(arg1)
-    string_or_nothing(ccall((:CPLReadLineL, libgdal), Cstring, (Ptr{VSILFILE},), arg1))
+    aftercare(ccall((:CPLReadLineL, libgdal), Cstring, (Ptr{VSILFILE},), arg1), false)
 end
 
 """
@@ -263,7 +263,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered or the maximum number of characters allowed reached.
 """
 function cplreadline2l(arg1, arg2, arg3)
-    string_or_nothing(ccall((:CPLReadLine2L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, CSLConstList), arg1, arg2, arg3))
+    aftercare(ccall((:CPLReadLine2L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, CSLConstList), arg1, arg2, arg3), false)
 end
 
 """
@@ -284,7 +284,7 @@ Simplified line reading from text file.
 pointer to an internal buffer containing a line of text read from the file or NULL if the end of file was encountered or the maximum number of characters allowed reached.
 """
 function cplreadline3l(arg1, arg2, arg3, arg4)
-    string_or_nothing(ccall((:CPLReadLine3L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, Ptr{Cint}, CSLConstList), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:CPLReadLine3L, libgdal), Cstring, (Ptr{VSILFILE}, Cint, Ptr{Cint}, CSLConstList), arg1, arg2, arg3, arg4), false)
 end
 
 """
@@ -299,7 +299,7 @@ Converts ASCII string to floating point number.
 Converted value, if any.
 """
 function cplatof(arg1)
-    ccall((:CPLAtof, libgdal), Cdouble, (Cstring,), arg1)
+    aftercare(ccall((:CPLAtof, libgdal), Cdouble, (Cstring,), arg1))
 end
 
 """
@@ -316,7 +316,7 @@ Converts ASCII string to floating point number.
 Converted value, if any.
 """
 function cplatofdelim(arg1, arg2)
-    ccall((:CPLAtofDelim, libgdal), Cdouble, (Cstring, UInt8), arg1, arg2)
+    aftercare(ccall((:CPLAtofDelim, libgdal), Cdouble, (Cstring, UInt8), arg1, arg2))
 end
 
 """
@@ -333,7 +333,7 @@ Converts ASCII string to floating point number.
 Converted value, if any.
 """
 function cplstrtod(arg1, arg2)
-    ccall((:CPLStrtod, libgdal), Cdouble, (Cstring, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:CPLStrtod, libgdal), Cdouble, (Cstring, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -352,7 +352,7 @@ Converts ASCII string to floating point number using specified delimiter.
 Converted value, if any.
 """
 function cplstrtoddelim(arg1, arg2, arg3)
-    ccall((:CPLStrtodDelim, libgdal), Cdouble, (Cstring, Ptr{Cstring}, UInt8), arg1, arg2, arg3)
+    aftercare(ccall((:CPLStrtodDelim, libgdal), Cdouble, (Cstring, Ptr{Cstring}, UInt8), arg1, arg2, arg3))
 end
 
 """
@@ -369,7 +369,7 @@ Converts ASCII string to floating point number.
 Converted value, if any.
 """
 function cplstrtof(arg1, arg2)
-    ccall((:CPLStrtof, libgdal), Cfloat, (Cstring, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:CPLStrtof, libgdal), Cfloat, (Cstring, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -388,7 +388,7 @@ Converts ASCII string to floating point number using specified delimiter.
 Converted value, if any.
 """
 function cplstrtofdelim(arg1, arg2, arg3)
-    ccall((:CPLStrtofDelim, libgdal), Cfloat, (Cstring, Ptr{Cstring}, UInt8), arg1, arg2, arg3)
+    aftercare(ccall((:CPLStrtofDelim, libgdal), Cfloat, (Cstring, Ptr{Cstring}, UInt8), arg1, arg2, arg3))
 end
 
 """
@@ -403,7 +403,7 @@ Converts ASCII string to floating point number using any numeric locale.
 Converted value, if any. Zero on failure.
 """
 function cplatofm(arg1)
-    ccall((:CPLAtofM, libgdal), Cdouble, (Cstring,), arg1)
+    aftercare(ccall((:CPLAtofM, libgdal), Cdouble, (Cstring,), arg1))
 end
 
 """
@@ -424,7 +424,7 @@ Scan up to a maximum number of characters from a given string, allocate a buffer
 Pointer to the resulting string buffer. Caller responsible to free this buffer with CPLFree().
 """
 function cplscanstring(arg1, arg2, arg3, arg4)
-    string_or_nothing(ccall((:CPLScanString, libgdal), Cstring, (Cstring, Cint, Cint, Cint), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:CPLScanString, libgdal), Cstring, (Cstring, Cint, Cint, Cint), arg1, arg2, arg3, arg4), false)
 end
 
 """
@@ -441,7 +441,7 @@ Extract double from string.
 Double value, converted from its ASCII form.
 """
 function cplscandouble(arg1, arg2)
-    ccall((:CPLScanDouble, libgdal), Cdouble, (Cstring, Cint), arg1, arg2)
+    aftercare(ccall((:CPLScanDouble, libgdal), Cdouble, (Cstring, Cint), arg1, arg2))
 end
 
 """
@@ -458,7 +458,7 @@ Scan up to a maximum number of characters from a string and convert the result t
 Long value, converted from its ASCII form.
 """
 function cplscanlong(arg1, arg2)
-    ccall((:CPLScanLong, libgdal), Clong, (Cstring, Cint), arg1, arg2)
+    aftercare(ccall((:CPLScanLong, libgdal), Clong, (Cstring, Cint), arg1, arg2))
 end
 
 """
@@ -475,7 +475,7 @@ Scan up to a maximum number of characters from a string and convert the result t
 Unsigned long value, converted from its ASCII form.
 """
 function cplscanulong(arg1, arg2)
-    ccall((:CPLScanULong, libgdal), Culong, (Cstring, Cint), arg1, arg2)
+    aftercare(ccall((:CPLScanULong, libgdal), Culong, (Cstring, Cint), arg1, arg2))
 end
 
 """
@@ -492,7 +492,7 @@ Extract big integer from string.
 GUIntBig value, converted from its ASCII form.
 """
 function cplscanuintbig(arg1, arg2)
-    ccall((:CPLScanUIntBig, libgdal), GUIntBig, (Cstring, Cint), arg1, arg2)
+    aftercare(ccall((:CPLScanUIntBig, libgdal), GUIntBig, (Cstring, Cint), arg1, arg2))
 end
 
 """
@@ -507,7 +507,7 @@ Convert a string to a 64 bit signed integer.
 64 bit signed integer.
 """
 function cplatogintbig(pszString)
-    ccall((:CPLAtoGIntBig, libgdal), GIntBig, (Cstring,), pszString)
+    aftercare(ccall((:CPLAtoGIntBig, libgdal), GIntBig, (Cstring,), pszString))
 end
 
 """
@@ -526,7 +526,7 @@ Convert a string to a 64 bit signed integer.
 64 bit signed integer.
 """
 function cplatogintbigex(pszString, bWarn, pbOverflow)
-    ccall((:CPLAtoGIntBigEx, libgdal), GIntBig, (Cstring, Cint, Ptr{Cint}), pszString, bWarn, pbOverflow)
+    aftercare(ccall((:CPLAtoGIntBigEx, libgdal), GIntBig, (Cstring, Cint, Ptr{Cint}), pszString, bWarn, pbOverflow))
 end
 
 """
@@ -543,7 +543,7 @@ Extract pointer from string.
 pointer value, converted from its ASCII form.
 """
 function cplscanpointer(arg1, arg2)
-    failsafe(ccall((:CPLScanPointer, libgdal), Ptr{Cvoid}, (Cstring, Cint), arg1, arg2))
+    aftercare(ccall((:CPLScanPointer, libgdal), Ptr{Cvoid}, (Cstring, Cint), arg1, arg2))
 end
 
 """
@@ -562,7 +562,7 @@ Copy the string pointed to by pszSrc, NOT including the terminating \0 character
 Number of characters printed.
 """
 function cplprintstring(arg1, arg2, arg3)
-    ccall((:CPLPrintString, libgdal), Cint, (Cstring, Cstring, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:CPLPrintString, libgdal), Cint, (Cstring, Cstring, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -581,7 +581,7 @@ Copy the string pointed to by pszSrc, NOT including the terminating \0 character
 Number of characters printed.
 """
 function cplprintstringfill(arg1, arg2, arg3)
-    ccall((:CPLPrintStringFill, libgdal), Cint, (Cstring, Cstring, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:CPLPrintStringFill, libgdal), Cint, (Cstring, Cstring, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -600,7 +600,7 @@ Print GInt32 value into specified string buffer.
 Number of characters printed.
 """
 function cplprintint32(arg1, arg2, arg3)
-    ccall((:CPLPrintInt32, libgdal), Cint, (Cstring, GInt32, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:CPLPrintInt32, libgdal), Cint, (Cstring, GInt32, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -619,7 +619,7 @@ Print GUIntBig value into specified string buffer.
 Number of characters printed.
 """
 function cplprintuintbig(arg1, arg2, arg3)
-    ccall((:CPLPrintUIntBig, libgdal), Cint, (Cstring, GUIntBig, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:CPLPrintUIntBig, libgdal), Cint, (Cstring, GUIntBig, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -640,7 +640,7 @@ Print double value into specified string buffer.
 Number of characters printed.
 """
 function cplprintdouble(arg1, arg2, arg3, arg4)
-    ccall((:CPLPrintDouble, libgdal), Cint, (Cstring, Cstring, Cdouble, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:CPLPrintDouble, libgdal), Cint, (Cstring, Cstring, Cdouble, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -663,7 +663,7 @@ Print specified time value accordingly to the format options and specified local
 Number of characters printed.
 """
 function cplprinttime(arg1, arg2, arg3, arg4, arg5)
-    ccall((:CPLPrintTime, libgdal), Cint, (Cstring, Cint, Cstring, Ptr{Ctm}, Cstring), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:CPLPrintTime, libgdal), Cint, (Cstring, Cint, Cstring, Ptr{Ctm}, Cstring), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -682,7 +682,7 @@ Print pointer value into specified string buffer.
 Number of characters printed.
 """
 function cplprintpointer(arg1, arg2, arg3)
-    ccall((:CPLPrintPointer, libgdal), Cint, (Cstring, Ptr{Cvoid}, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:CPLPrintPointer, libgdal), Cint, (Cstring, Ptr{Cvoid}, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -699,7 +699,7 @@ Fetch a function pointer from a shared library / DLL.
 A pointer to the function if found, or NULL if the function isn't found, or the shared library can't be loaded.
 """
 function cplgetsymbol(arg1, arg2)
-    failsafe(ccall((:CPLGetSymbol, libgdal), Ptr{Cvoid}, (Cstring, Cstring), arg1, arg2))
+    aftercare(ccall((:CPLGetSymbol, libgdal), Ptr{Cvoid}, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -716,7 +716,7 @@ Fetch path of executable.
 FALSE on failure or TRUE on success.
 """
 function cplgetexecpath(pszPathBuf, nMaxLength)
-    ccall((:CPLGetExecPath, libgdal), Cint, (Cstring, Cint), pszPathBuf, nMaxLength)
+    aftercare(ccall((:CPLGetExecPath, libgdal), Cint, (Cstring, Cint), pszPathBuf, nMaxLength))
 end
 
 """
@@ -731,7 +731,7 @@ Extract directory path portion of filename.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call. The returned will generally not contain a trailing path separator.
 """
 function cplgetpath(arg1)
-    string_or_nothing(ccall((:CPLGetPath, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLGetPath, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -746,7 +746,7 @@ Extract directory path portion of filename.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call. The returned will generally not contain a trailing path separator.
 """
 function cplgetdirname(arg1)
-    string_or_nothing(ccall((:CPLGetDirname, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLGetDirname, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -761,7 +761,7 @@ Extract non-directory portion of filename.
 just the non-directory portion of the path (points back into original string).
 """
 function cplgetfilename(arg1)
-    string_or_nothing(ccall((:CPLGetFilename, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLGetFilename, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -776,7 +776,7 @@ Extract basename (non-directory, non-extension) portion of filename.
 just the non-directory, non-extension portion of the path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplgetbasename(arg1)
-    string_or_nothing(ccall((:CPLGetBasename, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLGetBasename, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -791,7 +791,7 @@ Extract filename extension from full filename.
 just the extension portion of the path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplgetextension(arg1)
-    string_or_nothing(ccall((:CPLGetExtension, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLGetExtension, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -803,7 +803,7 @@ Get the current working directory name.
 a pointer to buffer, containing current working directory path or NULL in case of error. User is responsible to free that buffer after usage with CPLFree() function. If HAVE_GETCWD macro is not defined, the function returns NULL.
 """
 function cplgetcurrentdir()
-    string_or_nothing(ccall((:CPLGetCurrentDir, libgdal), Cstring, ()))
+    aftercare(ccall((:CPLGetCurrentDir, libgdal), Cstring, ()), false)
 end
 
 """
@@ -822,7 +822,7 @@ Build a full file path from a passed path, file basename and extension.
 a fully formed filename in an internal static string. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplformfilename(pszPath, pszBasename, pszExtension)
-    string_or_nothing(ccall((:CPLFormFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
+    aftercare(ccall((:CPLFormFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension), false)
 end
 
 """
@@ -841,7 +841,7 @@ Case insensitive file searching, returning full path.
 a fully formed filename in an internal static string. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplformcifilename(pszPath, pszBasename, pszExtension)
-    string_or_nothing(ccall((:CPLFormCIFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension))
+    aftercare(ccall((:CPLFormCIFilename, libgdal), Cstring, (Cstring, Cstring, Cstring), pszPath, pszBasename, pszExtension), false)
 end
 
 """
@@ -858,7 +858,7 @@ Replace the extension with the provided one.
 an altered filename with the new extension. Do not modify or free the returned string. The string may be destroyed by the next CPL call.
 """
 function cplresetextension(arg1, arg2)
-    string_or_nothing(ccall((:CPLResetExtension, libgdal), Cstring, (Cstring, Cstring), arg1, arg2))
+    aftercare(ccall((:CPLResetExtension, libgdal), Cstring, (Cstring, Cstring), arg1, arg2), false)
 end
 
 """
@@ -875,7 +875,7 @@ Find a file relative to a project file.
 a composed path to the secondary file. The returned string is internal and should not be altered, freed, or depending on past the next CPL call.
 """
 function cplprojectrelativefilename(pszProjectDir, pszSecondaryFilename)
-    string_or_nothing(ccall((:CPLProjectRelativeFilename, libgdal), Cstring, (Cstring, Cstring), pszProjectDir, pszSecondaryFilename))
+    aftercare(ccall((:CPLProjectRelativeFilename, libgdal), Cstring, (Cstring, Cstring), pszProjectDir, pszSecondaryFilename), false)
 end
 
 """
@@ -890,7 +890,7 @@ Is filename relative or absolute?
 TRUE if the filename is relative or FALSE if it is absolute.
 """
 function cplisfilenamerelative(pszFilename)
-    ccall((:CPLIsFilenameRelative, libgdal), Cint, (Cstring,), pszFilename)
+    aftercare(ccall((:CPLIsFilenameRelative, libgdal), Cint, (Cstring,), pszFilename))
 end
 
 """
@@ -909,7 +909,7 @@ Get relative path from directory to target file.
 an adjusted path or the original if it could not be made relative to the pszBaseFile's path.
 """
 function cplextractrelativepath(arg1, arg2, arg3)
-    string_or_nothing(ccall((:CPLExtractRelativePath, libgdal), Cstring, (Cstring, Cstring, Ptr{Cint}), arg1, arg2, arg3))
+    aftercare(ccall((:CPLExtractRelativePath, libgdal), Cstring, (Cstring, Cstring, Ptr{Cint}), arg1, arg2, arg3), false)
 end
 
 """
@@ -924,7 +924,7 @@ Remove trailing forward/backward slash from the path for UNIX/Windows resp.
 Path in an internal string which must not be freed. The string may be destroyed by the next CPL filename handling call.
 """
 function cplcleantrailingslash(arg1)
-    string_or_nothing(ccall((:CPLCleanTrailingSlash, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:CPLCleanTrailingSlash, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -943,7 +943,7 @@ Identify corresponding paths.
 a list of files corresponding to papszFileList but renamed to correspond to pszNewFilename.
 """
 function cplcorrespondingpaths(pszOldFilename, pszNewFilename, papszFileList)
-    unsafe_loadstringlist(ccall((:CPLCorrespondingPaths, libgdal), Ptr{Cstring}, (Cstring, Cstring, Ptr{Cstring}), pszOldFilename, pszNewFilename, papszFileList))
+    aftercare(ccall((:CPLCorrespondingPaths, libgdal), Ptr{Cstring}, (Cstring, Cstring, Ptr{Cstring}), pszOldFilename, pszNewFilename, papszFileList))
 end
 
 """
@@ -960,7 +960,7 @@ Check for file existence.
 TRUE if a match is found, or FALSE if not.
 """
 function cplcheckforfile(pszFilename, papszSiblingList)
-    ccall((:CPLCheckForFile, libgdal), Cint, (Cstring, Ptr{Cstring}), pszFilename, papszSiblingList)
+    aftercare(ccall((:CPLCheckForFile, libgdal), Cint, (Cstring, Ptr{Cstring}), pszFilename, papszSiblingList))
 end
 
 """
@@ -975,7 +975,7 @@ Generate temporary file name.
 a filename which is valid till the next CPL call in this thread.
 """
 function cplgeneratetempfilename(pszStem)
-    string_or_nothing(ccall((:CPLGenerateTempFilename, libgdal), Cstring, (Cstring,), pszStem))
+    aftercare(ccall((:CPLGenerateTempFilename, libgdal), Cstring, (Cstring,), pszStem), false)
 end
 
 """
@@ -990,7 +990,7 @@ Expands ~/ at start of filename.
 an expanded filename.
 """
 function cplexpandtilde(pszFilename)
-    string_or_nothing(ccall((:CPLExpandTilde, libgdal), Cstring, (Cstring,), pszFilename))
+    aftercare(ccall((:CPLExpandTilde, libgdal), Cstring, (Cstring,), pszFilename), false)
 end
 
 """
@@ -1002,7 +1002,7 @@ Return the path to the home directory.
 the home directory, or NULL.
 """
 function cplgethomedir()
-    string_or_nothing(ccall((:CPLGetHomeDir, libgdal), Cstring, ()))
+    aftercare(ccall((:CPLGetHomeDir, libgdal), Cstring, ()), false)
 end
 
 """
@@ -1012,7 +1012,7 @@ end
 CPLFindFile.
 """
 function cplfindfile(pszClass, pszBasename)
-    string_or_nothing(ccall((:CPLFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
+    aftercare(ccall((:CPLFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename), false)
 end
 
 """
@@ -1022,7 +1022,7 @@ end
 CPLDefaultFindFile.
 """
 function cpldefaultfindfile(pszClass, pszBasename)
-    string_or_nothing(ccall((:CPLDefaultFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename))
+    aftercare(ccall((:CPLDefaultFindFile, libgdal), Cstring, (Cstring, Cstring), pszClass, pszBasename), false)
 end
 
 """
@@ -1031,7 +1031,7 @@ end
 CPLPushFileFinder.
 """
 function cplpushfilefinder(pfnFinder)
-    ccall((:CPLPushFileFinder, libgdal), Cvoid, (CPLFileFinder,), pfnFinder)
+    aftercare(ccall((:CPLPushFileFinder, libgdal), Cvoid, (CPLFileFinder,), pfnFinder))
 end
 
 """
@@ -1040,7 +1040,7 @@ end
 CPLPopFileFinder.
 """
 function cplpopfilefinder()
-    failsafe(ccall((:CPLPopFileFinder, libgdal), CPLFileFinder, ()))
+    aftercare(ccall((:CPLPopFileFinder, libgdal), CPLFileFinder, ()))
 end
 
 """
@@ -1049,7 +1049,7 @@ end
 CPLPushFinderLocation.
 """
 function cplpushfinderlocation(arg1)
-    ccall((:CPLPushFinderLocation, libgdal), Cvoid, (Cstring,), arg1)
+    aftercare(ccall((:CPLPushFinderLocation, libgdal), Cvoid, (Cstring,), arg1))
 end
 
 """
@@ -1058,7 +1058,7 @@ end
 CPLPopFinderLocation.
 """
 function cplpopfinderlocation()
-    ccall((:CPLPopFinderLocation, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLPopFinderLocation, libgdal), Cvoid, ()))
 end
 
 """
@@ -1067,7 +1067,7 @@ end
 CPLFinderClean.
 """
 function cplfinderclean()
-    ccall((:CPLFinderClean, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLFinderClean, libgdal), Cvoid, ()))
 end
 
 """
@@ -1077,7 +1077,7 @@ end
 Same as VSIStat() except it works on "C:" as if it were "C:\".
 """
 function cplstat(arg1, arg2)
-    ccall((:CPLStat, libgdal), Cint, (Cstring, Ptr{VSIStatBuf}), arg1, arg2)
+    aftercare(ccall((:CPLStat, libgdal), Cint, (Cstring, Ptr{VSIStatBuf}), arg1, arg2))
 end
 
 """
@@ -1096,7 +1096,7 @@ Open a shared file handle.
 a file handle or NULL if opening fails.
 """
 function cplopenshared()
-    ccall((:CPLOpenShared, libgdal), Ptr{Cint}, ())
+    aftercare(ccall((:CPLOpenShared, libgdal), Ptr{Cint}, ()))
 end
 
 """
@@ -1108,7 +1108,7 @@ Close shared file.
 * **fp**: file handle from CPLOpenShared() to deaccess.
 """
 function cplcloseshared(arg1)
-    ccall((:CPLCloseShared, libgdal), Cvoid, (Ptr{Cint},), arg1)
+    aftercare(ccall((:CPLCloseShared, libgdal), Cvoid, (Ptr{Cint},), arg1))
 end
 
 """
@@ -1123,7 +1123,7 @@ Fetch list of open shared files.
 the pointer to the first in the array of shared file info structures.
 """
 function cplgetsharedlist(arg1)
-    ccall((:CPLGetSharedList, libgdal), Ptr{CPLSharedFileInfo}, (Ptr{Cint},), arg1)
+    aftercare(ccall((:CPLGetSharedList, libgdal), Ptr{CPLSharedFileInfo}, (Ptr{Cint},), arg1))
 end
 
 """
@@ -1135,14 +1135,14 @@ Report open shared files.
 * **fp**: File handle to write to.
 """
 function cpldumpsharedlist(arg1)
-    ccall((:CPLDumpSharedList, libgdal), Cvoid, (Ptr{Cint},), arg1)
+    aftercare(ccall((:CPLDumpSharedList, libgdal), Cvoid, (Ptr{Cint},), arg1))
 end
 
 """
     CPLCleanupSharedFileMutex() -> void
 """
 function cplcleanupsharedfilemutex()
-    ccall((:CPLCleanupSharedFileMutex, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLCleanupSharedFileMutex, libgdal), Cvoid, ()))
 end
 
 """
@@ -1151,7 +1151,7 @@ end
 CPLDMSToDec.
 """
 function cpldmstodec(is)
-    ccall((:CPLDMSToDec, libgdal), Cdouble, (Cstring,), is)
+    aftercare(ccall((:CPLDMSToDec, libgdal), Cdouble, (Cstring,), is))
 end
 
 """
@@ -1162,7 +1162,7 @@ end
 Translate a decimal degrees value to a DMS string with hemisphere.
 """
 function cpldectodms(dfAngle, pszAxis, nPrecision)
-    string_or_nothing(ccall((:CPLDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), dfAngle, pszAxis, nPrecision))
+    aftercare(ccall((:CPLDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), dfAngle, pszAxis, nPrecision), false)
 end
 
 """
@@ -1177,7 +1177,7 @@ Convert a packed DMS value (DDDMMMSSS.SS) into decimal degrees.
 Angle in decimal degrees.
 """
 function cplpackeddmstodec(arg1)
-    ccall((:CPLPackedDMSToDec, libgdal), Cdouble, (Cdouble,), arg1)
+    aftercare(ccall((:CPLPackedDMSToDec, libgdal), Cdouble, (Cdouble,), arg1))
 end
 
 """
@@ -1192,7 +1192,7 @@ Convert decimal degrees into packed DMS value (DDDMMMSSS.SS).
 Angle in packed DMS format.
 """
 function cpldectopackeddms(dfDec)
-    ccall((:CPLDecToPackedDMS, libgdal), Cdouble, (Cdouble,), dfDec)
+    aftercare(ccall((:CPLDecToPackedDMS, libgdal), Cdouble, (Cdouble,), dfDec))
 end
 
 """
@@ -1203,7 +1203,7 @@ end
 Fetch the real and imaginary part of a serialized complex number.
 """
 function cplstringtocomplex(pszString, pdfReal, pdfImag)
-    ccall((:CPLStringToComplex, libgdal), Cvoid, (Cstring, Ptr{Cdouble}, Ptr{Cdouble}), pszString, pdfReal, pdfImag)
+    aftercare(ccall((:CPLStringToComplex, libgdal), Cvoid, (Cstring, Ptr{Cdouble}, Ptr{Cdouble}), pszString, pdfReal, pdfImag))
 end
 
 """
@@ -1215,7 +1215,7 @@ Recursively unlink a directory.
 0 on successful completion, -1 if function fails.
 """
 function cplunlinktree(arg1)
-    ccall((:CPLUnlinkTree, libgdal), Cint, (Cstring,), arg1)
+    aftercare(ccall((:CPLUnlinkTree, libgdal), Cint, (Cstring,), arg1))
 end
 
 """
@@ -1225,7 +1225,7 @@ end
 Copy a file.
 """
 function cplcopyfile(pszNewPath, pszOldPath)
-    ccall((:CPLCopyFile, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath)
+    aftercare(ccall((:CPLCopyFile, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath))
 end
 
 """
@@ -1235,7 +1235,7 @@ end
 Recursively copy a tree.
 """
 function cplcopytree(pszNewPath, pszOldPath)
-    ccall((:CPLCopyTree, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath)
+    aftercare(ccall((:CPLCopyTree, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath))
 end
 
 """
@@ -1245,7 +1245,7 @@ end
 Move a file.
 """
 function cplmovefile(pszNewPath, pszOldPath)
-    ccall((:CPLMoveFile, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath)
+    aftercare(ccall((:CPLMoveFile, libgdal), Cint, (Cstring, Cstring), pszNewPath, pszOldPath))
 end
 
 """
@@ -1256,7 +1256,7 @@ end
 Create a symbolic link.
 """
 function cplsymlink(pszOldPath, pszNewPath, papszOptions)
-    ccall((:CPLSymlink, libgdal), Cint, (Cstring, Cstring, CSLConstList), pszOldPath, pszNewPath, papszOptions)
+    aftercare(ccall((:CPLSymlink, libgdal), Cint, (Cstring, Cstring, CSLConstList), pszOldPath, pszNewPath, papszOptions))
 end
 
 """
@@ -1264,7 +1264,7 @@ end
                  char **) -> void *
 """
 function cplcreatezip(pszZipFilename, papszOptions)
-    failsafe(ccall((:CPLCreateZip, libgdal), Ptr{Cvoid}, (Cstring, Ptr{Cstring}), pszZipFilename, papszOptions))
+    aftercare(ccall((:CPLCreateZip, libgdal), Ptr{Cvoid}, (Cstring, Ptr{Cstring}), pszZipFilename, papszOptions))
 end
 
 """
@@ -1273,7 +1273,7 @@ end
                        char **) -> CPLErr
 """
 function cplcreatefileinzip(hZip, pszFilename, papszOptions)
-    ccall((:CPLCreateFileInZip, libgdal), CPLErr, (Ptr{Cvoid}, Cstring, Ptr{Cstring}), hZip, pszFilename, papszOptions)
+    aftercare(ccall((:CPLCreateFileInZip, libgdal), CPLErr, (Ptr{Cvoid}, Cstring, Ptr{Cstring}), hZip, pszFilename, papszOptions))
 end
 
 """
@@ -1282,21 +1282,21 @@ end
                       int) -> CPLErr
 """
 function cplwritefileinzip(hZip, pBuffer, nBufferSize)
-    ccall((:CPLWriteFileInZip, libgdal), CPLErr, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), hZip, pBuffer, nBufferSize)
+    aftercare(ccall((:CPLWriteFileInZip, libgdal), CPLErr, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), hZip, pBuffer, nBufferSize))
 end
 
 """
     CPLCloseFileInZip(void *) -> CPLErr
 """
 function cplclosefileinzip(hZip)
-    ccall((:CPLCloseFileInZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip)
+    aftercare(ccall((:CPLCloseFileInZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
 end
 
 """
     CPLCloseZip(void *) -> CPLErr
 """
 function cplclosezip(hZip)
-    ccall((:CPLCloseZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip)
+    aftercare(ccall((:CPLCloseZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
 end
 
 """
@@ -1308,7 +1308,7 @@ end
                    size_t * pnOutBytes) -> void *
 """
 function cplzlibdeflate(ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBytes)
-    failsafe(ccall((:CPLZLibDeflate, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Cint, Ptr{Cvoid}, Csize_t, Ptr{Csize_t}), ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBytes))
+    aftercare(ccall((:CPLZLibDeflate, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Cint, Ptr{Cvoid}, Csize_t, Ptr{Csize_t}), ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBytes))
 end
 
 """
@@ -1319,7 +1319,7 @@ end
                    size_t * pnOutBytes) -> void *
 """
 function cplzlibinflate(ptr, nBytes, outptr, nOutAvailableBytes, pnOutBytes)
-    failsafe(ccall((:CPLZLibInflate, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, Ptr{Csize_t}), ptr, nBytes, outptr, nOutAvailableBytes, pnOutBytes))
+    aftercare(ccall((:CPLZLibInflate, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, Ptr{Csize_t}), ptr, nBytes, outptr, nOutAvailableBytes, pnOutBytes))
 end
 
 """
@@ -1338,7 +1338,7 @@ Validate a XML file against a XML schema.
 TRUE if the XML file validates against the XML schema.
 """
 function cplvalidatexml(pszXMLFilename, pszXSDFilename, papszOptions)
-    ccall((:CPLValidateXML, libgdal), Cint, (Cstring, Cstring, CSLConstList), pszXMLFilename, pszXSDFilename, papszOptions)
+    aftercare(ccall((:CPLValidateXML, libgdal), Cint, (Cstring, Cstring, CSLConstList), pszXMLFilename, pszXSDFilename, papszOptions))
 end
 
 """
@@ -1355,14 +1355,14 @@ Prevents parallel executions of setlocale().
 See your compiler's documentation on setlocale.
 """
 function cplsetlocale(category, locale)
-    string_or_nothing(ccall((:CPLsetlocale, libgdal), Cstring, (Cint, Cstring), category, locale))
+    aftercare(ccall((:CPLsetlocale, libgdal), Cstring, (Cint, Cstring), category, locale), false)
 end
 
 """
     CPLCleanupSetlocaleMutex(void) -> void
 """
 function cplcleanupsetlocalemutex()
-    ccall((:CPLCleanupSetlocaleMutex, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLCleanupSetlocaleMutex, libgdal), Cvoid, ()))
 end
 
 """
@@ -1375,5 +1375,5 @@ end
 TRUE if i is power of two otherwise return FALSE
 """
 function cplispoweroftwo(i)
-    ccall((:CPLIsPowerOfTwo, libgdal), Cint, (UInt32,), i)
+    aftercare(ccall((:CPLIsPowerOfTwo, libgdal), Cint, (UInt32,), i))
 end

--- a/src/cpl_error.jl
+++ b/src/cpl_error.jl
@@ -56,7 +56,7 @@ Get the last error message.
 the last error message, or NULL if there is no posted error message.
 """
 function cplgetlasterrormsg()
-    unsafe_string(ccall((:CPLGetLastErrorMsg, libgdal), Cstring, ()))
+    string_or_nothing(ccall((:CPLGetLastErrorMsg, libgdal), Cstring, ()))
 end
 
 """

--- a/src/cpl_error.jl
+++ b/src/cpl_error.jl
@@ -56,7 +56,7 @@ Get the last error message.
 the last error message, or NULL if there is no posted error message.
 """
 function cplgetlasterrormsg()
-    string_or_nothing(ccall((:CPLGetLastErrorMsg, libgdal), Cstring, ()))
+    unsafe_string(ccall((:CPLGetLastErrorMsg, libgdal), Cstring, ()))
 end
 
 """
@@ -80,7 +80,7 @@ Fetch the user data for the error context.
 the user data pointer for the error context
 """
 function cplgeterrorhandleruserdata()
-    failsafe(ccall((:CPLGetErrorHandlerUserData, libgdal), Ptr{Cvoid}, ()))
+    ccall((:CPLGetErrorHandlerUserData, libgdal), Ptr{Cvoid}, ())
 end
 
 """
@@ -140,7 +140,7 @@ end
 Whether failures should be turned into warnings.
 """
 function cplturnfailureintowarning(bOn)
-    ccall((:CPLTurnFailureIntoWarning, libgdal), Cvoid, (Cint,), bOn)
+    aftercare(ccall((:CPLTurnFailureIntoWarning, libgdal), Cvoid, (Cint,), bOn))
 end
 
 """
@@ -155,7 +155,7 @@ Install custom error handler.
 returns the previously installed error handler.
 """
 function cplseterrorhandler(arg1)
-    failsafe(ccall((:CPLSetErrorHandler, libgdal), CPLErrorHandler, (CPLErrorHandler,), arg1))
+    ccall((:CPLSetErrorHandler, libgdal), CPLErrorHandler, (CPLErrorHandler,), arg1)
 end
 
 """
@@ -172,7 +172,7 @@ Install custom error handle with user's data.
 returns the previously installed error handler.
 """
 function cplseterrorhandlerex(arg1, arg2)
-    failsafe(ccall((:CPLSetErrorHandlerEx, libgdal), CPLErrorHandler, (CPLErrorHandler, Ptr{Cvoid}), arg1, arg2))
+    ccall((:CPLSetErrorHandlerEx, libgdal), CPLErrorHandler, (CPLErrorHandler, Ptr{Cvoid}), arg1, arg2)
 end
 
 """
@@ -230,5 +230,5 @@ end
 Report failure of a logical assertion.
 """
 function _cplassert(arg1, arg2, arg3)
-    ccall((:_CPLAssert, libgdal), Cvoid, (Cstring, Cstring, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:_CPLAssert, libgdal), Cvoid, (Cstring, Cstring, Cint), arg1, arg2, arg3))
 end

--- a/src/cpl_minixml.jl
+++ b/src/cpl_minixml.jl
@@ -79,7 +79,7 @@ Fetch element/attribute value.
 the requested value or pszDefault if not found.
 """
 function cplgetxmlvalue(poRoot, pszPath, pszDefault)
-    unsafe_string(ccall((:CPLGetXMLValue, libgdal), Cstring, (Ptr{CPLXMLNode}, Cstring, Cstring), poRoot, pszPath, pszDefault))
+    string_or_nothing(ccall((:CPLGetXMLValue, libgdal), Cstring, (Ptr{CPLXMLNode}, Cstring, Cstring), poRoot, pszPath, pszDefault))
 end
 
 """
@@ -113,7 +113,7 @@ Convert tree into string document.
 the document on success or NULL on failure.
 """
 function cplserializexmltree(psNode)
-    unsafe_string(ccall((:CPLSerializeXMLTree, libgdal), Cstring, (Ptr{CPLXMLNode},), psNode))
+    string_or_nothing(ccall((:CPLSerializeXMLTree, libgdal), Cstring, (Ptr{CPLXMLNode},), psNode))
 end
 
 """

--- a/src/cpl_minixml.jl
+++ b/src/cpl_minixml.jl
@@ -14,7 +14,7 @@ Parse an XML string into tree form.
 parsed tree or NULL on error.
 """
 function cplparsexmlstring(arg1)
-    ccall((:CPLParseXMLString, libgdal), Ptr{CPLXMLNode}, (Cstring,), arg1)
+    aftercare(ccall((:CPLParseXMLString, libgdal), Ptr{CPLXMLNode}, (Cstring,), arg1))
 end
 
 """
@@ -26,7 +26,7 @@ Destroy a tree.
 * **psNode**: the tree to free.
 """
 function cpldestroyxmlnode(arg1)
-    ccall((:CPLDestroyXMLNode, libgdal), Cvoid, (Ptr{CPLXMLNode},), arg1)
+    aftercare(ccall((:CPLDestroyXMLNode, libgdal), Cvoid, (Ptr{CPLXMLNode},), arg1))
 end
 
 """
@@ -43,7 +43,7 @@ Find node by path.
 the requested element node, or NULL if not found.
 """
 function cplgetxmlnode(poRoot, pszPath)
-    ccall((:CPLGetXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring), poRoot, pszPath)
+    aftercare(ccall((:CPLGetXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring), poRoot, pszPath))
 end
 
 """
@@ -60,7 +60,7 @@ Search for a node in document.
 The matching node or NULL on failure.
 """
 function cplsearchxmlnode(poRoot, pszTarget)
-    ccall((:CPLSearchXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring), poRoot, pszTarget)
+    aftercare(ccall((:CPLSearchXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring), poRoot, pszTarget))
 end
 
 """
@@ -79,7 +79,7 @@ Fetch element/attribute value.
 the requested value or pszDefault if not found.
 """
 function cplgetxmlvalue(poRoot, pszPath, pszDefault)
-    string_or_nothing(ccall((:CPLGetXMLValue, libgdal), Cstring, (Ptr{CPLXMLNode}, Cstring, Cstring), poRoot, pszPath, pszDefault))
+    aftercare(ccall((:CPLGetXMLValue, libgdal), Cstring, (Ptr{CPLXMLNode}, Cstring, Cstring), poRoot, pszPath, pszDefault), false)
 end
 
 """
@@ -98,7 +98,7 @@ Create an document tree item.
 the newly created node, now owned by the caller (or parent node).
 """
 function cplcreatexmlnode(poParent, eType, pszText)
-    ccall((:CPLCreateXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, CPLXMLNodeType, Cstring), poParent, eType, pszText)
+    aftercare(ccall((:CPLCreateXMLNode, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, CPLXMLNodeType, Cstring), poParent, eType, pszText))
 end
 
 """
@@ -113,7 +113,7 @@ Convert tree into string document.
 the document on success or NULL on failure.
 """
 function cplserializexmltree(psNode)
-    string_or_nothing(ccall((:CPLSerializeXMLTree, libgdal), Cstring, (Ptr{CPLXMLNode},), psNode))
+    aftercare(ccall((:CPLSerializeXMLTree, libgdal), Cstring, (Ptr{CPLXMLNode},), psNode), false)
 end
 
 """
@@ -127,7 +127,7 @@ Add child node to parent.
 * **psChild**: the child to add to the parent. May not be NULL. Should not be a child of any other parent.
 """
 function cpladdxmlchild(psParent, psChild)
-    ccall((:CPLAddXMLChild, libgdal), Cvoid, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psParent, psChild)
+    aftercare(ccall((:CPLAddXMLChild, libgdal), Cvoid, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psParent, psChild))
 end
 
 """
@@ -144,7 +144,7 @@ Remove child node from parent.
 TRUE on success or FALSE if the child was not found.
 """
 function cplremovexmlchild(psParent, psChild)
-    ccall((:CPLRemoveXMLChild, libgdal), Cint, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psParent, psChild)
+    aftercare(ccall((:CPLRemoveXMLChild, libgdal), Cint, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psParent, psChild))
 end
 
 """
@@ -158,7 +158,7 @@ Add new sibling.
 * **psNewSibling**: the node to add at the end of psOlderSiblings psNext chain.
 """
 function cpladdxmlsibling(psOlderSibling, psNewSibling)
-    ccall((:CPLAddXMLSibling, libgdal), Cvoid, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psOlderSibling, psNewSibling)
+    aftercare(ccall((:CPLAddXMLSibling, libgdal), Cvoid, (Ptr{CPLXMLNode}, Ptr{CPLXMLNode}), psOlderSibling, psNewSibling))
 end
 
 """
@@ -177,7 +177,7 @@ Create an element and text value.
 the pointer to the new element node.
 """
 function cplcreatexmlelementandvalue(psParent, pszName, pszValue)
-    ccall((:CPLCreateXMLElementAndValue, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring, Cstring), psParent, pszName, pszValue)
+    aftercare(ccall((:CPLCreateXMLElementAndValue, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode}, Cstring, Cstring), psParent, pszName, pszValue))
 end
 
 """
@@ -193,7 +193,7 @@ Create an attribute and text value.
 * **pszValue**: the text to attach to the attribute. Must not be NULL.
 """
 function cpladdxmlattributeandvalue(psParent, pszName, pszValue)
-    ccall((:CPLAddXMLAttributeAndValue, libgdal), Cvoid, (Ptr{CPLXMLNode}, Cstring, Cstring), psParent, pszName, pszValue)
+    aftercare(ccall((:CPLAddXMLAttributeAndValue, libgdal), Cvoid, (Ptr{CPLXMLNode}, Cstring, Cstring), psParent, pszName, pszValue))
 end
 
 """
@@ -208,7 +208,7 @@ Copy tree.
 a copy of the whole tree.
 """
 function cplclonexmltree(psTree)
-    ccall((:CPLCloneXMLTree, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode},), psTree)
+    aftercare(ccall((:CPLCloneXMLTree, libgdal), Ptr{CPLXMLNode}, (Ptr{CPLXMLNode},), psTree))
 end
 
 """
@@ -227,7 +227,7 @@ Set element value by path.
 TRUE on success.
 """
 function cplsetxmlvalue(psRoot, pszPath, pszValue)
-    ccall((:CPLSetXMLValue, libgdal), Cint, (Ptr{CPLXMLNode}, Cstring, Cstring), psRoot, pszPath, pszValue)
+    aftercare(ccall((:CPLSetXMLValue, libgdal), Cint, (Ptr{CPLXMLNode}, Cstring, Cstring), psRoot, pszPath, pszValue))
 end
 
 """
@@ -243,7 +243,7 @@ Strip indicated namespaces.
 * **bRecurse**: TRUE to recurse over whole document, or FALSE to only operate on the passed node.
 """
 function cplstripxmlnamespace(psRoot, pszNameSpace, bRecurse)
-    ccall((:CPLStripXMLNamespace, libgdal), Cvoid, (Ptr{CPLXMLNode}, Cstring, Cint), psRoot, pszNameSpace, bRecurse)
+    aftercare(ccall((:CPLStripXMLNamespace, libgdal), Cvoid, (Ptr{CPLXMLNode}, Cstring, Cint), psRoot, pszNameSpace, bRecurse))
 end
 
 """
@@ -255,7 +255,7 @@ Make string into safe XML token.
 * **pszTarget**: the string to be adjusted. It is altered in place.
 """
 function cplcleanxmlelementname(arg1)
-    ccall((:CPLCleanXMLElementName, libgdal), Cvoid, (Cstring,), arg1)
+    aftercare(ccall((:CPLCleanXMLElementName, libgdal), Cvoid, (Cstring,), arg1))
 end
 
 """
@@ -270,7 +270,7 @@ Parse XML file into tree.
 NULL on failure, or the document tree on success.
 """
 function cplparsexmlfile(pszFilename)
-    ccall((:CPLParseXMLFile, libgdal), Ptr{CPLXMLNode}, (Cstring,), pszFilename)
+    aftercare(ccall((:CPLParseXMLFile, libgdal), Ptr{CPLXMLNode}, (Cstring,), pszFilename))
 end
 
 """
@@ -287,5 +287,5 @@ Write document tree to a file.
 TRUE on success, FALSE otherwise.
 """
 function cplserializexmltreetofile(psTree, pszFilename)
-    ccall((:CPLSerializeXMLTreeToFile, libgdal), Cint, (Ptr{CPLXMLNode}, Cstring), psTree, pszFilename)
+    aftercare(ccall((:CPLSerializeXMLTreeToFile, libgdal), Cint, (Ptr{CPLXMLNode}, Cstring), psTree, pszFilename))
 end

--- a/src/cpl_progress.jl
+++ b/src/cpl_progress.jl
@@ -10,7 +10,7 @@
 Stub progress function.
 """
 function gdaldummyprogress(arg1, arg2, arg3)
-    ccall((:GDALDummyProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALDummyProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3))
 end
 
 """
@@ -29,7 +29,7 @@ Simple progress report to terminal.
 Always returns TRUE indicating the process should continue.
 """
 function gdaltermprogress(arg1, arg2, arg3)
-    ccall((:GDALTermProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALTermProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3))
 end
 
 """
@@ -40,7 +40,7 @@ end
 Scaled progress transformer.
 """
 function gdalscaledprogress(arg1, arg2, arg3)
-    ccall((:GDALScaledProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALScaledProgress, libgdal), Cint, (Cdouble, Cstring, Ptr{Cvoid}), arg1, arg2, arg3))
 end
 
 """
@@ -61,7 +61,7 @@ Create scaled progress transformer.
 pointer to pass as pProgressArg to sub functions. Should be freed with GDALDestroyScaledProgress().
 """
 function gdalcreatescaledprogress(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:GDALCreateScaledProgress, libgdal), Ptr{Cvoid}, (Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:GDALCreateScaledProgress, libgdal), Ptr{Cvoid}, (Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -73,5 +73,5 @@ Cleanup scaled progress handle.
 * **pData**: scaled progress handle returned by GDALCreateScaledProgress().
 """
 function gdaldestroyscaledprogress(arg1)
-    ccall((:GDALDestroyScaledProgress, libgdal), Cvoid, (Ptr{Cvoid},), arg1)
+    aftercare(ccall((:GDALDestroyScaledProgress, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
 end

--- a/src/cpl_virtualmem.jl
+++ b/src/cpl_virtualmem.jl
@@ -11,7 +11,7 @@ Return the size of a page of virtual memory.
 the page size.
 """
 function cplgetpagesize()
-    ccall((:CPLGetPageSize, libgdal), Csize_t, ())
+    aftercare(ccall((:CPLGetPageSize, libgdal), Csize_t, ()))
 end
 
 """
@@ -42,7 +42,7 @@ Create a new virtual memory mapping.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function cplvirtualmemnew(nSize, nCacheSize, nPageSizeHint, bSingleThreadUsage, eAccessMode, pfnCachePage, pfnUnCachePage, pfnFreeUserData, pCbkUserData)
-    failsafe(ccall((:CPLVirtualMemNew, libgdal), Ptr{CPLVirtualMem}, (Csize_t, Csize_t, Csize_t, Cint, CPLVirtualMemAccessMode, CPLVirtualMemCachePageCbk, CPLVirtualMemUnCachePageCbk, CPLVirtualMemFreeUserData, Ptr{Cvoid}), nSize, nCacheSize, nPageSizeHint, bSingleThreadUsage, eAccessMode, pfnCachePage, pfnUnCachePage, pfnFreeUserData, pCbkUserData))
+    aftercare(ccall((:CPLVirtualMemNew, libgdal), Ptr{CPLVirtualMem}, (Csize_t, Csize_t, Csize_t, Cint, CPLVirtualMemAccessMode, CPLVirtualMemCachePageCbk, CPLVirtualMemUnCachePageCbk, CPLVirtualMemFreeUserData, Ptr{Cvoid}), nSize, nCacheSize, nPageSizeHint, bSingleThreadUsage, eAccessMode, pfnCachePage, pfnUnCachePage, pfnFreeUserData, pCbkUserData))
 end
 
 """
@@ -54,7 +54,7 @@ Return if virtual memory mapping of a file is available.
 TRUE if virtual memory mapping of a file is available.
 """
 function cplisvirtualmemfilemapavailable()
-    ccall((:CPLIsVirtualMemFileMapAvailable, libgdal), Cint, ())
+    aftercare(ccall((:CPLIsVirtualMemFileMapAvailable, libgdal), Cint, ()))
 end
 
 """
@@ -79,7 +79,7 @@ Create a new virtual memory mapping from a file.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function cplvirtualmemfilemapnew(fp, nOffset, nLength, eAccessMode, pfnFreeUserData, pCbkUserData)
-    failsafe(ccall((:CPLVirtualMemFileMapNew, libgdal), Ptr{CPLVirtualMem}, (Ptr{VSILFILE}, vsi_l_offset, vsi_l_offset, CPLVirtualMemAccessMode, CPLVirtualMemFreeUserData, Ptr{Cvoid}), fp, nOffset, nLength, eAccessMode, pfnFreeUserData, pCbkUserData))
+    aftercare(ccall((:CPLVirtualMemFileMapNew, libgdal), Ptr{CPLVirtualMem}, (Ptr{VSILFILE}, vsi_l_offset, vsi_l_offset, CPLVirtualMemAccessMode, CPLVirtualMemFreeUserData, Ptr{Cvoid}), fp, nOffset, nLength, eAccessMode, pfnFreeUserData, pCbkUserData))
 end
 
 """
@@ -102,7 +102,7 @@ Create a new virtual memory mapping derived from an other virtual memory mapping
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function cplvirtualmemderivednew(pVMemBase, nOffset, nSize, pfnFreeUserData, pCbkUserData)
-    failsafe(ccall((:CPLVirtualMemDerivedNew, libgdal), Ptr{CPLVirtualMem}, (Ptr{CPLVirtualMem}, vsi_l_offset, vsi_l_offset, CPLVirtualMemFreeUserData, Ptr{Cvoid}), pVMemBase, nOffset, nSize, pfnFreeUserData, pCbkUserData))
+    aftercare(ccall((:CPLVirtualMemDerivedNew, libgdal), Ptr{CPLVirtualMem}, (Ptr{CPLVirtualMem}, vsi_l_offset, vsi_l_offset, CPLVirtualMemFreeUserData, Ptr{Cvoid}), pVMemBase, nOffset, nSize, pfnFreeUserData, pCbkUserData))
 end
 
 """
@@ -114,7 +114,7 @@ Free a virtual memory mapping.
 * **ctxt**: context returned by CPLVirtualMemNew().
 """
 function cplvirtualmemfree(ctxt)
-    ccall((:CPLVirtualMemFree, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemFree, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -129,7 +129,7 @@ Return the pointer to the start of a virtual memory mapping.
 the pointer to the start of a virtual memory mapping.
 """
 function cplvirtualmemgetaddr(ctxt)
-    failsafe(ccall((:CPLVirtualMemGetAddr, libgdal), Ptr{Cvoid}, (Ptr{CPLVirtualMem},), ctxt))
+    aftercare(ccall((:CPLVirtualMemGetAddr, libgdal), Ptr{Cvoid}, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -144,7 +144,7 @@ Return the size of the virtual memory mapping.
 the size of the virtual memory mapping.
 """
 function cplvirtualmemgetsize(ctxt)
-    ccall((:CPLVirtualMemGetSize, libgdal), Csize_t, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemGetSize, libgdal), Csize_t, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -159,7 +159,7 @@ Return if the virtual memory mapping is a direct file mapping.
 TRUE if the virtual memory mapping is a direct file mapping.
 """
 function cplvirtualmemisfilemapping(ctxt)
-    ccall((:CPLVirtualMemIsFileMapping, libgdal), Cint, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemIsFileMapping, libgdal), Cint, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -174,7 +174,7 @@ Return the access mode of the virtual memory mapping.
 the access mode of the virtual memory mapping.
 """
 function cplvirtualmemgetaccessmode(ctxt)
-    ccall((:CPLVirtualMemGetAccessMode, libgdal), CPLVirtualMemAccessMode, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemGetAccessMode, libgdal), CPLVirtualMemAccessMode, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -189,7 +189,7 @@ Return the page size associated to a virtual memory mapping.
 the page size
 """
 function cplvirtualmemgetpagesize(ctxt)
-    ccall((:CPLVirtualMemGetPageSize, libgdal), Csize_t, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemGetPageSize, libgdal), Csize_t, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -204,7 +204,7 @@ Return TRUE if this memory mapping can be accessed safely from concurrent thread
 TRUE if this memory mapping can be accessed safely from concurrent threads.
 """
 function cplvirtualmemisaccessthreadsafe(ctxt)
-    ccall((:CPLVirtualMemIsAccessThreadSafe, libgdal), Cint, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemIsAccessThreadSafe, libgdal), Cint, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -216,7 +216,7 @@ Declare that a thread will access a virtual memory mapping.
 * **ctxt**: context returned by CPLVirtualMemNew().
 """
 function cplvirtualmemdeclarethread(ctxt)
-    ccall((:CPLVirtualMemDeclareThread, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemDeclareThread, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -228,7 +228,7 @@ Declare that a thread will stop accessing a virtual memory mapping.
 * **ctxt**: context returned by CPLVirtualMemNew().
 """
 function cplvirtualmemundeclarethread(ctxt)
-    ccall((:CPLVirtualMemUnDeclareThread, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt)
+    aftercare(ccall((:CPLVirtualMemUnDeclareThread, libgdal), Cvoid, (Ptr{CPLVirtualMem},), ctxt))
 end
 
 """
@@ -246,7 +246,7 @@ Make sure that a region of virtual memory will be realized.
 * **bWriteOp**: set to TRUE if the memory are will be accessed in write mode.
 """
 function cplvirtualmempin(ctxt, pAddr, nSize, bWriteOp)
-    ccall((:CPLVirtualMemPin, libgdal), Cvoid, (Ptr{CPLVirtualMem}, Ptr{Cvoid}, Csize_t, Cint), ctxt, pAddr, nSize, bWriteOp)
+    aftercare(ccall((:CPLVirtualMemPin, libgdal), Cvoid, (Ptr{CPLVirtualMem}, Ptr{Cvoid}, Csize_t, Cint), ctxt, pAddr, nSize, bWriteOp))
 end
 
 """
@@ -255,5 +255,5 @@ end
 Cleanup any resource and handlers related to virtual memory.
 """
 function cplvirtualmemmanagerterminate()
-    ccall((:CPLVirtualMemManagerTerminate, libgdal), Cvoid, ())
+    aftercare(ccall((:CPLVirtualMemManagerTerminate, libgdal), Cvoid, ()))
 end

--- a/src/cpl_vsi.jl
+++ b/src/cpl_vsi.jl
@@ -7,14 +7,14 @@
              const char * pszAccess) -> FILE *
 """
 function vsifopen()
-    ccall((:VSIFOpen, libgdal), Ptr{Cint}, ())
+    aftercare(ccall((:VSIFOpen, libgdal), Ptr{Cint}, ()))
 end
 
 """
     VSIFClose(FILE * fp) -> int
 """
 function vsifclose(arg1)
-    ccall((:VSIFClose, libgdal), Cint, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIFClose, libgdal), Cint, (Ptr{Cint},), arg1))
 end
 
 """
@@ -23,28 +23,28 @@ end
              int nWhence) -> int
 """
 function vsifseek(arg1, arg2, arg3)
-    ccall((:VSIFSeek, libgdal), Cint, (Ptr{Cint}, Clong, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:VSIFSeek, libgdal), Cint, (Ptr{Cint}, Clong, Cint), arg1, arg2, arg3))
 end
 
 """
     VSIFTell(FILE * fp) -> long
 """
 function vsiftell(arg1)
-    ccall((:VSIFTell, libgdal), Clong, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIFTell, libgdal), Clong, (Ptr{Cint},), arg1))
 end
 
 """
     VSIRewind(FILE * fp) -> void
 """
 function vsirewind(arg1)
-    ccall((:VSIRewind, libgdal), Cvoid, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIRewind, libgdal), Cvoid, (Ptr{Cint},), arg1))
 end
 
 """
     VSIFFlush(FILE * fp) -> void
 """
 function vsifflush(arg1)
-    ccall((:VSIFFlush, libgdal), Cvoid, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIFFlush, libgdal), Cvoid, (Ptr{Cint},), arg1))
 end
 
 """
@@ -54,7 +54,7 @@ end
              FILE * fp) -> size_t
 """
 function vsifread()
-    ccall((:VSIFRead, libgdal), Cint, ())
+    aftercare(ccall((:VSIFRead, libgdal), Cint, ()))
 end
 
 """
@@ -64,7 +64,7 @@ end
               FILE * fp) -> size_t
 """
 function vsifwrite()
-    ccall((:VSIFWrite, libgdal), Cint, ())
+    aftercare(ccall((:VSIFWrite, libgdal), Cint, ()))
 end
 
 """
@@ -73,7 +73,7 @@ end
              FILE * fp) -> char *
 """
 function vsifgets(arg1, arg2, arg3)
-    string_or_nothing(ccall((:VSIFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
+    aftercare(ccall((:VSIFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3), false)
 end
 
 """
@@ -81,14 +81,14 @@ end
              FILE * fp) -> int
 """
 function vsifputs(arg1, arg2)
-    ccall((:VSIFPuts, libgdal), Cint, (Cstring, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:VSIFPuts, libgdal), Cint, (Cstring, Ptr{Cint}), arg1, arg2))
 end
 
 """
     VSIFGetc(FILE * fp) -> int
 """
 function vsifgetc(arg1)
-    ccall((:VSIFGetc, libgdal), Cint, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIFGetc, libgdal), Cint, (Ptr{Cint},), arg1))
 end
 
 """
@@ -96,7 +96,7 @@ end
              FILE * fp) -> int
 """
 function vsifputc(arg1, arg2)
-    ccall((:VSIFPutc, libgdal), Cint, (Cint, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:VSIFPutc, libgdal), Cint, (Cint, Ptr{Cint}), arg1, arg2))
 end
 
 """
@@ -104,14 +104,14 @@ end
               FILE * fp) -> int
 """
 function vsiungetc(arg1, arg2)
-    ccall((:VSIUngetc, libgdal), Cint, (Cint, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:VSIUngetc, libgdal), Cint, (Cint, Ptr{Cint}), arg1, arg2))
 end
 
 """
     VSIFEof(FILE * fp) -> int
 """
 function vsifeof(arg1)
-    ccall((:VSIFEof, libgdal), Cint, (Ptr{Cint},), arg1)
+    aftercare(ccall((:VSIFEof, libgdal), Cint, (Ptr{Cint},), arg1))
 end
 
 """
@@ -119,7 +119,7 @@ end
             VSIStatBuf * pStatBuf) -> int
 """
 function vsistat(arg1, arg2)
-    ccall((:VSIStat, libgdal), Cint, (Cstring, Ptr{VSIStatBuf}), arg1, arg2)
+    aftercare(ccall((:VSIStat, libgdal), Cint, (Cstring, Ptr{VSIStatBuf}), arg1, arg2))
 end
 
 """
@@ -136,7 +136,7 @@ Open file.
 NULL on failure, or the file handle.
 """
 function vsifopenl(arg1, arg2)
-    ccall((:VSIFOpenL, libgdal), Ptr{VSILFILE}, (Cstring, Cstring), arg1, arg2)
+    aftercare(ccall((:VSIFOpenL, libgdal), Ptr{VSILFILE}, (Cstring, Cstring), arg1, arg2))
 end
 
 """
@@ -155,7 +155,7 @@ Open file.
 NULL on failure, or the file handle.
 """
 function vsifopenexl(arg1, arg2, arg3)
-    ccall((:VSIFOpenExL, libgdal), Ptr{VSILFILE}, (Cstring, Cstring, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:VSIFOpenExL, libgdal), Ptr{VSILFILE}, (Cstring, Cstring, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -170,7 +170,7 @@ Close file.
 0 on success or -1 on failure.
 """
 function vsifclosel(arg1)
-    ccall((:VSIFCloseL, libgdal), Cint, (Ptr{VSILFILE},), arg1)
+    aftercare(ccall((:VSIFCloseL, libgdal), Cint, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -189,7 +189,7 @@ Seek to requested offset.
 0 on success or -1 one failure.
 """
 function vsifseekl(arg1, arg2, arg3)
-    ccall((:VSIFSeekL, libgdal), Cint, (Ptr{VSILFILE}, vsi_l_offset, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:VSIFSeekL, libgdal), Cint, (Ptr{VSILFILE}, vsi_l_offset, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -204,7 +204,7 @@ Tell current file offset.
 file offset in bytes.
 """
 function vsiftelll(arg1)
-    ccall((:VSIFTellL, libgdal), vsi_l_offset, (Ptr{VSILFILE},), arg1)
+    aftercare(ccall((:VSIFTellL, libgdal), vsi_l_offset, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -216,7 +216,7 @@ Rewind the file pointer to the beginning of the file.
 * **fp**: file handle opened with VSIFOpenL().
 """
 function vsirewindl(arg1)
-    ccall((:VSIRewindL, libgdal), Cvoid, (Ptr{VSILFILE},), arg1)
+    aftercare(ccall((:VSIRewindL, libgdal), Cvoid, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -237,7 +237,7 @@ Read bytes from file.
 number of objects successfully read.
 """
 function vsifreadl()
-    ccall((:VSIFReadL, libgdal), Cint, ())
+    aftercare(ccall((:VSIFReadL, libgdal), Cint, ()))
 end
 
 """
@@ -260,7 +260,7 @@ Read several ranges of bytes from file.
 0 in case of success, -1 otherwise.
 """
 function vsifreadmultirangel(nRanges, ppData, panOffsets, panSizes, arg1)
-    ccall((:VSIFReadMultiRangeL, libgdal), Cint, (Cint, Ptr{Ptr{Cvoid}}, Ptr{vsi_l_offset}, Ptr{Cint}, Ptr{VSILFILE}), nRanges, ppData, panOffsets, panSizes, arg1)
+    aftercare(ccall((:VSIFReadMultiRangeL, libgdal), Cint, (Cint, Ptr{Ptr{Cvoid}}, Ptr{vsi_l_offset}, Ptr{Cint}, Ptr{VSILFILE}), nRanges, ppData, panOffsets, panSizes, arg1))
 end
 
 """
@@ -281,7 +281,7 @@ Write bytes to file.
 number of objects successfully written.
 """
 function vsifwritel()
-    ccall((:VSIFWriteL, libgdal), Cint, ())
+    aftercare(ccall((:VSIFWriteL, libgdal), Cint, ()))
 end
 
 """
@@ -296,7 +296,7 @@ Test for end of file.
 TRUE if at EOF else FALSE.
 """
 function vsifeofl(arg1)
-    ccall((:VSIFEofL, libgdal), Cint, (Ptr{VSILFILE},), arg1)
+    aftercare(ccall((:VSIFEofL, libgdal), Cint, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -313,7 +313,7 @@ Truncate/expand the file to the specified size.
 0 on success
 """
 function vsiftruncatel(arg1, arg2)
-    ccall((:VSIFTruncateL, libgdal), Cint, (Ptr{VSILFILE}, vsi_l_offset), arg1, arg2)
+    aftercare(ccall((:VSIFTruncateL, libgdal), Cint, (Ptr{VSILFILE}, vsi_l_offset), arg1, arg2))
 end
 
 """
@@ -328,7 +328,7 @@ Flush pending writes to disk.
 0 on success or -1 on error.
 """
 function vsifflushl(arg1)
-    ccall((:VSIFFlushL, libgdal), Cint, (Ptr{VSILFILE},), arg1)
+    aftercare(ccall((:VSIFFlushL, libgdal), Cint, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -345,7 +345,7 @@ Write a single byte to the file.
 1 in case of success, 0 on error.
 """
 function vsifputcl(arg1, arg2)
-    ccall((:VSIFPutcL, libgdal), Cint, (Cint, Ptr{VSILFILE}), arg1, arg2)
+    aftercare(ccall((:VSIFPutcL, libgdal), Cint, (Cint, Ptr{VSILFILE}), arg1, arg2))
 end
 
 """
@@ -364,7 +364,7 @@ Return if a given file range contains data or holes filled with zeroes.
 extent status: VSI_RANGE_STATUS_UNKNOWN, VSI_RANGE_STATUS_DATA or VSI_RANGE_STATUS_HOLE
 """
 function vsifgetrangestatusl(fp, nStart, nLength)
-    ccall((:VSIFGetRangeStatusL, libgdal), VSIRangeStatus, (Ptr{VSILFILE}, vsi_l_offset, vsi_l_offset), fp, nStart, nLength)
+    aftercare(ccall((:VSIFGetRangeStatusL, libgdal), VSIRangeStatus, (Ptr{VSILFILE}, vsi_l_offset, vsi_l_offset), fp, nStart, nLength))
 end
 
 """
@@ -387,7 +387,7 @@ Ingest a file into memory.
 TRUE in case of success.
 """
 function vsiingestfile(fp, pszFilename, ppabyRet, pnSize, nMaxSize)
-    ccall((:VSIIngestFile, libgdal), Cint, (Ptr{VSILFILE}, Cstring, Ptr{Ptr{GByte}}, Ptr{vsi_l_offset}, GIntBig), fp, pszFilename, ppabyRet, pnSize, nMaxSize)
+    aftercare(ccall((:VSIIngestFile, libgdal), Cint, (Ptr{VSILFILE}, Cstring, Ptr{Ptr{GByte}}, Ptr{vsi_l_offset}, GIntBig), fp, pszFilename, ppabyRet, pnSize, nMaxSize))
 end
 
 """
@@ -404,7 +404,7 @@ Get filesystem object info.
 0 on success or -1 on an error.
 """
 function vsistatl(arg1, arg2)
-    ccall((:VSIStatL, libgdal), Cint, (Cstring, Ptr{VSIStatBufL}), arg1, arg2)
+    aftercare(ccall((:VSIStatL, libgdal), Cint, (Cstring, Ptr{VSIStatBufL}), arg1, arg2))
 end
 
 """
@@ -423,7 +423,7 @@ Get filesystem object info.
 0 on success or -1 on an error.
 """
 function vsistatexl(pszFilename, psStatBuf, nFlags)
-    ccall((:VSIStatExL, libgdal), Cint, (Cstring, Ptr{VSIStatBufL}, Cint), pszFilename, psStatBuf, nFlags)
+    aftercare(ccall((:VSIStatExL, libgdal), Cint, (Cstring, Ptr{VSIStatBufL}, Cint), pszFilename, psStatBuf, nFlags))
 end
 
 """
@@ -438,7 +438,7 @@ Returns if the filenames of the filesystem are case sensitive.
 TRUE if the filenames of the filesystem are case sensitive.
 """
 function vsiiscasesensitivefs(pszFilename)
-    ccall((:VSIIsCaseSensitiveFS, libgdal), Cint, (Cstring,), pszFilename)
+    aftercare(ccall((:VSIIsCaseSensitiveFS, libgdal), Cint, (Cstring,), pszFilename))
 end
 
 """
@@ -453,7 +453,7 @@ Returns if the filesystem supports sparse files.
 TRUE if the file system is known to support sparse files. FALSE may be returned both in cases where it is known to not support them, or when it is unknown.
 """
 function vsisupportssparsefiles(pszPath)
-    ccall((:VSISupportsSparseFiles, libgdal), Cint, (Cstring,), pszPath)
+    aftercare(ccall((:VSISupportsSparseFiles, libgdal), Cint, (Cstring,), pszPath))
 end
 
 """
@@ -468,7 +468,7 @@ Returns if the filesystem supports efficient multi-range reading.
 TRUE if the file system is known to have an efficient multi-range reading.
 """
 function vsihasoptimizedreadmultirange(pszPath)
-    ccall((:VSIHasOptimizedReadMultiRange, libgdal), Cint, (Cstring,), pszPath)
+    aftercare(ccall((:VSIHasOptimizedReadMultiRange, libgdal), Cint, (Cstring,), pszPath))
 end
 
 """
@@ -483,7 +483,7 @@ Returns the actual URL of a supplied filename.
 the actual URL corresponding to the supplied filename, or NULL. Should not be freed.
 """
 function vsigetactualurl(pszFilename)
-    string_or_nothing(ccall((:VSIGetActualURL, libgdal), Cstring, (Cstring,), pszFilename))
+    aftercare(ccall((:VSIGetActualURL, libgdal), Cstring, (Cstring,), pszFilename), false)
 end
 
 """
@@ -508,7 +508,7 @@ VERB=GET/HEAD/DELETE/PUT/POST: HTTP VERB for which the request will be used. Def
 a signed URL, or NULL. Should be freed with CPLFree().
 """
 function vsigetsignedurl(pszFilename, papszOptions)
-    string_or_nothing(ccall((:VSIGetSignedURL, libgdal), Cstring, (Cstring, CSLConstList), pszFilename, papszOptions))
+    aftercare(ccall((:VSIGetSignedURL, libgdal), Cstring, (Cstring, CSLConstList), pszFilename, papszOptions), false)
 end
 
 """
@@ -523,7 +523,7 @@ Return the list of options associated with a virtual file system handler as a se
 a string, which must not be freed, or NULL if no options is declared.
 """
 function vsigetfilesystemoptions(pszFilename)
-    string_or_nothing(ccall((:VSIGetFileSystemOptions, libgdal), Cstring, (Cstring,), pszFilename))
+    aftercare(ccall((:VSIGetFileSystemOptions, libgdal), Cstring, (Cstring,), pszFilename), false)
 end
 
 """
@@ -535,7 +535,7 @@ Return the list of prefixes for virtual file system handlers currently registere
 a NULL terminated list of prefixes. Must be freed with CSLDestroy()
 """
 function vsigetfilesystemsprefixes()
-    unsafe_loadstringlist(ccall((:VSIGetFileSystemsPrefixes, libgdal), Ptr{Cstring}, ()))
+    aftercare(ccall((:VSIGetFileSystemsPrefixes, libgdal), Ptr{Cstring}, ()))
 end
 
 """
@@ -550,7 +550,7 @@ Returns the "native" file descriptor for the virtual handle.
 the native file descriptor, or NULL.
 """
 function vsifgetnativefiledescriptorl(arg1)
-    failsafe(ccall((:VSIFGetNativeFileDescriptorL, libgdal), Ptr{Cvoid}, (Ptr{VSILFILE},), arg1))
+    aftercare(ccall((:VSIFGetNativeFileDescriptorL, libgdal), Ptr{Cvoid}, (Ptr{VSILFILE},), arg1))
 end
 
 """
@@ -560,7 +560,7 @@ end
 Analog of calloc().
 """
 function vsicalloc()
-    failsafe(ccall((:VSICalloc, libgdal), Ptr{Cvoid}, ()))
+    aftercare(ccall((:VSICalloc, libgdal), Ptr{Cvoid}, ()))
 end
 
 """
@@ -569,7 +569,7 @@ end
 Analog of malloc().
 """
 function vsimalloc()
-    failsafe(ccall((:VSIMalloc, libgdal), Ptr{Cvoid}, ()))
+    aftercare(ccall((:VSIMalloc, libgdal), Ptr{Cvoid}, ()))
 end
 
 """
@@ -578,7 +578,7 @@ end
 Analog of free() for data allocated with VSIMalloc(), VSICalloc(), VSIRealloc()
 """
 function vsifree(arg1)
-    ccall((:VSIFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1)
+    aftercare(ccall((:VSIFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
 end
 
 """
@@ -588,7 +588,7 @@ end
 Analog of realloc().
 """
 function vsirealloc(arg1, size_t)
-    failsafe(ccall((:VSIRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), arg1, size_t))
+    aftercare(ccall((:VSIRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), arg1, size_t))
 end
 
 """
@@ -597,7 +597,7 @@ end
 Analog of strdup().
 """
 function vsistrdup(arg1)
-    string_or_nothing(ccall((:VSIStrdup, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:VSIStrdup, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -614,7 +614,7 @@ Allocates a buffer with an alignment constraint.
 a buffer aligned on nAlignment and of size nSize, or NULL
 """
 function vsimallocaligned(nAlignment, nSize)
-    failsafe(ccall((:VSIMallocAligned, libgdal), Ptr{Cvoid}, (Cint, Cint), nAlignment, nSize))
+    aftercare(ccall((:VSIMallocAligned, libgdal), Ptr{Cvoid}, (Cint, Cint), nAlignment, nSize))
 end
 
 """
@@ -629,7 +629,7 @@ Allocates a buffer with an alignment constraint such that it can be used by the 
 an aligned buffer of size nSize, or NULL
 """
 function vsimallocalignedauto(nSize)
-    failsafe(ccall((:VSIMallocAlignedAuto, libgdal), Ptr{Cvoid}, (Cint,), nSize))
+    aftercare(ccall((:VSIMallocAlignedAuto, libgdal), Ptr{Cvoid}, (Cint,), nSize))
 end
 
 """
@@ -641,7 +641,7 @@ Free a buffer allocated with VSIMallocAligned().
 * **ptr**: Buffer to free.
 """
 function vsifreealigned(ptr)
-    ccall((:VSIFreeAligned, libgdal), Cvoid, (Ptr{Cvoid},), ptr)
+    aftercare(ccall((:VSIFreeAligned, libgdal), Cvoid, (Ptr{Cvoid},), ptr))
 end
 
 """
@@ -652,7 +652,7 @@ end
 See VSIMallocAlignedAuto()
 """
 function vsimallocalignedautoverbose(nSize, pszFile, nLine)
-    failsafe(ccall((:VSIMallocAlignedAutoVerbose, libgdal), Ptr{Cvoid}, (Cint, Cstring, Cint), nSize, pszFile, nLine))
+    aftercare(ccall((:VSIMallocAlignedAutoVerbose, libgdal), Ptr{Cvoid}, (Cint, Cstring, Cint), nSize, pszFile, nLine))
 end
 
 """
@@ -662,7 +662,7 @@ end
 VSIMalloc2 allocates (nSize1 * nSize2) bytes.
 """
 function vsimalloc2(nSize1, nSize2)
-    failsafe(ccall((:VSIMalloc2, libgdal), Ptr{Cvoid}, (Cint, Cint), nSize1, nSize2))
+    aftercare(ccall((:VSIMalloc2, libgdal), Ptr{Cvoid}, (Cint, Cint), nSize1, nSize2))
 end
 
 """
@@ -673,7 +673,7 @@ end
 VSIMalloc3 allocates (nSize1 * nSize2 * nSize3) bytes.
 """
 function vsimalloc3(nSize1, nSize2, nSize3)
-    failsafe(ccall((:VSIMalloc3, libgdal), Ptr{Cvoid}, (Cint, Cint, Cint), nSize1, nSize2, nSize3))
+    aftercare(ccall((:VSIMalloc3, libgdal), Ptr{Cvoid}, (Cint, Cint, Cint), nSize1, nSize2, nSize3))
 end
 
 """
@@ -684,7 +684,7 @@ end
 VSIMallocVerbose.
 """
 function vsimallocverbose(nSize, pszFile, nLine)
-    failsafe(ccall((:VSIMallocVerbose, libgdal), Ptr{Cvoid}, (Cint, Cstring, Cint), nSize, pszFile, nLine))
+    aftercare(ccall((:VSIMallocVerbose, libgdal), Ptr{Cvoid}, (Cint, Cstring, Cint), nSize, pszFile, nLine))
 end
 
 """
@@ -696,7 +696,7 @@ end
 VSIMalloc2Verbose.
 """
 function vsimalloc2verbose(nSize1, nSize2, pszFile, nLine)
-    failsafe(ccall((:VSIMalloc2Verbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cstring, Cint), nSize1, nSize2, pszFile, nLine))
+    aftercare(ccall((:VSIMalloc2Verbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cstring, Cint), nSize1, nSize2, pszFile, nLine))
 end
 
 """
@@ -709,7 +709,7 @@ end
 VSIMalloc3Verbose.
 """
 function vsimalloc3verbose(nSize1, nSize2, nSize3, pszFile, nLine)
-    failsafe(ccall((:VSIMalloc3Verbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cint, Cstring, Cint), nSize1, nSize2, nSize3, pszFile, nLine))
+    aftercare(ccall((:VSIMalloc3Verbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cint, Cstring, Cint), nSize1, nSize2, nSize3, pszFile, nLine))
 end
 
 """
@@ -721,7 +721,7 @@ end
 VSICallocVerbose.
 """
 function vsicallocverbose(nCount, nSize, pszFile, nLine)
-    failsafe(ccall((:VSICallocVerbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cstring, Cint), nCount, nSize, pszFile, nLine))
+    aftercare(ccall((:VSICallocVerbose, libgdal), Ptr{Cvoid}, (Cint, Cint, Cstring, Cint), nCount, nSize, pszFile, nLine))
 end
 
 """
@@ -733,7 +733,7 @@ end
 VSIReallocVerbose.
 """
 function vsireallocverbose(pOldPtr, nNewSize, pszFile, nLine)
-    failsafe(ccall((:VSIReallocVerbose, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Cstring, Cint), pOldPtr, nNewSize, pszFile, nLine))
+    aftercare(ccall((:VSIReallocVerbose, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Cstring, Cint), pOldPtr, nNewSize, pszFile, nLine))
 end
 
 """
@@ -744,7 +744,7 @@ end
 VSIStrdupVerbose.
 """
 function vsistrdupverbose(pszStr, pszFile, nLine)
-    string_or_nothing(ccall((:VSIStrdupVerbose, libgdal), Cstring, (Cstring, Cstring, Cint), pszStr, pszFile, nLine))
+    aftercare(ccall((:VSIStrdupVerbose, libgdal), Cstring, (Cstring, Cstring, Cint), pszStr, pszFile, nLine), false)
 end
 
 """
@@ -756,7 +756,7 @@ Return the total physical RAM in bytes.
 the total physical RAM in bytes (or 0 in case of failure).
 """
 function cplgetphysicalram()
-    ccall((:CPLGetPhysicalRAM, libgdal), GIntBig, ())
+    aftercare(ccall((:CPLGetPhysicalRAM, libgdal), GIntBig, ()))
 end
 
 """
@@ -768,7 +768,7 @@ Return the total physical RAM, usable by a process, in bytes.
 the total physical RAM, usable by a process, in bytes (or 0 in case of failure).
 """
 function cplgetusablephysicalram()
-    ccall((:CPLGetUsablePhysicalRAM, libgdal), GIntBig, ())
+    aftercare(ccall((:CPLGetUsablePhysicalRAM, libgdal), GIntBig, ()))
 end
 
 """
@@ -783,7 +783,7 @@ Read names in a directory.
 The list of entries in the directory, or NULL if the directory doesn't exist. Filenames are returned in UTF-8 encoding.
 """
 function vsireaddir(arg1)
-    unsafe_loadstringlist(ccall((:VSIReadDir, libgdal), Ptr{Cstring}, (Cstring,), arg1))
+    aftercare(ccall((:VSIReadDir, libgdal), Ptr{Cstring}, (Cstring,), arg1))
 end
 
 """
@@ -798,7 +798,7 @@ Read names in a directory recursively.
 The list of entries in the directory and subdirectories or NULL if the directory doesn't exist. Filenames are returned in UTF-8 encoding.
 """
 function vsireaddirrecursive(pszPath)
-    unsafe_loadstringlist(ccall((:VSIReadDirRecursive, libgdal), Ptr{Cstring}, (Cstring,), pszPath))
+    aftercare(ccall((:VSIReadDirRecursive, libgdal), Ptr{Cstring}, (Cstring,), pszPath))
 end
 
 """
@@ -815,7 +815,7 @@ Read names in a directory.
 The list of entries in the directory, or NULL if the directory doesn't exist. Filenames are returned in UTF-8 encoding.
 """
 function vsireaddirex(pszPath, nMaxFiles)
-    unsafe_loadstringlist(ccall((:VSIReadDirEx, libgdal), Ptr{Cstring}, (Cstring, Cint), pszPath, nMaxFiles))
+    aftercare(ccall((:VSIReadDirEx, libgdal), Ptr{Cstring}, (Cstring, Cint), pszPath, nMaxFiles))
 end
 
 """
@@ -834,7 +834,7 @@ Open a directory to read its entries.
 a handle, or NULL in case of error
 """
 function vsiopendir(pszPath, nRecurseDepth, papszOptions)
-    failsafe(ccall((:VSIOpenDir, libgdal), Ptr{VSIDIR}, (Cstring, Cint, Ptr{Cstring}), pszPath, nRecurseDepth, papszOptions))
+    aftercare(ccall((:VSIOpenDir, libgdal), Ptr{VSIDIR}, (Cstring, Cint, Ptr{Cstring}), pszPath, nRecurseDepth, papszOptions))
 end
 
 """
@@ -849,7 +849,7 @@ Return the next entry of the directory.
 a entry, or NULL if there is no more entry in the directory. This return value must not be freed.
 """
 function vsigetnextdirentry(dir)
-    ccall((:VSIGetNextDirEntry, libgdal), Ptr{VSIDIREntry}, (Ptr{VSIDIR},), dir)
+    aftercare(ccall((:VSIGetNextDirEntry, libgdal), Ptr{VSIDIREntry}, (Ptr{VSIDIR},), dir))
 end
 
 """
@@ -861,7 +861,7 @@ Close a directory.
 * **dir**: Directory handled returned by VSIOpenDir().
 """
 function vsiclosedir(dir)
-    ccall((:VSICloseDir, libgdal), Cvoid, (Ptr{VSIDIR},), dir)
+    aftercare(ccall((:VSICloseDir, libgdal), Cvoid, (Ptr{VSIDIR},), dir))
 end
 
 """
@@ -878,7 +878,7 @@ Create a directory.
 0 on success or -1 on an error.
 """
 function vsimkdir(pszPathname, mode)
-    ccall((:VSIMkdir, libgdal), Cint, (Cstring, Clong), pszPathname, mode)
+    aftercare(ccall((:VSIMkdir, libgdal), Cint, (Cstring, Clong), pszPathname, mode))
 end
 
 """
@@ -895,7 +895,7 @@ Create a directory and all its ancestors.
 0 on success or -1 on an error.
 """
 function vsimkdirrecursive(pszPathname, mode)
-    ccall((:VSIMkdirRecursive, libgdal), Cint, (Cstring, Clong), pszPathname, mode)
+    aftercare(ccall((:VSIMkdirRecursive, libgdal), Cint, (Cstring, Clong), pszPathname, mode))
 end
 
 """
@@ -910,7 +910,7 @@ Delete a directory.
 0 on success or -1 on an error.
 """
 function vsirmdir(pszDirname)
-    ccall((:VSIRmdir, libgdal), Cint, (Cstring,), pszDirname)
+    aftercare(ccall((:VSIRmdir, libgdal), Cint, (Cstring,), pszDirname))
 end
 
 """
@@ -922,7 +922,7 @@ Delete a directory recursively.
 0 on success or -1 on an error.
 """
 function vsirmdirrecursive(pszDirname)
-    ccall((:VSIRmdirRecursive, libgdal), Cint, (Cstring,), pszDirname)
+    aftercare(ccall((:VSIRmdirRecursive, libgdal), Cint, (Cstring,), pszDirname))
 end
 
 """
@@ -937,7 +937,7 @@ Delete a file.
 0 on success or -1 on an error.
 """
 function vsiunlink(pszFilename)
-    ccall((:VSIUnlink, libgdal), Cint, (Cstring,), pszFilename)
+    aftercare(ccall((:VSIUnlink, libgdal), Cint, (Cstring,), pszFilename))
 end
 
 """
@@ -954,7 +954,7 @@ Rename a file.
 0 on success or -1 on an error.
 """
 function vsirename(oldpath, newpath)
-    ccall((:VSIRename, libgdal), Cint, (Cstring, Cstring), oldpath, newpath)
+    aftercare(ccall((:VSIRename, libgdal), Cint, (Cstring, Cstring), oldpath, newpath))
 end
 
 """
@@ -986,7 +986,7 @@ The ETAG strategy assumes that the ETag metadata of the remote file is the MD5Su
 TRUE on success or FALSE on an error.
 """
 function vsisync(pszSource, pszTarget, papszOptions, pProgressFunc, pProgressData, ppapszOutputs)
-    ccall((:VSISync, libgdal), Cint, (Cstring, Cstring, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Ptr{Cstring}}), pszSource, pszTarget, papszOptions, pProgressFunc, pProgressData, ppapszOutputs)
+    aftercare(ccall((:VSISync, libgdal), Cint, (Cstring, Cstring, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Ptr{Cstring}}), pszSource, pszTarget, papszOptions, pProgressFunc, pProgressData, ppapszOutputs))
 end
 
 """
@@ -995,7 +995,7 @@ end
 Return the error string corresponding to the error number.
 """
 function vsistrerror(arg1)
-    string_or_nothing(ccall((:VSIStrerror, libgdal), Cstring, (Cint,), arg1))
+    aftercare(ccall((:VSIStrerror, libgdal), Cstring, (Cint,), arg1), false)
 end
 
 """
@@ -1010,7 +1010,7 @@ Return free disk space available on the filesystem.
 The free space in bytes. Or -1 in case of error.
 """
 function vsigetdiskfreespace(pszDirname)
-    ccall((:VSIGetDiskFreeSpace, libgdal), GIntBig, (Cstring,), pszDirname)
+    aftercare(ccall((:VSIGetDiskFreeSpace, libgdal), GIntBig, (Cstring,), pszDirname))
 end
 
 """
@@ -1019,11 +1019,11 @@ end
 Install "memory" file system handler.
 """
 function vsiinstallmemfilehandler()
-    ccall((:VSIInstallMemFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallMemFileHandler, libgdal), Cvoid, ()))
 end
 
 function vsiinstalllargefilehandler()
-    ccall((:VSIInstallLargeFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallLargeFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1032,7 +1032,7 @@ end
 Install /vsisubfile/ virtual file handler.
 """
 function vsiinstallsubfilehandler()
-    ccall((:VSIInstallSubFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallSubFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1041,7 +1041,7 @@ end
 Install /vsicurl/ HTTP/FTP file system handler (requires libcurl)
 """
 function vsiinstallcurlfilehandler()
-    ccall((:VSIInstallCurlFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallCurlFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1050,7 +1050,7 @@ end
 Clean local cache associated with /vsicurl/ (and related file systems)
 """
 function vsicurlclearcache()
-    ccall((:VSICurlClearCache, libgdal), Cvoid, ())
+    aftercare(ccall((:VSICurlClearCache, libgdal), Cvoid, ()))
 end
 
 """
@@ -1062,14 +1062,14 @@ Clean local cache associated with /vsicurl/ (and related file systems) for a giv
 * **pszFilenamePrefix**: Filename prefix
 """
 function vsicurlpartialclearcache(pszFilenamePrefix)
-    ccall((:VSICurlPartialClearCache, libgdal), Cvoid, (Cstring,), pszFilenamePrefix)
+    aftercare(ccall((:VSICurlPartialClearCache, libgdal), Cvoid, (Cstring,), pszFilenamePrefix))
 end
 
 """
     VSIInstallCurlStreamingFileHandler(void) -> void
 """
 function vsiinstallcurlstreamingfilehandler()
-    ccall((:VSIInstallCurlStreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallCurlStreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1078,14 +1078,14 @@ end
 Install /vsis3/ Amazon S3 file system handler (requires libcurl)
 """
 function vsiinstalls3filehandler()
-    ccall((:VSIInstallS3FileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallS3FileHandler, libgdal), Cvoid, ()))
 end
 
 """
     VSIInstallS3StreamingFileHandler(void) -> void
 """
 function vsiinstalls3streamingfilehandler()
-    ccall((:VSIInstallS3StreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallS3StreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1094,14 +1094,14 @@ end
 Install /vsigs/ Google Cloud Storage file system handler (requires libcurl)
 """
 function vsiinstallgsfilehandler()
-    ccall((:VSIInstallGSFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallGSFileHandler, libgdal), Cvoid, ()))
 end
 
 """
     VSIInstallGSStreamingFileHandler(void) -> void
 """
 function vsiinstallgsstreamingfilehandler()
-    ccall((:VSIInstallGSStreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallGSStreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1110,14 +1110,14 @@ end
 Install /vsiaz/ Microsoft Azure Blob file system handler (requires libcurl)
 """
 function vsiinstallazurefilehandler()
-    ccall((:VSIInstallAzureFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallAzureFileHandler, libgdal), Cvoid, ()))
 end
 
 """
     VSIInstallAzureStreamingFileHandler(void) -> void
 """
 function vsiinstallazurestreamingfilehandler()
-    ccall((:VSIInstallAzureStreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallAzureStreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1126,14 +1126,14 @@ end
 Install /vsioss/ Alibaba Cloud Object Storage Service (OSS) file system handler (requires libcurl)
 """
 function vsiinstallossfilehandler()
-    ccall((:VSIInstallOSSFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallOSSFileHandler, libgdal), Cvoid, ()))
 end
 
 """
     VSIInstallOSSStreamingFileHandler(void) -> void
 """
 function vsiinstallossstreamingfilehandler()
-    ccall((:VSIInstallOSSStreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallOSSStreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1142,14 +1142,14 @@ end
 Install /vsiswift/ OpenStack Swif Object Storage (Swift) file system handler (requires libcurl)
 """
 function vsiinstallswiftfilehandler()
-    ccall((:VSIInstallSwiftFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallSwiftFileHandler, libgdal), Cvoid, ()))
 end
 
 """
     VSIInstallSwiftStreamingFileHandler(void) -> void
 """
 function vsiinstallswiftstreamingfilehandler()
-    ccall((:VSIInstallSwiftStreamingFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallSwiftStreamingFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1158,7 +1158,7 @@ end
 Install GZip file system handler.
 """
 function vsiinstallgzipfilehandler()
-    ccall((:VSIInstallGZipFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallGZipFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1167,7 +1167,7 @@ end
 Install ZIP file system handler.
 """
 function vsiinstallzipfilehandler()
-    ccall((:VSIInstallZipFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallZipFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1176,7 +1176,7 @@ end
 Install /vsistdin/ file system handler.
 """
 function vsiinstallstdinhandler()
-    ccall((:VSIInstallStdinHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallStdinHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1185,7 +1185,7 @@ end
 Install /vsihdfs/ file system handler (requires JVM and HDFS support)
 """
 function vsiinstallhdfshandler()
-    ccall((:VSIInstallHdfsHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallHdfsHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1194,7 +1194,7 @@ end
 Install /vsiwebhdfs/ WebHDFS (Hadoop File System) REST API file system handler (requires libcurl)
 """
 function vsiinstallwebhdfshandler()
-    ccall((:VSIInstallWebHdfsHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallWebHdfsHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1203,7 +1203,7 @@ end
 Install /vsistdout/ file system handler.
 """
 function vsiinstallstdouthandler()
-    ccall((:VSIInstallStdoutHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallStdoutHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1212,7 +1212,7 @@ end
 Install /vsisparse/ virtual file handler.
 """
 function vsiinstallsparsefilehandler()
-    ccall((:VSIInstallSparseFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallSparseFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1221,7 +1221,7 @@ end
 Install /vsitar/ file system handler.
 """
 function vsiinstalltarfilehandler()
-    ccall((:VSIInstallTarFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallTarFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1230,7 +1230,7 @@ end
 Install /vsicrypt/ encrypted file system handler (requires libcrypto++)
 """
 function vsiinstallcryptfilehandler()
-    ccall((:VSIInstallCryptFileHandler, libgdal), Cvoid, ())
+    aftercare(ccall((:VSIInstallCryptFileHandler, libgdal), Cvoid, ()))
 end
 
 """
@@ -1244,11 +1244,11 @@ Installs the encryption/decryption key.
 * **nKeySize**: length of the key in bytes. Might be 0 to clear previously set key.
 """
 function vsisetcryptkey(pabyKey, nKeySize)
-    ccall((:VSISetCryptKey, libgdal), Cvoid, (Ptr{GByte}, Cint), pabyKey, nKeySize)
+    aftercare(ccall((:VSISetCryptKey, libgdal), Cvoid, (Ptr{GByte}, Cint), pabyKey, nKeySize))
 end
 
 function vsicleanupfilemanager()
-    ccall((:VSICleanupFileManager, libgdal), Cvoid, ())
+    aftercare(ccall((:VSICleanupFileManager, libgdal), Cvoid, ()))
 end
 
 """
@@ -1269,7 +1269,7 @@ Create memory "file" from a buffer.
 open file handle on created file (see VSIFOpenL()).
 """
 function vsifilefrommembuffer(pszFilename, pabyData, nDataLength, bTakeOwnership)
-    ccall((:VSIFileFromMemBuffer, libgdal), Ptr{VSILFILE}, (Cstring, Ptr{GByte}, vsi_l_offset, Cint), pszFilename, pabyData, nDataLength, bTakeOwnership)
+    aftercare(ccall((:VSIFileFromMemBuffer, libgdal), Ptr{VSILFILE}, (Cstring, Ptr{GByte}, vsi_l_offset, Cint), pszFilename, pabyData, nDataLength, bTakeOwnership))
 end
 
 """
@@ -1288,7 +1288,7 @@ Fetch buffer underlying memory file.
 pointer to memory buffer or NULL on failure.
 """
 function vsigetmemfilebuffer(pszFilename, pnDataLength, bUnlinkAndSeize)
-    ccall((:VSIGetMemFileBuffer, libgdal), Ptr{GByte}, (Cstring, Ptr{vsi_l_offset}, Cint), pszFilename, pnDataLength, bUnlinkAndSeize)
+    aftercare(ccall((:VSIGetMemFileBuffer, libgdal), Ptr{GByte}, (Cstring, Ptr{vsi_l_offset}, Cint), pszFilename, pnDataLength, bUnlinkAndSeize))
 end
 
 """
@@ -1302,7 +1302,7 @@ Set an alternative write function and output file handle instead of fwrite() / s
 * **stream**: File handle on which to output. Passed to pFct.
 """
 function vsistdoutsetredirection(pFct, stream)
-    ccall((:VSIStdoutSetRedirection, libgdal), Cvoid, (Cint, Ptr{Cint}), pFct, stream)
+    aftercare(ccall((:VSIStdoutSetRedirection, libgdal), Cvoid, (Cint, Ptr{Cint}), pFct, stream))
 end
 
 """
@@ -1311,7 +1311,7 @@ end
 return a VSIFilesystemPluginCallbacksStruct to be populated at runtime with handler callbacks
 """
 function vsiallocfilesystemplugincallbacksstruct()
-    ccall((:VSIAllocFilesystemPluginCallbacksStruct, libgdal), Ptr{VSIFilesystemPluginCallbacksStruct}, ())
+    aftercare(ccall((:VSIAllocFilesystemPluginCallbacksStruct, libgdal), Ptr{VSIFilesystemPluginCallbacksStruct}, ()))
 end
 
 """
@@ -1320,7 +1320,7 @@ end
 free resources allocated by VSIAllocFilesystemPluginCallbacksStruct
 """
 function vsifreefilesystemplugincallbacksstruct(poCb)
-    ccall((:VSIFreeFilesystemPluginCallbacksStruct, libgdal), Cvoid, (Ptr{VSIFilesystemPluginCallbacksStruct},), poCb)
+    aftercare(ccall((:VSIFreeFilesystemPluginCallbacksStruct, libgdal), Cvoid, (Ptr{VSIFilesystemPluginCallbacksStruct},), poCb))
 end
 
 """
@@ -1330,21 +1330,21 @@ end
 register a handler on the given prefix.
 """
 function vsiinstallpluginhandler(pszPrefix, poCb)
-    ccall((:VSIInstallPluginHandler, libgdal), Cint, (Cstring, Ptr{VSIFilesystemPluginCallbacksStruct}), pszPrefix, poCb)
+    aftercare(ccall((:VSIInstallPluginHandler, libgdal), Cint, (Cstring, Ptr{VSIFilesystemPluginCallbacksStruct}), pszPrefix, poCb))
 end
 
 """
     VSITime(unsigned long * pnTimeToSet) -> unsigned long
 """
 function vsitime(arg1)
-    ccall((:VSITime, libgdal), Culong, (Ptr{Culong},), arg1)
+    aftercare(ccall((:VSITime, libgdal), Culong, (Ptr{Culong},), arg1))
 end
 
 """
     VSICTime(unsigned long nTime) -> const char *
 """
 function vsictime(arg1)
-    string_or_nothing(ccall((:VSICTime, libgdal), Cstring, (Culong,), arg1))
+    aftercare(ccall((:VSICTime, libgdal), Cstring, (Culong,), arg1), false)
 end
 
 """
@@ -1352,7 +1352,7 @@ end
               struct tm * poBrokenTime) -> struct tm *
 """
 function vsigmtime(pnTime, poBrokenTime)
-    ccall((:VSIGMTime, libgdal), Ptr{Ctm}, (Ptr{Cint}, Ptr{Ctm}), pnTime, poBrokenTime)
+    aftercare(ccall((:VSIGMTime, libgdal), Ptr{Ctm}, (Ptr{Cint}, Ptr{Ctm}), pnTime, poBrokenTime))
 end
 
 """
@@ -1360,5 +1360,5 @@ end
                  struct tm * poBrokenTime) -> struct tm *
 """
 function vsilocaltime(pnTime, poBrokenTime)
-    ccall((:VSILocalTime, libgdal), Ptr{Ctm}, (Ptr{Cint}, Ptr{Ctm}), pnTime, poBrokenTime)
+    aftercare(ccall((:VSILocalTime, libgdal), Ptr{Ctm}, (Ptr{Cint}, Ptr{Ctm}), pnTime, poBrokenTime))
 end

--- a/src/cpl_vsi.jl
+++ b/src/cpl_vsi.jl
@@ -73,7 +73,7 @@ end
              FILE * fp) -> char *
 """
 function vsifgets(arg1, arg2, arg3)
-    unsafe_string(ccall((:VSIFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
+    string_or_nothing(ccall((:VSIFGets, libgdal), Cstring, (Cstring, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -483,7 +483,7 @@ Returns the actual URL of a supplied filename.
 the actual URL corresponding to the supplied filename, or NULL. Should not be freed.
 """
 function vsigetactualurl(pszFilename)
-    unsafe_string(ccall((:VSIGetActualURL, libgdal), Cstring, (Cstring,), pszFilename))
+    string_or_nothing(ccall((:VSIGetActualURL, libgdal), Cstring, (Cstring,), pszFilename))
 end
 
 """
@@ -508,7 +508,7 @@ VERB=GET/HEAD/DELETE/PUT/POST: HTTP VERB for which the request will be used. Def
 a signed URL, or NULL. Should be freed with CPLFree().
 """
 function vsigetsignedurl(pszFilename, papszOptions)
-    unsafe_string(ccall((:VSIGetSignedURL, libgdal), Cstring, (Cstring, CSLConstList), pszFilename, papszOptions))
+    string_or_nothing(ccall((:VSIGetSignedURL, libgdal), Cstring, (Cstring, CSLConstList), pszFilename, papszOptions))
 end
 
 """
@@ -523,7 +523,7 @@ Return the list of options associated with a virtual file system handler as a se
 a string, which must not be freed, or NULL if no options is declared.
 """
 function vsigetfilesystemoptions(pszFilename)
-    unsafe_string(ccall((:VSIGetFileSystemOptions, libgdal), Cstring, (Cstring,), pszFilename))
+    string_or_nothing(ccall((:VSIGetFileSystemOptions, libgdal), Cstring, (Cstring,), pszFilename))
 end
 
 """
@@ -597,7 +597,7 @@ end
 Analog of strdup().
 """
 function vsistrdup(arg1)
-    unsafe_string(ccall((:VSIStrdup, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:VSIStrdup, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -744,7 +744,7 @@ end
 VSIStrdupVerbose.
 """
 function vsistrdupverbose(pszStr, pszFile, nLine)
-    unsafe_string(ccall((:VSIStrdupVerbose, libgdal), Cstring, (Cstring, Cstring, Cint), pszStr, pszFile, nLine))
+    string_or_nothing(ccall((:VSIStrdupVerbose, libgdal), Cstring, (Cstring, Cstring, Cint), pszStr, pszFile, nLine))
 end
 
 """
@@ -995,7 +995,7 @@ end
 Return the error string corresponding to the error number.
 """
 function vsistrerror(arg1)
-    unsafe_string(ccall((:VSIStrerror, libgdal), Cstring, (Cint,), arg1))
+    string_or_nothing(ccall((:VSIStrerror, libgdal), Cstring, (Cint,), arg1))
 end
 
 """
@@ -1344,7 +1344,7 @@ end
     VSICTime(unsigned long nTime) -> const char *
 """
 function vsictime(arg1)
-    unsafe_string(ccall((:VSICTime, libgdal), Cstring, (Culong,), arg1))
+    string_or_nothing(ccall((:VSICTime, libgdal), Cstring, (Culong,), arg1))
 end
 
 """

--- a/src/error.jl
+++ b/src/error.jl
@@ -82,5 +82,8 @@ function aftercare(ptr::Ptr{Cstring})
         i += 1
         cstring = unsafe_load(ptr, i)
     end
+    # TODO it seems that, like aftercare(::Cstring), we need to
+    # free the memory ourselves with CSLDestroy (not currently wrapped)
+    # not sure if that is true for some or all functions
     strings
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -22,6 +22,13 @@ function Base.showerror(io::IO, err::GDALError)
     println(io, err)
 end
 
+"""The custom GDAL error handling function that we set in __init__
+
+This function will get called by GDAL itself when it decides it wants to throw
+an error. We turn the error into a GDALError and throw it from Julia. This allows
+us to get GDALErrors that look similar to the ones that we throw when our own error
+checking code decides it should throw.
+"""
 function gdaljl_errorhandler(class::CPLErr, errno::Cint, errmsg::Cstring)
     # function signature needs to match the one in __init__, and the signature
     # of the callback for a custom error handler in the GDAL docs
@@ -43,6 +50,10 @@ end
 Handle anything returned from GDAL
 
 When values are returned from GDAL, always check if there was a failure using `maybe_throw`.
+If the failure was thrown by GDAL itself, it will not even get to `aftercare` and end up in
+`gdaljl_errorhandler`. However in many cases even though GDAL sets the error state to `CE_Failure`
+it will not throw the error. However we always do, to make sure not failure goes unnoticed.
+If an error might be expected, one can use `try .. catch` to handle this.
 
 Depending on the return type, we do extra work.
 """

--- a/src/error.jl
+++ b/src/error.jl
@@ -17,8 +17,6 @@ function GDALError()
     GDALError(class, code, msg)
 end
 
-const throw_class = (CE_Failure, CE_Fatal)
-
 function Base.showerror(io::IO, err::GDALError)
     err = string("GDALError (", err.class, ", code ", err.code, "):\n\t", err.msg)
     println(io, err)
@@ -27,16 +25,62 @@ end
 function gdaljl_errorhandler(class::CPLErr, errno::Cint, errmsg::Cstring)
     # function signature needs to match the one in __init__, and the signature
     # of the callback for a custom error handler in the GDAL docs
-    if class in throw_class
+    if class === CE_Failure
         throw(GDALError(class, errno, unsafe_string(errmsg)))
     end
     return C_NULL
 end
 
-"Throw an error if a pointer is null and GDAL reports an error"
-function failsafe(ptr)
-    if ptr == C_NULL && cplgetlasterrortype() in throw_class
+"Check the last error type and throw a GDALError if it is a failure"
+function maybe_throw()
+    if cplgetlasterrortype() === CE_Failure
         throw(GDALError())
     end
-    ptr
+    nothing
+end
+
+"""
+Handle anything returned from GDAL
+
+When values are returned from GDAL, always check if there was a failure using `maybe_throw`.
+
+Depending on the return type, we do extra work.
+"""
+function aftercare(x)
+    maybe_throw()
+    x
+end
+
+"For string pointers, load them to String, and free them if we should."
+function aftercare(ptr::Cstring, free::Bool)
+    maybe_throw()
+    if ptr == C_NULL
+        return nothing
+    else
+        s = unsafe_string(ptr)
+        free && vsifree(convert(Ptr{Cvoid}, ptr))
+        return s
+    end
+end
+
+"""
+For string list pointers, load them to Vector{String}
+
+That is it expects a `StringList`, in the sense of the CPL functions,
+as a null-terminated array of strings.
+"""
+function aftercare(ptr::Ptr{Cstring})
+    maybe_throw()
+    strings = Vector{String}()
+    if ptr == C_NULL
+        return strings
+    end
+    i = 1
+    cstring = unsafe_load(ptr, i)
+    while cstring != C_NULL
+        push!(strings, unsafe_string(cstring))
+        i += 1
+        cstring = unsafe_load(ptr, i)
+    end
+    strings
 end

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -28,7 +28,7 @@ Compute optimal PCT for RGB image.
 returns CE_None on success or CE_Failure if an error occurs.
 """
 function gdalcomputemediancutpct(hRed, hGreen, hBlue, pfnIncludePixel, nColors, hColorTable, pfnProgress, pProgressArg)
-    ccall((:GDALComputeMedianCutPCT, libgdal), Cint, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, Ptr{Cvoid}, Cint, GDALColorTableH, GDALProgressFunc, Ptr{Cvoid}), hRed, hGreen, hBlue, pfnIncludePixel, nColors, hColorTable, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALComputeMedianCutPCT, libgdal), Cint, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, Ptr{Cvoid}, Cint, GDALColorTableH, GDALProgressFunc, Ptr{Cvoid}), hRed, hGreen, hBlue, pfnIncludePixel, nColors, hColorTable, pfnProgress, pProgressArg))
 end
 
 """
@@ -55,7 +55,7 @@ end
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdalditherrgb2pct(hRed, hGreen, hBlue, hTarget, hColorTable, pfnProgress, pProgressArg)
-    ccall((:GDALDitherRGB2PCT, libgdal), Cint, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALColorTableH, GDALProgressFunc, Ptr{Cvoid}), hRed, hGreen, hBlue, hTarget, hColorTable, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALDitherRGB2PCT, libgdal), Cint, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALColorTableH, GDALProgressFunc, Ptr{Cvoid}), hRed, hGreen, hBlue, hTarget, hColorTable, pfnProgress, pProgressArg))
 end
 
 """
@@ -78,7 +78,7 @@ Compute checksum for image region.
 Checksum value.
 """
 function gdalchecksumimage(hBand, nXOff, nYOff, nXSize, nYSize)
-    ccall((:GDALChecksumImage, libgdal), Cint, (GDALRasterBandH, Cint, Cint, Cint, Cint), hBand, nXOff, nYOff, nXSize, nYSize)
+    aftercare(ccall((:GDALChecksumImage, libgdal), Cint, (GDALRasterBandH, Cint, Cint, Cint, Cint), hBand, nXOff, nYOff, nXSize, nYSize))
 end
 
 """
@@ -91,7 +91,7 @@ end
 Compute the proximity of all pixels in the image to a set of pixels in the source image.
 """
 function gdalcomputeproximity(hSrcBand, hProximityBand, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALComputeProximity, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hProximityBand, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALComputeProximity, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hProximityBand, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -125,7 +125,7 @@ NODATA=value (starting with GDAL 2.4). Source pixels at that value will be ignor
 CE_None on success or CE_Failure if something goes wrong.
 """
 function gdalfillnodata(hTargetBand, hMaskBand, dfMaxSearchDist, bDeprecatedOption, nSmoothingIterations, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALFillNodata, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Cdouble, Cint, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hTargetBand, hMaskBand, dfMaxSearchDist, bDeprecatedOption, nSmoothingIterations, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALFillNodata, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Cdouble, Cint, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hTargetBand, hMaskBand, dfMaxSearchDist, bDeprecatedOption, nSmoothingIterations, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -153,7 +153,7 @@ Create polygon coverage from raster data.
 CE_None on success or CE_Failure on a failure.
 """
 function gdalpolygonize(hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALPolygonize, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, OGRLayerH, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALPolygonize, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, OGRLayerH, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -181,7 +181,7 @@ Create polygon coverage from raster data.
 CE_None on success or CE_Failure on a failure.
 """
 function gdalfpolygonize(hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALFPolygonize, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, OGRLayerH, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALFPolygonize, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, OGRLayerH, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hOutLayer, iPixValField, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -210,14 +210,14 @@ Removes small raster polygons.
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdalsievefilter(hSrcBand, hMaskBand, hDstBand, nSizeThreshold, nConnectedness, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALSieveFilter, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, Cint, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hDstBand, nSizeThreshold, nConnectedness, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALSieveFilter, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, Cint, Cint, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hMaskBand, hDstBand, nSizeThreshold, nConnectedness, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
     GDALDestroyTransformer(void * pTransformArg) -> void
 """
 function gdaldestroytransformer(pTransformerArg)
-    ccall((:GDALDestroyTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformerArg)
+    aftercare(ccall((:GDALDestroyTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformerArg))
 end
 
 """
@@ -230,7 +230,7 @@ end
                        int * panSuccess) -> int
 """
 function gdalusetransformer(pTransformerArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALUseTransformer, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformerArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALUseTransformer, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformerArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -239,7 +239,7 @@ end
                                  double dfRatioY) -> void *
 """
 function gdalcreatesimilartransformer(psTransformerArg, dfSrcRatioX, dfSrcRatioY)
-    failsafe(ccall((:GDALCreateSimilarTransformer, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cdouble, Cdouble), psTransformerArg, dfSrcRatioX, dfSrcRatioY))
+    aftercare(ccall((:GDALCreateSimilarTransformer, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cdouble, Cdouble), psTransformerArg, dfSrcRatioX, dfSrcRatioY))
 end
 
 """
@@ -266,7 +266,7 @@ Create image to image transformer.
 handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer().
 """
 function gdalcreategenimgprojtransformer(hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, bGCPUseOK, dfGCPErrorThreshold, nOrder)
-    failsafe(ccall((:GDALCreateGenImgProjTransformer, libgdal), Ptr{Cvoid}, (GDALDatasetH, Cstring, GDALDatasetH, Cstring, Cint, Cdouble, Cint), hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, bGCPUseOK, dfGCPErrorThreshold, nOrder))
+    aftercare(ccall((:GDALCreateGenImgProjTransformer, libgdal), Ptr{Cvoid}, (GDALDatasetH, Cstring, GDALDatasetH, Cstring, Cint, Cdouble, Cint), hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, bGCPUseOK, dfGCPErrorThreshold, nOrder))
 end
 
 """
@@ -285,7 +285,7 @@ Create image to image transformer.
 handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
 """
 function gdalcreategenimgprojtransformer2(hSrcDS, hDstDS, papszOptions)
-    failsafe(ccall((:GDALCreateGenImgProjTransformer2, libgdal), Ptr{Cvoid}, (GDALDatasetH, GDALDatasetH, Ptr{Cstring}), hSrcDS, hDstDS, papszOptions))
+    aftercare(ccall((:GDALCreateGenImgProjTransformer2, libgdal), Ptr{Cvoid}, (GDALDatasetH, GDALDatasetH, Ptr{Cstring}), hSrcDS, hDstDS, papszOptions))
 end
 
 """
@@ -306,7 +306,7 @@ Create image to image transformer.
 handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
 """
 function gdalcreategenimgprojtransformer3(pszSrcWKT, padfSrcGeoTransform, pszDstWKT, padfDstGeoTransform)
-    failsafe(ccall((:GDALCreateGenImgProjTransformer3, libgdal), Ptr{Cvoid}, (Cstring, Ptr{Cdouble}, Cstring, Ptr{Cdouble}), pszSrcWKT, padfSrcGeoTransform, pszDstWKT, padfDstGeoTransform))
+    aftercare(ccall((:GDALCreateGenImgProjTransformer3, libgdal), Ptr{Cvoid}, (Cstring, Ptr{Cdouble}, Cstring, Ptr{Cdouble}), pszSrcWKT, padfSrcGeoTransform, pszDstWKT, padfDstGeoTransform))
 end
 
 """
@@ -319,7 +319,7 @@ end
 Create image to image transformer.
 """
 function gdalcreategenimgprojtransformer4(hSrcSRS, padfSrcGeoTransform, hDstSRS, padfDstGeoTransform, papszOptions)
-    failsafe(ccall((:GDALCreateGenImgProjTransformer4, libgdal), Ptr{Cvoid}, (OGRSpatialReferenceH, Ptr{Cdouble}, OGRSpatialReferenceH, Ptr{Cdouble}, Ptr{Cstring}), hSrcSRS, padfSrcGeoTransform, hDstSRS, padfDstGeoTransform, papszOptions))
+    aftercare(ccall((:GDALCreateGenImgProjTransformer4, libgdal), Ptr{Cvoid}, (OGRSpatialReferenceH, Ptr{Cdouble}, OGRSpatialReferenceH, Ptr{Cdouble}, Ptr{Cstring}), hSrcSRS, padfSrcGeoTransform, hDstSRS, padfDstGeoTransform, papszOptions))
 end
 
 """
@@ -333,7 +333,7 @@ Set GenImgProj output geotransform.
 * **padfGeoTransform**: the destination geotransform to apply (six doubles).
 """
 function gdalsetgenimgprojtransformerdstgeotransform(arg1, arg2)
-    ccall((:GDALSetGenImgProjTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALSetGenImgProjTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -345,7 +345,7 @@ GenImgProjTransformer deallocator.
 * **hTransformArg**: the handle to deallocate.
 """
 function gdaldestroygenimgprojtransformer(arg1)
-    ccall((:GDALDestroyGenImgProjTransformer, libgdal), Cvoid, (Ptr{Cvoid},), arg1)
+    aftercare(ccall((:GDALDestroyGenImgProjTransformer, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
 end
 
 """
@@ -360,7 +360,7 @@ end
 Perform general image reprojection transformation.
 """
 function gdalgenimgprojtransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALGenImgProjTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALGenImgProjTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -374,7 +374,7 @@ Set ApproxTransformer or GenImgProj output geotransform.
 * **padfGeoTransform**: the destination geotransform to apply (six doubles).
 """
 function gdalsettransformerdstgeotransform(arg1, arg2)
-    ccall((:GDALSetTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALSetTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -388,7 +388,7 @@ Get ApproxTransformer or GenImgProj output geotransform.
 * **padfGeoTransform**: (output) the destination geotransform to return (six doubles).
 """
 function gdalgettransformerdstgeotransform(arg1, arg2)
-    ccall((:GDALGetTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALGetTransformerDstGeoTransform, libgdal), Cvoid, (Ptr{Cvoid}, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -405,7 +405,7 @@ Create reprojection transformer.
 Handle for use with GDALReprojectionTransform(), or NULL if the system fails to initialize the reprojection.
 """
 function gdalcreatereprojectiontransformer(pszSrcWKT, pszDstWKT)
-    failsafe(ccall((:GDALCreateReprojectionTransformer, libgdal), Ptr{Cvoid}, (Cstring, Cstring), pszSrcWKT, pszDstWKT))
+    aftercare(ccall((:GDALCreateReprojectionTransformer, libgdal), Ptr{Cvoid}, (Cstring, Cstring), pszSrcWKT, pszDstWKT))
 end
 
 """
@@ -432,7 +432,7 @@ COORDINATE_EPOCH=decimal_year: Coordinate epoch, expressed as a decimal year. Us
 Handle for use with GDALReprojectionTransform(), or NULL if the system fails to initialize the reprojection.
 """
 function gdalcreatereprojectiontransformerex(hSrcSRS, hDstSRS, papszOptions)
-    failsafe(ccall((:GDALCreateReprojectionTransformerEx, libgdal), Ptr{Cvoid}, (OGRSpatialReferenceH, OGRSpatialReferenceH, Ptr{Cstring}), hSrcSRS, hDstSRS, papszOptions))
+    aftercare(ccall((:GDALCreateReprojectionTransformerEx, libgdal), Ptr{Cvoid}, (OGRSpatialReferenceH, OGRSpatialReferenceH, Ptr{Cstring}), hSrcSRS, hDstSRS, papszOptions))
 end
 
 """
@@ -444,7 +444,7 @@ Destroy reprojection transformation.
 * **pTransformArg**: the transformation handle returned by GDALCreateReprojectionTransformer().
 """
 function gdaldestroyreprojectiontransformer(arg1)
-    ccall((:GDALDestroyReprojectionTransformer, libgdal), Cvoid, (Ptr{Cvoid},), arg1)
+    aftercare(ccall((:GDALDestroyReprojectionTransformer, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
 end
 
 """
@@ -459,7 +459,7 @@ end
 Perform reprojection transformation.
 """
 function gdalreprojectiontransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALReprojectionTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALReprojectionTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -480,7 +480,7 @@ Create GCP based polynomial transformer.
 the transform argument or nullptr if creation fails.
 """
 function gdalcreategcptransformer(nGCPCount, pasGCPList, nReqOrder, bReversed)
-    failsafe(ccall((:GDALCreateGCPTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint, Cint), nGCPCount, pasGCPList, nReqOrder, bReversed))
+    aftercare(ccall((:GDALCreateGCPTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint, Cint), nGCPCount, pasGCPList, nReqOrder, bReversed))
 end
 
 """
@@ -494,7 +494,7 @@ end
 Create GCP based polynomial transformer, with a tolerance threshold to discard GCPs that transform badly.
 """
 function gdalcreategcprefinetransformer(nGCPCount, pasGCPList, nReqOrder, bReversed, tolerance, minimumGcps)
-    failsafe(ccall((:GDALCreateGCPRefineTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint, Cint, Cdouble, Cint), nGCPCount, pasGCPList, nReqOrder, bReversed, tolerance, minimumGcps))
+    aftercare(ccall((:GDALCreateGCPRefineTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint, Cint, Cdouble, Cint), nGCPCount, pasGCPList, nReqOrder, bReversed, tolerance, minimumGcps))
 end
 
 """
@@ -506,7 +506,7 @@ Destroy GCP transformer.
 * **pTransformArg**: the transform arg previously returned by GDALCreateGCPTransformer().
 """
 function gdaldestroygcptransformer(pTransformArg)
-    ccall((:GDALDestroyGCPTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg)
+    aftercare(ccall((:GDALDestroyGCPTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg))
 end
 
 """
@@ -533,7 +533,7 @@ Transforms point based on GCP derived polynomial model.
 TRUE.
 """
 function gdalgcptransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALGCPTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALGCPTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -552,7 +552,7 @@ Create Thin Plate Spline transformer from GCPs.
 the transform argument or NULL if creation fails.
 """
 function gdalcreatetpstransformer(nGCPCount, pasGCPList, bReversed)
-    failsafe(ccall((:GDALCreateTPSTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint), nGCPCount, pasGCPList, bReversed))
+    aftercare(ccall((:GDALCreateTPSTransformer, libgdal), Ptr{Cvoid}, (Cint, Ptr{GDAL_GCP}, Cint), nGCPCount, pasGCPList, bReversed))
 end
 
 """
@@ -564,7 +564,7 @@ Destroy TPS transformer.
 * **pTransformArg**: the transform arg previously returned by GDALCreateTPSTransformer().
 """
 function gdaldestroytpstransformer(pTransformArg)
-    ccall((:GDALDestroyTPSTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg)
+    aftercare(ccall((:GDALDestroyTPSTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg))
 end
 
 """
@@ -591,14 +591,14 @@ Transforms point based on GCP derived polynomial model.
 TRUE.
 """
 function gdaltpstransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALTPSTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALTPSTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
     RPCInfoToMD(GDALRPCInfo * psRPCInfo) -> char **
 """
 function rpcinfotomd(psRPCInfo)
-    unsafe_loadstringlist(ccall((:RPCInfoToMD, libgdal), Ptr{Cstring}, (Ptr{GDALRPCInfo},), psRPCInfo))
+    aftercare(ccall((:RPCInfoToMD, libgdal), Ptr{Cstring}, (Ptr{GDALRPCInfo},), psRPCInfo))
 end
 
 """
@@ -619,7 +619,7 @@ Create an RPC based transformer.
 transformer callback data (deallocate with GDALDestroyTransformer()).
 """
 function gdalcreaterpctransformer(psRPC, bReversed, dfPixErrThreshold, papszOptions)
-    failsafe(ccall((:GDALCreateRPCTransformer, libgdal), Ptr{Cvoid}, (Ptr{GDALRPCInfo}, Cint, Cdouble, Ptr{Cstring}), psRPC, bReversed, dfPixErrThreshold, papszOptions))
+    aftercare(ccall((:GDALCreateRPCTransformer, libgdal), Ptr{Cvoid}, (Ptr{GDALRPCInfo}, Cint, Cdouble, Ptr{Cstring}), psRPC, bReversed, dfPixErrThreshold, papszOptions))
 end
 
 """
@@ -628,7 +628,7 @@ end
 Destroy RPC tranformer.
 """
 function gdaldestroyrpctransformer(pTransformArg)
-    ccall((:GDALDestroyRPCTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg)
+    aftercare(ccall((:GDALDestroyRPCTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg))
 end
 
 """
@@ -643,7 +643,7 @@ end
 RPC transform.
 """
 function gdalrpctransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALRPCTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALRPCTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -654,7 +654,7 @@ end
 Create GeoLocation transformer.
 """
 function gdalcreategeoloctransformer(hBaseDS, papszGeolocationInfo, bReversed)
-    failsafe(ccall((:GDALCreateGeoLocTransformer, libgdal), Ptr{Cvoid}, (GDALDatasetH, Ptr{Cstring}, Cint), hBaseDS, papszGeolocationInfo, bReversed))
+    aftercare(ccall((:GDALCreateGeoLocTransformer, libgdal), Ptr{Cvoid}, (GDALDatasetH, Ptr{Cstring}, Cint), hBaseDS, papszGeolocationInfo, bReversed))
 end
 
 """
@@ -663,7 +663,7 @@ end
 Destroy GeoLocation transformer.
 """
 function gdaldestroygeoloctransformer(pTransformArg)
-    ccall((:GDALDestroyGeoLocTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg)
+    aftercare(ccall((:GDALDestroyGeoLocTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pTransformArg))
 end
 
 """
@@ -678,7 +678,7 @@ end
 Use GeoLocation transformer.
 """
 function gdalgeoloctransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALGeoLocTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALGeoLocTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -697,7 +697,7 @@ Create an approximating transformer.
 callback pointer suitable for use with GDALApproxTransform(). It should be deallocated with GDALDestroyApproxTransformer().
 """
 function gdalcreateapproxtransformer(pfnRawTransformer, pRawTransformerArg, dfMaxError)
-    failsafe(ccall((:GDALCreateApproxTransformer, libgdal), Ptr{Cvoid}, (GDALTransformerFunc, Ptr{Cvoid}, Cdouble), pfnRawTransformer, pRawTransformerArg, dfMaxError))
+    aftercare(ccall((:GDALCreateApproxTransformer, libgdal), Ptr{Cvoid}, (GDALTransformerFunc, Ptr{Cvoid}, Cdouble), pfnRawTransformer, pRawTransformerArg, dfMaxError))
 end
 
 """
@@ -707,7 +707,7 @@ end
 Set bOwnSubtransformer flag.
 """
 function gdalapproxtransformerownssubtransformer(pCBData, bOwnFlag)
-    ccall((:GDALApproxTransformerOwnsSubtransformer, libgdal), Cvoid, (Ptr{Cvoid}, Cint), pCBData, bOwnFlag)
+    aftercare(ccall((:GDALApproxTransformerOwnsSubtransformer, libgdal), Cvoid, (Ptr{Cvoid}, Cint), pCBData, bOwnFlag))
 end
 
 """
@@ -719,7 +719,7 @@ Cleanup approximate transformer.
 * **pCBData**: callback data originally returned by GDALCreateApproxTransformer().
 """
 function gdaldestroyapproxtransformer(pApproxArg)
-    ccall((:GDALDestroyApproxTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pApproxArg)
+    aftercare(ccall((:GDALDestroyApproxTransformer, libgdal), Cvoid, (Ptr{Cvoid},), pApproxArg))
 end
 
 """
@@ -734,7 +734,7 @@ end
 Perform approximate transformation.
 """
 function gdalapproxtransform(pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
-    ccall((:GDALApproxTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess)
+    aftercare(ccall((:GDALApproxTransform, libgdal), Cint, (Ptr{Cvoid}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), pTransformArg, bDstToSrc, nPointCount, x, y, z, panSuccess))
 end
 
 """
@@ -765,7 +765,7 @@ Perform simple image warp.
 TRUE if the operation completes, or FALSE if an error occurs.
 """
 function gdalsimpleimagewarp(hSrcDS, hDstDS, nBandCount, panBandList, pfnTransform, pTransformArg, pfnProgress, pProgressArg, papszWarpOptions)
-    ccall((:GDALSimpleImageWarp, libgdal), Cint, (GDALDatasetH, GDALDatasetH, Cint, Ptr{Cint}, GDALTransformerFunc, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Cstring}), hSrcDS, hDstDS, nBandCount, panBandList, pfnTransform, pTransformArg, pfnProgress, pProgressArg, papszWarpOptions)
+    aftercare(ccall((:GDALSimpleImageWarp, libgdal), Cint, (GDALDatasetH, GDALDatasetH, Cint, Ptr{Cint}, GDALTransformerFunc, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Cstring}), hSrcDS, hDstDS, nBandCount, panBandList, pfnTransform, pTransformArg, pfnProgress, pProgressArg, papszWarpOptions))
 end
 
 """
@@ -790,7 +790,7 @@ Suggest output file size.
 CE_None if successful or CE_Failure otherwise.
 """
 function gdalsuggestedwarpoutput(hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines)
-    ccall((:GDALSuggestedWarpOutput, libgdal), CPLErr, (GDALDatasetH, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}), hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines)
+    aftercare(ccall((:GDALSuggestedWarpOutput, libgdal), CPLErr, (GDALDatasetH, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}), hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines))
 end
 
 """
@@ -819,7 +819,7 @@ Suggest output file size.
 CE_None if successful or CE_Failure otherwise.
 """
 function gdalsuggestedwarpoutput2(hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines, padfExtents, nOptions)
-    ccall((:GDALSuggestedWarpOutput2, libgdal), CPLErr, (GDALDatasetH, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint), hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines, padfExtents, nOptions)
+    aftercare(ccall((:GDALSuggestedWarpOutput2, libgdal), CPLErr, (GDALDatasetH, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint), hSrcDS, pfnTransformer, pTransformArg, padfGeoTransformOut, pnPixels, pnLines, padfExtents, nOptions))
 end
 
 """
@@ -827,7 +827,7 @@ end
                              void * pTransformArg) -> CPLXMLNode *
 """
 function gdalserializetransformer(pfnFunc, pTransformArg)
-    ccall((:GDALSerializeTransformer, libgdal), Ptr{CPLXMLNode}, (GDALTransformerFunc, Ptr{Cvoid}), pfnFunc, pTransformArg)
+    aftercare(ccall((:GDALSerializeTransformer, libgdal), Ptr{CPLXMLNode}, (GDALTransformerFunc, Ptr{Cvoid}), pfnFunc, pTransformArg))
 end
 
 """
@@ -836,7 +836,7 @@ end
                                void ** ppTransformArg) -> CPLErr
 """
 function gdaldeserializetransformer(psTree, ppfnFunc, ppTransformArg)
-    ccall((:GDALDeserializeTransformer, libgdal), CPLErr, (Ptr{CPLXMLNode}, Ptr{GDALTransformerFunc}, Ptr{Ptr{Cvoid}}), psTree, ppfnFunc, ppTransformArg)
+    aftercare(ccall((:GDALDeserializeTransformer, libgdal), CPLErr, (Ptr{CPLXMLNode}, Ptr{GDALTransformerFunc}, Ptr{Ptr{Cvoid}}), psTree, ppfnFunc, ppTransformArg))
 end
 
 """
@@ -865,7 +865,7 @@ Transform locations held in bands.
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdaltransformgeolocations(hXBand, hYBand, hZBand, pfnTransformer, pTransformArg, pfnProgress, pProgressArg, papszOptions)
-    ccall((:GDALTransformGeolocations, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALTransformerFunc, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Cstring}), hXBand, hYBand, hZBand, pfnTransformer, pTransformArg, pfnProgress, pProgressArg, papszOptions)
+    aftercare(ccall((:GDALTransformGeolocations, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, GDALRasterBandH, GDALTransformerFunc, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}, Ptr{Cstring}), hXBand, hYBand, hZBand, pfnTransformer, pTransformArg, pfnProgress, pProgressArg, papszOptions))
 end
 
 """
@@ -881,7 +881,7 @@ end
 Create contour generator.
 """
 function gdal_cg_create(nWidth, nHeight, bNoDataSet, dfNoDataValue, dfContourInterval, dfContourBase, pfnWriter, pCBData)
-    failsafe(ccall((:GDAL_CG_Create, libgdal), GDALContourGeneratorH, (Cint, Cint, Cint, Cdouble, Cdouble, Cdouble, GDALContourWriter, Ptr{Cvoid}), nWidth, nHeight, bNoDataSet, dfNoDataValue, dfContourInterval, dfContourBase, pfnWriter, pCBData))
+    aftercare(ccall((:GDAL_CG_Create, libgdal), GDALContourGeneratorH, (Cint, Cint, Cint, Cdouble, Cdouble, Cdouble, GDALContourWriter, Ptr{Cvoid}), nWidth, nHeight, bNoDataSet, dfNoDataValue, dfContourInterval, dfContourBase, pfnWriter, pCBData))
 end
 
 """
@@ -891,7 +891,7 @@ end
 Feed a line to the contour generator.
 """
 function gdal_cg_feedline(hCG, padfScanline)
-    ccall((:GDAL_CG_FeedLine, libgdal), CPLErr, (GDALContourGeneratorH, Ptr{Cdouble}), hCG, padfScanline)
+    aftercare(ccall((:GDAL_CG_FeedLine, libgdal), CPLErr, (GDALContourGeneratorH, Ptr{Cdouble}), hCG, padfScanline))
 end
 
 """
@@ -900,7 +900,7 @@ end
 Destroy contour generator.
 """
 function gdal_cg_destroy(hCG)
-    ccall((:GDAL_CG_Destroy, libgdal), Cvoid, (GDALContourGeneratorH,), hCG)
+    aftercare(ccall((:GDAL_CG_Destroy, libgdal), Cvoid, (GDALContourGeneratorH,), hCG))
 end
 
 """
@@ -911,7 +911,7 @@ end
                      void * pInfo) -> CPLErr
 """
 function ogrcontourwriter(arg1, arg2, arg3, arg4, pInfo)
-    ccall((:OGRContourWriter, libgdal), CPLErr, (Cdouble, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cvoid}), arg1, arg2, arg3, arg4, pInfo)
+    aftercare(ccall((:OGRContourWriter, libgdal), CPLErr, (Cdouble, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cvoid}), arg1, arg2, arg3, arg4, pInfo))
 end
 
 """
@@ -948,7 +948,7 @@ Create vector contours from raster DEM.
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdalcontourgenerate(hBand, dfContourInterval, dfContourBase, nFixedLevelCount, padfFixedLevels, bUseNoData, dfNoDataValue, hLayer, iIDField, iElevField, pfnProgress, pProgressArg)
-    ccall((:GDALContourGenerate, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cdouble}, Cint, Cdouble, Ptr{Cvoid}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfContourInterval, dfContourBase, nFixedLevelCount, padfFixedLevels, bUseNoData, dfNoDataValue, hLayer, iIDField, iElevField, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALContourGenerate, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cdouble}, Cint, Cdouble, Ptr{Cvoid}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfContourInterval, dfContourBase, nFixedLevelCount, padfFixedLevels, bUseNoData, dfNoDataValue, hLayer, iIDField, iElevField, pfnProgress, pProgressArg))
 end
 
 """
@@ -971,7 +971,7 @@ Create vector contours from raster DEM.
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdalcontourgenerateex(hBand, hLayer, options, pfnProgress, pProgressArg)
-    ccall((:GDALContourGenerateEx, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cvoid}, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), hBand, hLayer, options, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALContourGenerateEx, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cvoid}, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), hBand, hLayer, options, pfnProgress, pProgressArg))
 end
 
 """
@@ -1017,7 +1017,7 @@ Burn geometries into raster.
 CE_None on success or CE_Failure on error.
 """
 function gdalrasterizegeometries(hDS, nBandCount, panBandList, nGeomCount, pahGeometries, pfnTransformer, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALRasterizeGeometries, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{Cint}, Cint, Ptr{OGRGeometryH}, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hDS, nBandCount, panBandList, nGeomCount, pahGeometries, pfnTransformer, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALRasterizeGeometries, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{Cint}, Cint, Ptr{OGRGeometryH}, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hDS, nBandCount, panBandList, nGeomCount, pahGeometries, pfnTransformer, pTransformArg, padfGeomBurnValue, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -1066,7 +1066,7 @@ Burn geometries from the specified list of layers into raster.
 CE_None on success or CE_Failure on error.
 """
 function gdalrasterizelayers(hDS, nBandCount, panBandList, nLayerCount, pahLayers, pfnTransformer, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALRasterizeLayers, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{Cint}, Cint, Ptr{OGRLayerH}, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hDS, nBandCount, panBandList, nLayerCount, pahLayers, pfnTransformer, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALRasterizeLayers, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{Cint}, Cint, Ptr{OGRLayerH}, GDALTransformerFunc, Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hDS, nBandCount, panBandList, nLayerCount, pahLayers, pfnTransformer, pTransformArg, padfLayerBurnValues, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -1122,7 +1122,7 @@ Burn geometries from the specified list of layer into raster.
 CE_None on success or CE_Failure on error.
 """
 function gdalrasterizelayersbuf(pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nLayerCount, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer, pTransformArg, dfBurnValue, papszOptions, pfnProgress, pProgressArg)
-    ccall((:GDALRasterizeLayersBuf, libgdal), CPLErr, (Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Cint, Cint, Ptr{OGRLayerH}, Cstring, Ptr{Cdouble}, GDALTransformerFunc, Ptr{Cvoid}, Cdouble, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nLayerCount, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer, pTransformArg, dfBurnValue, papszOptions, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALRasterizeLayersBuf, libgdal), CPLErr, (Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Cint, Cint, Ptr{OGRLayerH}, Cstring, Ptr{Cdouble}, GDALTransformerFunc, Ptr{Cvoid}, Cdouble, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nLayerCount, pahLayers, pszDstProjection, padfDstGeoTransform, pfnTransformer, pTransformArg, dfBurnValue, papszOptions, pfnProgress, pProgressArg))
 end
 
 """
@@ -1167,7 +1167,7 @@ Create regular grid from the scattered data.
 CE_None on success or CE_Failure if something goes wrong.
 """
 function gdalgridcreate(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16)
-    ccall((:GDALGridCreate, libgdal), CPLErr, (GDALGridAlgorithm, Ptr{Cvoid}, GUInt32, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, Cdouble, Cdouble, GUInt32, GUInt32, GDALDataType, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16)
+    aftercare(ccall((:GDALGridCreate, libgdal), CPLErr, (GDALGridAlgorithm, Ptr{Cvoid}, GUInt32, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, Cdouble, Cdouble, GUInt32, GUInt32, GDALDataType, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16))
 end
 
 """
@@ -1194,7 +1194,7 @@ Creates a context to do regular gridding from the scattered data.
 the context (to be freed with GDALGridContextFree()) or NULL in case or error.
 """
 function gdalgridcontextcreate(eAlgorithm, poOptions, nPoints, padfX, padfY, padfZ, bCallerWillKeepPointArraysAlive)
-    failsafe(ccall((:GDALGridContextCreate, libgdal), Ptr{GDALGridContext}, (GDALGridAlgorithm, Ptr{Cvoid}, GUInt32, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), eAlgorithm, poOptions, nPoints, padfX, padfY, padfZ, bCallerWillKeepPointArraysAlive))
+    aftercare(ccall((:GDALGridContextCreate, libgdal), Ptr{GDALGridContext}, (GDALGridAlgorithm, Ptr{Cvoid}, GUInt32, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint), eAlgorithm, poOptions, nPoints, padfX, padfY, padfZ, bCallerWillKeepPointArraysAlive))
 end
 
 """
@@ -1206,7 +1206,7 @@ Free a context used created by GDALGridContextCreate()
 * **psContext**: the context.
 """
 function gdalgridcontextfree(psContext)
-    ccall((:GDALGridContextFree, libgdal), Cvoid, (Ptr{GDALGridContext},), psContext)
+    aftercare(ccall((:GDALGridContextFree, libgdal), Cvoid, (Ptr{GDALGridContext},), psContext))
 end
 
 """
@@ -1241,7 +1241,7 @@ Do the gridding of a window of a raster.
 CE_None on success or CE_Failure if something goes wrong.
 """
 function gdalgridcontextprocess(psContext, dfXMin, dfXMax, dfYMin, dfYMax, nXSize, nYSize, eType, pData, pfnProgress, pProgressArg)
-    ccall((:GDALGridContextProcess, libgdal), CPLErr, (Ptr{GDALGridContext}, Cdouble, Cdouble, Cdouble, Cdouble, GUInt32, GUInt32, GDALDataType, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}), psContext, dfXMin, dfXMax, dfYMin, dfYMax, nXSize, nYSize, eType, pData, pfnProgress, pProgressArg)
+    aftercare(ccall((:GDALGridContextProcess, libgdal), CPLErr, (Ptr{GDALGridContext}, Cdouble, Cdouble, Cdouble, Cdouble, GUInt32, GUInt32, GDALDataType, Ptr{Cvoid}, GDALProgressFunc, Ptr{Cvoid}), psContext, dfXMin, dfXMax, dfYMin, dfYMax, nXSize, nYSize, eType, pData, pfnProgress, pProgressArg))
 end
 
 """
@@ -1253,7 +1253,7 @@ end
 GDALComputeMatchingPoints.
 """
 function gdalcomputematchingpoints(hFirstImage, hSecondImage, papszOptions, pnGCPCount)
-    ccall((:GDALComputeMatchingPoints, libgdal), Ptr{GDAL_GCP}, (GDALDatasetH, GDALDatasetH, Ptr{Cstring}, Ptr{Cint}), hFirstImage, hSecondImage, papszOptions, pnGCPCount)
+    aftercare(ccall((:GDALComputeMatchingPoints, libgdal), Ptr{GDAL_GCP}, (GDALDatasetH, GDALDatasetH, Ptr{Cstring}, Ptr{Cint}), hFirstImage, hSecondImage, papszOptions, pnGCPCount))
 end
 
 """
@@ -1265,7 +1265,7 @@ Returns if GDAL is built with Delaunay triangulation support.
 TRUE if GDAL is built with Delaunay triangulation support.
 """
 function gdalhastriangulation()
-    ccall((:GDALHasTriangulation, libgdal), Cint, ())
+    aftercare(ccall((:GDALHasTriangulation, libgdal), Cint, ()))
 end
 
 """
@@ -1284,7 +1284,7 @@ Computes a Delaunay triangulation of the passed points.
 triangulation that must be freed with GDALTriangulationFree(), or NULL in case of error.
 """
 function gdaltriangulationcreatedelaunay(nPoints, padfX, padfY)
-    ccall((:GDALTriangulationCreateDelaunay, libgdal), Ptr{GDALTriangulation}, (Cint, Ptr{Cdouble}, Ptr{Cdouble}), nPoints, padfX, padfY)
+    aftercare(ccall((:GDALTriangulationCreateDelaunay, libgdal), Ptr{GDALTriangulation}, (Cint, Ptr{Cdouble}, Ptr{Cdouble}), nPoints, padfX, padfY))
 end
 
 """
@@ -1303,7 +1303,7 @@ Computes barycentric coefficients for each triangles of the triangulation.
 TRUE in case of success.
 """
 function gdaltriangulationcomputebarycentriccoefficients(psDT, padfX, padfY)
-    ccall((:GDALTriangulationComputeBarycentricCoefficients, libgdal), Cint, (Ptr{GDALTriangulation}, Ptr{Cdouble}, Ptr{Cdouble}), psDT, padfX, padfY)
+    aftercare(ccall((:GDALTriangulationComputeBarycentricCoefficients, libgdal), Cint, (Ptr{GDALTriangulation}, Ptr{Cdouble}, Ptr{Cdouble}), psDT, padfX, padfY))
 end
 
 """
@@ -1330,7 +1330,7 @@ Computes the barycentric coordinates of a point.
 TRUE in case of success.
 """
 function gdaltriangulationcomputebarycentriccoordinates(psDT, nFacetIdx, dfX, dfY, pdfL1, pdfL2, pdfL3)
-    ccall((:GDALTriangulationComputeBarycentricCoordinates, libgdal), Cint, (Ptr{GDALTriangulation}, Cint, Cdouble, Cdouble, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), psDT, nFacetIdx, dfX, dfY, pdfL1, pdfL2, pdfL3)
+    aftercare(ccall((:GDALTriangulationComputeBarycentricCoordinates, libgdal), Cint, (Ptr{GDALTriangulation}, Cint, Cdouble, Cdouble, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), psDT, nFacetIdx, dfX, dfY, pdfL1, pdfL2, pdfL3))
 end
 
 """
@@ -1351,7 +1351,7 @@ Returns the index of the triangle that contains the point by iterating over all 
 index >= 0 of the triangle in case of success, -1 otherwise.
 """
 function gdaltriangulationfindfacetbruteforce(psDT, dfX, dfY, panOutputFacetIdx)
-    ccall((:GDALTriangulationFindFacetBruteForce, libgdal), Cint, (Ptr{GDALTriangulation}, Cdouble, Cdouble, Ptr{Cint}), psDT, dfX, dfY, panOutputFacetIdx)
+    aftercare(ccall((:GDALTriangulationFindFacetBruteForce, libgdal), Cint, (Ptr{GDALTriangulation}, Cdouble, Cdouble, Ptr{Cint}), psDT, dfX, dfY, panOutputFacetIdx))
 end
 
 """
@@ -1374,7 +1374,7 @@ Returns the index of the triangle that contains the point by walking in the tria
 TRUE in case of success, FALSE otherwise.
 """
 function gdaltriangulationfindfacetdirected(psDT, nFacetIdx, dfX, dfY, panOutputFacetIdx)
-    ccall((:GDALTriangulationFindFacetDirected, libgdal), Cint, (Ptr{GDALTriangulation}, Cint, Cdouble, Cdouble, Ptr{Cint}), psDT, nFacetIdx, dfX, dfY, panOutputFacetIdx)
+    aftercare(ccall((:GDALTriangulationFindFacetDirected, libgdal), Cint, (Ptr{GDALTriangulation}, Cint, Cdouble, Cdouble, Ptr{Cint}), psDT, nFacetIdx, dfX, dfY, panOutputFacetIdx))
 end
 
 """
@@ -1386,14 +1386,14 @@ Free a triangulation.
 * **psDT**: triangulation.
 """
 function gdaltriangulationfree(psDT)
-    ccall((:GDALTriangulationFree, libgdal), Cvoid, (Ptr{GDALTriangulation},), psDT)
+    aftercare(ccall((:GDALTriangulationFree, libgdal), Cvoid, (Ptr{GDALTriangulation},), psDT))
 end
 
 """
     GDALTriangulationTerminate() -> void
 """
 function gdaltriangulationterminate()
-    ccall((:GDALTriangulationTerminate, libgdal), Cvoid, ())
+    aftercare(ccall((:GDALTriangulationTerminate, libgdal), Cvoid, ()))
 end
 
 """
@@ -1410,7 +1410,7 @@ Load proj.4 geoidgrids as GDAL dataset.
 a dataset. If not NULL, it must be closed with GDALClose().
 """
 function gdalopenverticalshiftgrid(pszProj4Geoidgrids, pbError)
-    failsafe(ccall((:GDALOpenVerticalShiftGrid, libgdal), GDALDatasetH, (Cstring, Ptr{Cint}), pszProj4Geoidgrids, pbError))
+    aftercare(ccall((:GDALOpenVerticalShiftGrid, libgdal), GDALDatasetH, (Cstring, Ptr{Cint}), pszProj4Geoidgrids, pbError))
 end
 
 """
@@ -1449,5 +1449,5 @@ SRC_SRS=srs_def. Override projection on hSrcDataset;
 a new dataset corresponding to hSrcDataset adjusted with hGridDataset, or NULL. If not NULL, it must be closed with GDALClose().
 """
 function gdalapplyverticalshiftgrid(hSrcDataset, hGridDataset, bInverse, dfSrcUnitToMeter, dfDstUnitToMeter, papszOptions)
-    failsafe(ccall((:GDALApplyVerticalShiftGrid, libgdal), GDALDatasetH, (GDALDatasetH, GDALDatasetH, Cint, Cdouble, Cdouble, Ptr{Cstring}), hSrcDataset, hGridDataset, bInverse, dfSrcUnitToMeter, dfDstUnitToMeter, papszOptions))
+    aftercare(ccall((:GDALApplyVerticalShiftGrid, libgdal), GDALDatasetH, (GDALDatasetH, GDALDatasetH, Cint, Cdouble, Cdouble, Ptr{Cstring}), hSrcDataset, hGridDataset, bInverse, dfSrcUnitToMeter, dfDstUnitToMeter, papszOptions))
 end

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -14,7 +14,7 @@ Get data type size in bits.
 the number of bits or zero if it is not recognised.
 """
 function gdalgetdatatypesize(arg1)
-    ccall((:GDALGetDataTypeSize, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALGetDataTypeSize, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -29,7 +29,7 @@ Get data type size in bits.
 the number of bits or zero if it is not recognised.
 """
 function gdalgetdatatypesizebits(eDataType)
-    ccall((:GDALGetDataTypeSizeBits, libgdal), Cint, (GDALDataType,), eDataType)
+    aftercare(ccall((:GDALGetDataTypeSizeBits, libgdal), Cint, (GDALDataType,), eDataType))
 end
 
 """
@@ -44,7 +44,7 @@ Get data type size in bytes.
 the number of bytes or zero if it is not recognised.
 """
 function gdalgetdatatypesizebytes(arg1)
-    ccall((:GDALGetDataTypeSizeBytes, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALGetDataTypeSizeBytes, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -56,7 +56,7 @@ Is data type complex?
 TRUE if the passed type is complex (one of GDT_CInt16, GDT_CInt32, GDT_CFloat32 or GDT_CFloat64), that is it consists of a real and imaginary component.
 """
 function gdaldatatypeiscomplex(arg1)
-    ccall((:GDALDataTypeIsComplex, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALDataTypeIsComplex, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -68,7 +68,7 @@ Is data type integer? (might be complex)
 TRUE if the passed type is integer (one of GDT_Byte, GDT_Int16, GDT_UInt16, GDT_Int32, GDT_UInt32, GDT_CInt16, GDT_CInt32).
 """
 function gdaldatatypeisinteger(arg1)
-    ccall((:GDALDataTypeIsInteger, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALDataTypeIsInteger, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -80,7 +80,7 @@ Is data type floating? (might be complex)
 TRUE if the passed type is floating (one of GDT_Float32, GDT_Float64, GDT_CFloat32, GDT_CFloat64)
 """
 function gdaldatatypeisfloating(arg1)
-    ccall((:GDALDataTypeIsFloating, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALDataTypeIsFloating, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -92,7 +92,7 @@ Is data type signed?
 TRUE if the passed type is signed.
 """
 function gdaldatatypeissigned(arg1)
-    ccall((:GDALDataTypeIsSigned, libgdal), Cint, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALDataTypeIsSigned, libgdal), Cint, (GDALDataType,), arg1))
 end
 
 """
@@ -107,7 +107,7 @@ Get name of data type.
 string corresponding to existing data type or NULL pointer if invalid type given.
 """
 function gdalgetdatatypename(arg1)
-    string_or_nothing(ccall((:GDALGetDataTypeName, libgdal), Cstring, (GDALDataType,), arg1))
+    aftercare(ccall((:GDALGetDataTypeName, libgdal), Cstring, (GDALDataType,), arg1), false)
 end
 
 """
@@ -122,7 +122,7 @@ Get data type by symbolic name.
 GDAL data type.
 """
 function gdalgetdatatypebyname(arg1)
-    ccall((:GDALGetDataTypeByName, libgdal), GDALDataType, (Cstring,), arg1)
+    aftercare(ccall((:GDALGetDataTypeByName, libgdal), GDALDataType, (Cstring,), arg1))
 end
 
 """
@@ -139,7 +139,7 @@ Return the smallest data type that can fully express both input data types.
 a data type able to express eType1 and eType2.
 """
 function gdaldatatypeunion(arg1, arg2)
-    ccall((:GDALDataTypeUnion, libgdal), GDALDataType, (GDALDataType, GDALDataType), arg1, arg2)
+    aftercare(ccall((:GDALDataTypeUnion, libgdal), GDALDataType, (GDALDataType, GDALDataType), arg1, arg2))
 end
 
 """
@@ -158,7 +158,7 @@ Union a data type with the one found for a value.
 a data type able to express eDT and dValue.
 """
 function gdaldatatypeunionwithvalue(eDT, dValue, bComplex)
-    ccall((:GDALDataTypeUnionWithValue, libgdal), GDALDataType, (GDALDataType, Cdouble, Cint), eDT, dValue, bComplex)
+    aftercare(ccall((:GDALDataTypeUnionWithValue, libgdal), GDALDataType, (GDALDataType, Cdouble, Cint), eDT, dValue, bComplex))
 end
 
 """
@@ -179,7 +179,7 @@ Finds the smallest data type able to support the given requirements.
 a best fit GDALDataType for supporting the requirements
 """
 function gdalfinddatatype(nBits, bSigned, bFloating, bComplex)
-    ccall((:GDALFindDataType, libgdal), GDALDataType, (Cint, Cint, Cint, Cint), nBits, bSigned, bFloating, bComplex)
+    aftercare(ccall((:GDALFindDataType, libgdal), GDALDataType, (Cint, Cint, Cint, Cint), nBits, bSigned, bFloating, bComplex))
 end
 
 """
@@ -196,7 +196,7 @@ Finds the smallest data type able to support the provided value.
 a best fit GDALDataType for supporting the value
 """
 function gdalfinddatatypeforvalue(dValue, bComplex)
-    ccall((:GDALFindDataTypeForValue, libgdal), GDALDataType, (Cdouble, Cint), dValue, bComplex)
+    aftercare(ccall((:GDALFindDataTypeForValue, libgdal), GDALDataType, (Cdouble, Cint), dValue, bComplex))
 end
 
 """
@@ -217,7 +217,7 @@ Adjust a value to the output data type.
 adjusted value
 """
 function gdaladjustvaluetodatatype(eDT, dfValue, pbClamped, pbRounded)
-    ccall((:GDALAdjustValueToDataType, libgdal), Cdouble, (GDALDataType, Cdouble, Ptr{Cint}, Ptr{Cint}), eDT, dfValue, pbClamped, pbRounded)
+    aftercare(ccall((:GDALAdjustValueToDataType, libgdal), Cdouble, (GDALDataType, Cdouble, Ptr{Cint}, Ptr{Cint}), eDT, dfValue, pbClamped, pbRounded))
 end
 
 """
@@ -232,7 +232,7 @@ Return the base data type for the specified input.
 GDAL data type.
 """
 function gdalgetnoncomplexdatatype(arg1)
-    ccall((:GDALGetNonComplexDataType, libgdal), GDALDataType, (GDALDataType,), arg1)
+    aftercare(ccall((:GDALGetNonComplexDataType, libgdal), GDALDataType, (GDALDataType,), arg1))
 end
 
 """
@@ -249,7 +249,7 @@ Is conversion from eTypeFrom to eTypeTo potentially lossy.
 TRUE if conversion from eTypeFrom to eTypeTo potentially lossy.
 """
 function gdaldatatypeisconversionlossy(eTypeFrom, eTypeTo)
-    ccall((:GDALDataTypeIsConversionLossy, libgdal), Cint, (GDALDataType, GDALDataType), eTypeFrom, eTypeTo)
+    aftercare(ccall((:GDALDataTypeIsConversionLossy, libgdal), Cint, (GDALDataType, GDALDataType), eTypeFrom, eTypeTo))
 end
 
 """
@@ -264,7 +264,7 @@ Get name of AsyncStatus data type.
 string corresponding to type.
 """
 function gdalgetasyncstatustypename(arg1)
-    string_or_nothing(ccall((:GDALGetAsyncStatusTypeName, libgdal), Cstring, (GDALAsyncStatusType,), arg1))
+    aftercare(ccall((:GDALGetAsyncStatusTypeName, libgdal), Cstring, (GDALAsyncStatusType,), arg1), false)
 end
 
 """
@@ -279,7 +279,7 @@ Get AsyncStatusType by symbolic name.
 GDAL AsyncStatus type.
 """
 function gdalgetasyncstatustypebyname(arg1)
-    ccall((:GDALGetAsyncStatusTypeByName, libgdal), GDALAsyncStatusType, (Cstring,), arg1)
+    aftercare(ccall((:GDALGetAsyncStatusTypeByName, libgdal), GDALAsyncStatusType, (Cstring,), arg1))
 end
 
 """
@@ -294,7 +294,7 @@ Get name of color interpretation.
 string corresponding to color interpretation or NULL pointer if invalid enumerator given.
 """
 function gdalgetcolorinterpretationname(arg1)
-    string_or_nothing(ccall((:GDALGetColorInterpretationName, libgdal), Cstring, (GDALColorInterp,), arg1))
+    aftercare(ccall((:GDALGetColorInterpretationName, libgdal), Cstring, (GDALColorInterp,), arg1), false)
 end
 
 """
@@ -309,7 +309,7 @@ Get color interpretation by symbolic name.
 GDAL color interpretation.
 """
 function gdalgetcolorinterpretationbyname(pszName)
-    ccall((:GDALGetColorInterpretationByName, libgdal), GDALColorInterp, (Cstring,), pszName)
+    aftercare(ccall((:GDALGetColorInterpretationByName, libgdal), GDALColorInterp, (Cstring,), pszName))
 end
 
 """
@@ -324,7 +324,7 @@ Get name of palette interpretation.
 string corresponding to palette interpretation.
 """
 function gdalgetpaletteinterpretationname(arg1)
-    string_or_nothing(ccall((:GDALGetPaletteInterpretationName, libgdal), Cstring, (GDALPaletteInterp,), arg1))
+    aftercare(ccall((:GDALGetPaletteInterpretationName, libgdal), Cstring, (GDALPaletteInterp,), arg1), false)
 end
 
 """
@@ -333,7 +333,7 @@ end
 Register all known configured GDAL drivers.
 """
 function gdalallregister()
-    ccall((:GDALAllRegister, libgdal), Cvoid, ())
+    aftercare(ccall((:GDALAllRegister, libgdal), Cvoid, ()))
 end
 
 """
@@ -348,7 +348,7 @@ end
 Create a new dataset with this driver.
 """
 function gdalcreate(hDriver, arg1, arg2, arg3, arg4, arg5, arg6)
-    failsafe(ccall((:GDALCreate, libgdal), GDALDatasetH, (GDALDriverH, Cstring, Cint, Cint, Cint, GDALDataType, CSLConstList), hDriver, arg1, arg2, arg3, arg4, arg5, arg6))
+    aftercare(ccall((:GDALCreate, libgdal), GDALDatasetH, (GDALDriverH, Cstring, Cint, Cint, Cint, GDALDataType, CSLConstList), hDriver, arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -363,7 +363,7 @@ end
 Create a copy of a dataset.
 """
 function gdalcreatecopy(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-    failsafe(ccall((:GDALCreateCopy, libgdal), GDALDatasetH, (GDALDriverH, Cstring, GDALDatasetH, Cint, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7))
+    aftercare(ccall((:GDALCreateCopy, libgdal), GDALDatasetH, (GDALDriverH, Cstring, GDALDatasetH, Cint, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7))
 end
 
 """
@@ -380,7 +380,7 @@ Identify the driver that can open a raster file.
 A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
 """
 function gdalidentifydriver(pszFilename, papszFileList)
-    failsafe(ccall((:GDALIdentifyDriver, libgdal), GDALDriverH, (Cstring, CSLConstList), pszFilename, papszFileList))
+    aftercare(ccall((:GDALIdentifyDriver, libgdal), GDALDriverH, (Cstring, CSLConstList), pszFilename, papszFileList))
 end
 
 """
@@ -401,7 +401,7 @@ Identify the driver that can open a raster file.
 A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
 """
 function gdalidentifydriverex(pszFilename, nIdentifyFlags, papszAllowedDrivers, papszFileList)
-    failsafe(ccall((:GDALIdentifyDriverEx, libgdal), GDALDriverH, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nIdentifyFlags, papszAllowedDrivers, papszFileList))
+    aftercare(ccall((:GDALIdentifyDriverEx, libgdal), GDALDriverH, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nIdentifyFlags, papszAllowedDrivers, papszFileList))
 end
 
 """
@@ -418,7 +418,7 @@ Open a raster file as a GDALDataset.
 A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
 """
 function gdalopen(pszFilename, eAccess)
-    failsafe(ccall((:GDALOpen, libgdal), GDALDatasetH, (Cstring, GDALAccess), pszFilename, eAccess))
+    aftercare(ccall((:GDALOpen, libgdal), GDALDatasetH, (Cstring, GDALAccess), pszFilename, eAccess))
 end
 
 """
@@ -435,7 +435,7 @@ Open a raster file as a GDALDataset.
 A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
 """
 function gdalopenshared(arg1, arg2)
-    failsafe(ccall((:GDALOpenShared, libgdal), GDALDatasetH, (Cstring, GDALAccess), arg1, arg2))
+    aftercare(ccall((:GDALOpenShared, libgdal), GDALDatasetH, (Cstring, GDALAccess), arg1, arg2))
 end
 
 """
@@ -469,7 +469,7 @@ Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file 
 A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
 """
 function gdalopenex(pszFilename, nOpenFlags, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles)
-    failsafe(ccall((:GDALOpenEx, libgdal), GDALDatasetH, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nOpenFlags, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles))
+    aftercare(ccall((:GDALOpenEx, libgdal), GDALDatasetH, (Cstring, UInt32, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cstring}), pszFilename, nOpenFlags, papszAllowedDrivers, papszOpenOptions, papszSiblingFiles))
 end
 
 """
@@ -478,7 +478,7 @@ end
 List open datasets.
 """
 function gdaldumpopendatasets(arg1)
-    ccall((:GDALDumpOpenDatasets, libgdal), Cint, (Ptr{Cint},), arg1)
+    aftercare(ccall((:GDALDumpOpenDatasets, libgdal), Cint, (Ptr{Cint},), arg1))
 end
 
 """
@@ -487,7 +487,7 @@ end
 Fetch a driver based on the short name.
 """
 function gdalgetdriverbyname(arg1)
-    failsafe(ccall((:GDALGetDriverByName, libgdal), GDALDriverH, (Cstring,), arg1))
+    aftercare(ccall((:GDALGetDriverByName, libgdal), GDALDriverH, (Cstring,), arg1))
 end
 
 """
@@ -496,7 +496,7 @@ end
 Fetch the number of registered drivers.
 """
 function gdalgetdrivercount()
-    ccall((:GDALGetDriverCount, libgdal), Cint, ())
+    aftercare(ccall((:GDALGetDriverCount, libgdal), Cint, ()))
 end
 
 """
@@ -505,7 +505,7 @@ end
 Fetch driver by index.
 """
 function gdalgetdriver(arg1)
-    failsafe(ccall((:GDALGetDriver, libgdal), GDALDriverH, (Cint,), arg1))
+    aftercare(ccall((:GDALGetDriver, libgdal), GDALDriverH, (Cint,), arg1))
 end
 
 """
@@ -514,7 +514,7 @@ end
 Create a GDALDriver.
 """
 function gdalcreatedriver()
-    failsafe(ccall((:GDALCreateDriver, libgdal), GDALDriverH, ()))
+    aftercare(ccall((:GDALCreateDriver, libgdal), GDALDriverH, ()))
 end
 
 """
@@ -526,7 +526,7 @@ Destroy a GDALDriver.
 * **hDriver**: the driver to destroy.
 """
 function gdaldestroydriver(arg1)
-    ccall((:GDALDestroyDriver, libgdal), Cvoid, (GDALDriverH,), arg1)
+    aftercare(ccall((:GDALDestroyDriver, libgdal), Cvoid, (GDALDriverH,), arg1))
 end
 
 """
@@ -535,7 +535,7 @@ end
 Register a driver for use.
 """
 function gdalregisterdriver(arg1)
-    ccall((:GDALRegisterDriver, libgdal), Cint, (GDALDriverH,), arg1)
+    aftercare(ccall((:GDALRegisterDriver, libgdal), Cint, (GDALDriverH,), arg1))
 end
 
 """
@@ -544,7 +544,7 @@ end
 Deregister the passed driver.
 """
 function gdalderegisterdriver(arg1)
-    ccall((:GDALDeregisterDriver, libgdal), Cvoid, (GDALDriverH,), arg1)
+    aftercare(ccall((:GDALDeregisterDriver, libgdal), Cvoid, (GDALDriverH,), arg1))
 end
 
 """
@@ -553,14 +553,14 @@ end
 Destroy the driver manager.
 """
 function gdaldestroydrivermanager()
-    ccall((:GDALDestroyDriverManager, libgdal), Cvoid, ())
+    aftercare(ccall((:GDALDestroyDriverManager, libgdal), Cvoid, ()))
 end
 
 """
     GDALDestroy(void) -> void
 """
 function gdaldestroy()
-    ccall((:GDALDestroy, libgdal), Cvoid, ())
+    aftercare(ccall((:GDALDestroy, libgdal), Cvoid, ()))
 end
 
 """
@@ -570,7 +570,7 @@ end
 Delete named dataset.
 """
 function gdaldeletedataset(arg1, arg2)
-    ccall((:GDALDeleteDataset, libgdal), CPLErr, (GDALDriverH, Cstring), arg1, arg2)
+    aftercare(ccall((:GDALDeleteDataset, libgdal), CPLErr, (GDALDriverH, Cstring), arg1, arg2))
 end
 
 """
@@ -581,7 +581,7 @@ end
 Rename a dataset.
 """
 function gdalrenamedataset(arg1, pszNewName, pszOldName)
-    ccall((:GDALRenameDataset, libgdal), CPLErr, (GDALDriverH, Cstring, Cstring), arg1, pszNewName, pszOldName)
+    aftercare(ccall((:GDALRenameDataset, libgdal), CPLErr, (GDALDriverH, Cstring, Cstring), arg1, pszNewName, pszOldName))
 end
 
 """
@@ -592,7 +592,7 @@ end
 Copy the files of a dataset.
 """
 function gdalcopydatasetfiles(arg1, pszNewName, pszOldName)
-    ccall((:GDALCopyDatasetFiles, libgdal), CPLErr, (GDALDriverH, Cstring, Cstring), arg1, pszNewName, pszOldName)
+    aftercare(ccall((:GDALCopyDatasetFiles, libgdal), CPLErr, (GDALDriverH, Cstring, Cstring), arg1, pszNewName, pszOldName))
 end
 
 """
@@ -609,7 +609,7 @@ Validate the list of creation options that are handled by a driver.
 TRUE if the list of creation options is compatible with the Create() and CreateCopy() method of the driver, FALSE otherwise.
 """
 function gdalvalidatecreationoptions(arg1, papszCreationOptions)
-    ccall((:GDALValidateCreationOptions, libgdal), Cint, (GDALDriverH, CSLConstList), arg1, papszCreationOptions)
+    aftercare(ccall((:GDALValidateCreationOptions, libgdal), Cint, (GDALDriverH, CSLConstList), arg1, papszCreationOptions))
 end
 
 """
@@ -624,7 +624,7 @@ Return the short name of a driver.
 the short name of the driver. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdrivershortname(arg1)
-    string_or_nothing(ccall((:GDALGetDriverShortName, libgdal), Cstring, (GDALDriverH,), arg1))
+    aftercare(ccall((:GDALGetDriverShortName, libgdal), Cstring, (GDALDriverH,), arg1), false)
 end
 
 """
@@ -639,7 +639,7 @@ Return the long name of a driver.
 the long name of the driver or empty string. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdriverlongname(arg1)
-    string_or_nothing(ccall((:GDALGetDriverLongName, libgdal), Cstring, (GDALDriverH,), arg1))
+    aftercare(ccall((:GDALGetDriverLongName, libgdal), Cstring, (GDALDriverH,), arg1), false)
 end
 
 """
@@ -654,7 +654,7 @@ Return the URL to the help that describes the driver.
 the URL to the help that describes the driver or NULL. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdriverhelptopic(arg1)
-    string_or_nothing(ccall((:GDALGetDriverHelpTopic, libgdal), Cstring, (GDALDriverH,), arg1))
+    aftercare(ccall((:GDALGetDriverHelpTopic, libgdal), Cstring, (GDALDriverH,), arg1), false)
 end
 
 """
@@ -669,7 +669,7 @@ Return the list of creation options of the driver.
 an XML string that describes the list of creation options or empty string. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdrivercreationoptionlist(arg1)
-    string_or_nothing(ccall((:GDALGetDriverCreationOptionList, libgdal), Cstring, (GDALDriverH,), arg1))
+    aftercare(ccall((:GDALGetDriverCreationOptionList, libgdal), Cstring, (GDALDriverH,), arg1), false)
 end
 
 """
@@ -683,7 +683,7 @@ Initialize an array of GCPs.
 * **psGCP**: array of GCPs of size nCount.
 """
 function gdalinitgcps(arg1, arg2)
-    ccall((:GDALInitGCPs, libgdal), Cvoid, (Cint, Ptr{GDAL_GCP}), arg1, arg2)
+    aftercare(ccall((:GDALInitGCPs, libgdal), Cvoid, (Cint, Ptr{GDAL_GCP}), arg1, arg2))
 end
 
 """
@@ -697,7 +697,7 @@ De-initialize an array of GCPs (initialized with GDALInitGCPs())
 * **psGCP**: array of GCPs of size nCount.
 """
 function gdaldeinitgcps(arg1, arg2)
-    ccall((:GDALDeinitGCPs, libgdal), Cvoid, (Cint, Ptr{GDAL_GCP}), arg1, arg2)
+    aftercare(ccall((:GDALDeinitGCPs, libgdal), Cvoid, (Cint, Ptr{GDAL_GCP}), arg1, arg2))
 end
 
 """
@@ -711,7 +711,7 @@ Duplicate an array of GCPs.
 * **pasGCPList**: array of GCPs of size nCount.
 """
 function gdalduplicategcps(arg1, arg2)
-    ccall((:GDALDuplicateGCPs, libgdal), Ptr{GDAL_GCP}, (Cint, Ptr{GDAL_GCP}), arg1, arg2)
+    aftercare(ccall((:GDALDuplicateGCPs, libgdal), Ptr{GDAL_GCP}, (Cint, Ptr{GDAL_GCP}), arg1, arg2))
 end
 
 """
@@ -732,7 +732,7 @@ Generate Geotransform from GCPs.
 TRUE on success or FALSE if there aren't enough points to prepare a geotransform, the pointers are ill-determined or if bApproxOK is FALSE and the fit is poor.
 """
 function gdalgcpstogeotransform(nGCPCount, pasGCPs, padfGeoTransform, bApproxOK)
-    ccall((:GDALGCPsToGeoTransform, libgdal), Cint, (Cint, Ptr{GDAL_GCP}, Ptr{Cdouble}, Cint), nGCPCount, pasGCPs, padfGeoTransform, bApproxOK)
+    aftercare(ccall((:GDALGCPsToGeoTransform, libgdal), Cint, (Cint, Ptr{GDAL_GCP}, Ptr{Cdouble}, Cint), nGCPCount, pasGCPs, padfGeoTransform, bApproxOK))
 end
 
 """
@@ -749,7 +749,7 @@ Invert Geotransform.
 TRUE on success or FALSE if the equation is uninvertable.
 """
 function gdalinvgeotransform(padfGeoTransformIn, padfInvGeoTransformOut)
-    ccall((:GDALInvGeoTransform, libgdal), Cint, (Ptr{Cdouble}, Ptr{Cdouble}), padfGeoTransformIn, padfInvGeoTransformOut)
+    aftercare(ccall((:GDALInvGeoTransform, libgdal), Cint, (Ptr{Cdouble}, Ptr{Cdouble}), padfGeoTransformIn, padfInvGeoTransformOut))
 end
 
 """
@@ -769,7 +769,7 @@ Apply GeoTransform to x/y coordinate.
 * **pdfGeoY**: output location where geo_y (northing/latitude) location is placed.
 """
 function gdalapplygeotransform(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALApplyGeoTransform, libgdal), Cvoid, (Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALApplyGeoTransform, libgdal), Cvoid, (Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -785,7 +785,7 @@ Compose two geotransforms.
 * **padfGTOut**: the output geotransform, six values, may safely be the same array as padfGT1 or padfGT2.
 """
 function gdalcomposegeotransforms(padfGeoTransform1, padfGeoTransform2, padfGeoTransformOut)
-    ccall((:GDALComposeGeoTransforms, libgdal), Cvoid, (Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), padfGeoTransform1, padfGeoTransform2, padfGeoTransformOut)
+    aftercare(ccall((:GDALComposeGeoTransforms, libgdal), Cvoid, (Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), padfGeoTransform1, padfGeoTransform2, padfGeoTransformOut))
 end
 
 """
@@ -794,7 +794,7 @@ end
 Fetch list of metadata domains.
 """
 function gdalgetmetadatadomainlist(hObject)
-    unsafe_loadstringlist(ccall((:GDALGetMetadataDomainList, libgdal), Ptr{Cstring}, (GDALMajorObjectH,), hObject))
+    aftercare(ccall((:GDALGetMetadataDomainList, libgdal), Ptr{Cstring}, (GDALMajorObjectH,), hObject))
 end
 
 """
@@ -804,7 +804,7 @@ end
 Fetch metadata.
 """
 function gdalgetmetadata(arg1, arg2)
-    unsafe_loadstringlist(ccall((:GDALGetMetadata, libgdal), Ptr{Cstring}, (GDALMajorObjectH, Cstring), arg1, arg2))
+    aftercare(ccall((:GDALGetMetadata, libgdal), Ptr{Cstring}, (GDALMajorObjectH, Cstring), arg1, arg2))
 end
 
 """
@@ -815,7 +815,7 @@ end
 Set metadata.
 """
 function gdalsetmetadata(arg1, arg2, arg3)
-    ccall((:GDALSetMetadata, libgdal), CPLErr, (GDALMajorObjectH, CSLConstList, Cstring), arg1, arg2, arg3)
+    aftercare(ccall((:GDALSetMetadata, libgdal), CPLErr, (GDALMajorObjectH, CSLConstList, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -826,7 +826,7 @@ end
 Fetch single metadata item.
 """
 function gdalgetmetadataitem(arg1, arg2, arg3)
-    string_or_nothing(ccall((:GDALGetMetadataItem, libgdal), Cstring, (GDALMajorObjectH, Cstring, Cstring), arg1, arg2, arg3))
+    aftercare(ccall((:GDALGetMetadataItem, libgdal), Cstring, (GDALMajorObjectH, Cstring, Cstring), arg1, arg2, arg3), false)
 end
 
 """
@@ -838,7 +838,7 @@ end
 Set single metadata item.
 """
 function gdalsetmetadataitem(arg1, arg2, arg3, arg4)
-    ccall((:GDALSetMetadataItem, libgdal), CPLErr, (GDALMajorObjectH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALSetMetadataItem, libgdal), CPLErr, (GDALMajorObjectH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -847,7 +847,7 @@ end
 Fetch object description.
 """
 function gdalgetdescription(arg1)
-    string_or_nothing(ccall((:GDALGetDescription, libgdal), Cstring, (GDALMajorObjectH,), arg1))
+    aftercare(ccall((:GDALGetDescription, libgdal), Cstring, (GDALMajorObjectH,), arg1), false)
 end
 
 """
@@ -857,7 +857,7 @@ end
 Set object description.
 """
 function gdalsetdescription(arg1, arg2)
-    ccall((:GDALSetDescription, libgdal), Cvoid, (GDALMajorObjectH, Cstring), arg1, arg2)
+    aftercare(ccall((:GDALSetDescription, libgdal), Cvoid, (GDALMajorObjectH, Cstring), arg1, arg2))
 end
 
 """
@@ -866,7 +866,7 @@ end
 Fetch the driver to which this dataset relates.
 """
 function gdalgetdatasetdriver(arg1)
-    failsafe(ccall((:GDALGetDatasetDriver, libgdal), GDALDriverH, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetDatasetDriver, libgdal), GDALDriverH, (GDALDatasetH,), arg1))
 end
 
 """
@@ -875,7 +875,7 @@ end
 Fetch files forming dataset.
 """
 function gdalgetfilelist(arg1)
-    unsafe_loadstringlist(ccall((:GDALGetFileList, libgdal), Ptr{Cstring}, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetFileList, libgdal), Ptr{Cstring}, (GDALDatasetH,), arg1))
 end
 
 """
@@ -887,7 +887,7 @@ Close GDAL dataset.
 * **hDS**: The dataset to close. May be cast from a "GDALDataset *".
 """
 function gdalclose(arg1)
-    ccall((:GDALClose, libgdal), Cvoid, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALClose, libgdal), Cvoid, (GDALDatasetH,), arg1))
 end
 
 """
@@ -896,7 +896,7 @@ end
 Fetch raster width in pixels.
 """
 function gdalgetrasterxsize(arg1)
-    ccall((:GDALGetRasterXSize, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALGetRasterXSize, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -905,7 +905,7 @@ end
 Fetch raster height in pixels.
 """
 function gdalgetrasterysize(arg1)
-    ccall((:GDALGetRasterYSize, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALGetRasterYSize, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -914,7 +914,7 @@ end
 Fetch the number of raster bands on this dataset.
 """
 function gdalgetrastercount(arg1)
-    ccall((:GDALGetRasterCount, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALGetRasterCount, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -924,7 +924,7 @@ end
 Fetch a band object for a dataset.
 """
 function gdalgetrasterband(arg1, arg2)
-    failsafe(ccall((:GDALGetRasterBand, libgdal), GDALRasterBandH, (GDALDatasetH, Cint), arg1, arg2))
+    aftercare(ccall((:GDALGetRasterBand, libgdal), GDALRasterBandH, (GDALDatasetH, Cint), arg1, arg2))
 end
 
 """
@@ -935,7 +935,7 @@ end
 Add a band to a dataset.
 """
 function gdaladdband(hDS, eType, papszOptions)
-    ccall((:GDALAddBand, libgdal), CPLErr, (GDALDatasetH, GDALDataType, CSLConstList), hDS, eType, papszOptions)
+    aftercare(ccall((:GDALAddBand, libgdal), CPLErr, (GDALDatasetH, GDALDataType, CSLConstList), hDS, eType, papszOptions))
 end
 
 """
@@ -978,7 +978,7 @@ Sets up an asynchronous data request.
 handle representing the request.
 """
 function gdalbeginasyncreader(hDS, nXOff, nYOff, nXSize, nYSize, pBuf, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, papszOptions)
-    failsafe(ccall((:GDALBeginAsyncReader, libgdal), GDALAsyncReaderH, (GDALDatasetH, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, CSLConstList), hDS, nXOff, nYOff, nXSize, nYSize, pBuf, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, papszOptions))
+    aftercare(ccall((:GDALBeginAsyncReader, libgdal), GDALAsyncReaderH, (GDALDatasetH, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, CSLConstList), hDS, nXOff, nYOff, nXSize, nYSize, pBuf, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, papszOptions))
 end
 
 """
@@ -992,7 +992,7 @@ End asynchronous request.
 * **hAsyncReaderH**: handle returned by GDALBeginAsyncReader()
 """
 function gdalendasyncreader(hDS, hAsynchReaderH)
-    ccall((:GDALEndAsyncReader, libgdal), Cvoid, (GDALDatasetH, GDALAsyncReaderH), hDS, hAsynchReaderH)
+    aftercare(ccall((:GDALEndAsyncReader, libgdal), Cvoid, (GDALDatasetH, GDALAsyncReaderH), hDS, hAsynchReaderH))
 end
 
 """
@@ -1015,7 +1015,7 @@ end
 Read/write a region of image data from multiple bands.
 """
 function gdaldatasetrasterio(hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace)
-    ccall((:GDALDatasetRasterIO, libgdal), CPLErr, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint), hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace)
+    aftercare(ccall((:GDALDatasetRasterIO, libgdal), CPLErr, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint), hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace))
 end
 
 """
@@ -1039,7 +1039,7 @@ end
 Read/write a region of image data from multiple bands.
 """
 function gdaldatasetrasterioex(hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace, psExtraArg)
-    ccall((:GDALDatasetRasterIOEx, libgdal), CPLErr, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GSpacing, GSpacing, GSpacing, Ptr{GDALRasterIOExtraArg}), hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace, psExtraArg)
+    aftercare(ccall((:GDALDatasetRasterIOEx, libgdal), CPLErr, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GSpacing, GSpacing, GSpacing, Ptr{GDALRasterIOExtraArg}), hDS, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, nPixelSpace, nLineSpace, nBandSpace, psExtraArg))
 end
 
 """
@@ -1058,7 +1058,7 @@ end
 Advise driver of upcoming read requests.
 """
 function gdaldatasetadviseread(hDS, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, papszOptions)
-    ccall((:GDALDatasetAdviseRead, libgdal), CPLErr, (GDALDatasetH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, CSLConstList), hDS, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, papszOptions)
+    aftercare(ccall((:GDALDatasetAdviseRead, libgdal), CPLErr, (GDALDatasetH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, CSLConstList), hDS, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, nBandCount, panBandCount, papszOptions))
 end
 
 """
@@ -1067,7 +1067,7 @@ end
 Fetch the projection definition string for this dataset.
 """
 function gdalgetprojectionref(arg1)
-    string_or_nothing(ccall((:GDALGetProjectionRef, libgdal), Cstring, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetProjectionRef, libgdal), Cstring, (GDALDatasetH,), arg1), false)
 end
 
 """
@@ -1076,7 +1076,7 @@ end
 Fetch the projection definition string for this dataset.
 """
 function gdalgetspatialref(arg1)
-    failsafe(ccall((:GDALGetSpatialRef, libgdal), OGRSpatialReferenceH, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetSpatialRef, libgdal), OGRSpatialReferenceH, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1086,7 +1086,7 @@ end
 Set the projection reference string for this dataset.
 """
 function gdalsetprojection(arg1, arg2)
-    ccall((:GDALSetProjection, libgdal), CPLErr, (GDALDatasetH, Cstring), arg1, arg2)
+    aftercare(ccall((:GDALSetProjection, libgdal), CPLErr, (GDALDatasetH, Cstring), arg1, arg2))
 end
 
 """
@@ -1096,7 +1096,7 @@ end
 Set the spatial reference system for this dataset.
 """
 function gdalsetspatialref(arg1, arg2)
-    ccall((:GDALSetSpatialRef, libgdal), CPLErr, (GDALDatasetH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:GDALSetSpatialRef, libgdal), CPLErr, (GDALDatasetH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -1106,7 +1106,7 @@ end
 Fetch the affine transformation coefficients.
 """
 function gdalgetgeotransform(arg1, arg2)
-    ccall((:GDALGetGeoTransform, libgdal), CPLErr, (GDALDatasetH, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALGetGeoTransform, libgdal), CPLErr, (GDALDatasetH, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -1116,7 +1116,7 @@ end
 Set the affine transformation coefficients.
 """
 function gdalsetgeotransform(arg1, arg2)
-    ccall((:GDALSetGeoTransform, libgdal), CPLErr, (GDALDatasetH, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALSetGeoTransform, libgdal), CPLErr, (GDALDatasetH, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -1125,7 +1125,7 @@ end
 Get number of GCPs.
 """
 function gdalgetgcpcount(arg1)
-    ccall((:GDALGetGCPCount, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALGetGCPCount, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1134,7 +1134,7 @@ end
 Get output projection for GCPs.
 """
 function gdalgetgcpprojection(arg1)
-    string_or_nothing(ccall((:GDALGetGCPProjection, libgdal), Cstring, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetGCPProjection, libgdal), Cstring, (GDALDatasetH,), arg1), false)
 end
 
 """
@@ -1143,7 +1143,7 @@ end
 Get output spatial reference system for GCPs.
 """
 function gdalgetgcpspatialref(arg1)
-    failsafe(ccall((:GDALGetGCPSpatialRef, libgdal), OGRSpatialReferenceH, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALGetGCPSpatialRef, libgdal), OGRSpatialReferenceH, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1152,7 +1152,7 @@ end
 Fetch GCPs.
 """
 function gdalgetgcps(arg1)
-    ccall((:GDALGetGCPs, libgdal), Ptr{GDAL_GCP}, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALGetGCPs, libgdal), Ptr{GDAL_GCP}, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1164,7 +1164,7 @@ end
 Assign GCPs.
 """
 function gdalsetgcps(arg1, arg2, arg3, arg4)
-    ccall((:GDALSetGCPs, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{GDAL_GCP}, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALSetGCPs, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{GDAL_GCP}, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1176,7 +1176,7 @@ end
 Assign GCPs.
 """
 function gdalsetgcps2(arg1, arg2, arg3, arg4)
-    ccall((:GDALSetGCPs2, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{GDAL_GCP}, OGRSpatialReferenceH), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALSetGCPs2, libgdal), CPLErr, (GDALDatasetH, Cint, Ptr{GDAL_GCP}, OGRSpatialReferenceH), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1186,7 +1186,7 @@ end
 Fetch a format specific internally meaningful handle.
 """
 function gdalgetinternalhandle(arg1, arg2)
-    failsafe(ccall((:GDALGetInternalHandle, libgdal), Ptr{Cvoid}, (GDALDatasetH, Cstring), arg1, arg2))
+    aftercare(ccall((:GDALGetInternalHandle, libgdal), Ptr{Cvoid}, (GDALDatasetH, Cstring), arg1, arg2))
 end
 
 """
@@ -1195,7 +1195,7 @@ end
 Add one to dataset reference count.
 """
 function gdalreferencedataset(arg1)
-    ccall((:GDALReferenceDataset, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALReferenceDataset, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1204,7 +1204,7 @@ end
 Subtract one from dataset reference count.
 """
 function gdaldereferencedataset(arg1)
-    ccall((:GDALDereferenceDataset, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALDereferenceDataset, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1213,7 +1213,7 @@ end
 Drop a reference to this object, and destroy if no longer referenced.
 """
 function gdalreleasedataset(arg1)
-    ccall((:GDALReleaseDataset, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALReleaseDataset, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1229,7 +1229,7 @@ end
 Build raster overview(s)
 """
 function gdalbuildoverviews(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-    ccall((:GDALBuildOverviews, libgdal), CPLErr, (GDALDatasetH, Cstring, Cint, Ptr{Cint}, Cint, Ptr{Cint}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    aftercare(ccall((:GDALBuildOverviews, libgdal), CPLErr, (GDALDatasetH, Cstring, Cint, Ptr{Cint}, Cint, Ptr{Cint}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8))
 end
 
 """
@@ -1239,7 +1239,7 @@ end
 Fetch all open GDAL dataset handles.
 """
 function gdalgetopendatasets(hDS, pnCount)
-    ccall((:GDALGetOpenDatasets, libgdal), Cvoid, (Ptr{Ptr{GDALDatasetH}}, Ptr{Cint}), hDS, pnCount)
+    aftercare(ccall((:GDALGetOpenDatasets, libgdal), Cvoid, (Ptr{Ptr{GDALDatasetH}}, Ptr{Cint}), hDS, pnCount))
 end
 
 """
@@ -1248,7 +1248,7 @@ end
 Return access flag.
 """
 function gdalgetaccess(hDS)
-    ccall((:GDALGetAccess, libgdal), Cint, (GDALDatasetH,), hDS)
+    aftercare(ccall((:GDALGetAccess, libgdal), Cint, (GDALDatasetH,), hDS))
 end
 
 """
@@ -1257,7 +1257,7 @@ end
 Flush all write cached data to disk.
 """
 function gdalflushcache(hDS)
-    ccall((:GDALFlushCache, libgdal), Cvoid, (GDALDatasetH,), hDS)
+    aftercare(ccall((:GDALFlushCache, libgdal), Cvoid, (GDALDatasetH,), hDS))
 end
 
 """
@@ -1267,7 +1267,7 @@ end
 Adds a mask band to the dataset.
 """
 function gdalcreatedatasetmaskband(hDS, nFlags)
-    ccall((:GDALCreateDatasetMaskBand, libgdal), CPLErr, (GDALDatasetH, Cint), hDS, nFlags)
+    aftercare(ccall((:GDALCreateDatasetMaskBand, libgdal), CPLErr, (GDALDatasetH, Cint), hDS, nFlags))
 end
 
 """
@@ -1290,7 +1290,7 @@ Copy all dataset raster data.
 CE_None on success, or CE_Failure on failure.
 """
 function gdaldatasetcopywholeraster(hSrcDS, hDstDS, papszOptions, pfnProgress, pProgressData)
-    ccall((:GDALDatasetCopyWholeRaster, libgdal), CPLErr, (GDALDatasetH, GDALDatasetH, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), hSrcDS, hDstDS, papszOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALDatasetCopyWholeRaster, libgdal), CPLErr, (GDALDatasetH, GDALDatasetH, CSLConstList, GDALProgressFunc, Ptr{Cvoid}), hSrcDS, hDstDS, papszOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -1313,7 +1313,7 @@ Copy a whole raster band.
 CE_None on success, or CE_Failure on failure.
 """
 function gdalrasterbandcopywholeraster(hSrcBand, hDstBand, constpapszOptions, pfnProgress, pProgressData)
-    ccall((:GDALRasterBandCopyWholeRaster, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hDstBand, constpapszOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALRasterBandCopyWholeRaster, libgdal), CPLErr, (GDALRasterBandH, GDALRasterBandH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, hDstBand, constpapszOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -1338,7 +1338,7 @@ Generate downsampled overviews.
 CE_None on success or CE_Failure on failure.
 """
 function gdalregenerateoverviews(hSrcBand, nOverviewCount, pahOverviewBands, pszResampling, pfnProgress, pProgressData)
-    ccall((:GDALRegenerateOverviews, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, Cstring, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, nOverviewCount, pahOverviewBands, pszResampling, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALRegenerateOverviews, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, Cstring, GDALProgressFunc, Ptr{Cvoid}), hSrcBand, nOverviewCount, pahOverviewBands, pszResampling, pfnProgress, pProgressData))
 end
 
 """
@@ -1353,7 +1353,7 @@ Get the number of layers in this dataset.
 layer count.
 """
 function gdaldatasetgetlayercount(arg1)
-    ccall((:GDALDatasetGetLayerCount, libgdal), Cint, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALDatasetGetLayerCount, libgdal), Cint, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1370,7 +1370,7 @@ Fetch a layer by index.
 the layer, or NULL if iLayer is out of range or an error occurs.
 """
 function gdaldatasetgetlayer(arg1, arg2)
-    failsafe(ccall((:GDALDatasetGetLayer, libgdal), OGRLayerH, (GDALDatasetH, Cint), arg1, arg2))
+    aftercare(ccall((:GDALDatasetGetLayer, libgdal), OGRLayerH, (GDALDatasetH, Cint), arg1, arg2))
 end
 
 """
@@ -1387,7 +1387,7 @@ Fetch a layer by name.
 the layer, or NULL if Layer is not found or an error occurs.
 """
 function gdaldatasetgetlayerbyname(arg1, arg2)
-    failsafe(ccall((:GDALDatasetGetLayerByName, libgdal), OGRLayerH, (GDALDatasetH, Cstring), arg1, arg2))
+    aftercare(ccall((:GDALDatasetGetLayerByName, libgdal), OGRLayerH, (GDALDatasetH, Cstring), arg1, arg2))
 end
 
 """
@@ -1404,7 +1404,7 @@ Delete the indicated layer from the datasource.
 OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
 """
 function gdaldatasetdeletelayer(arg1, arg2)
-    ccall((:GDALDatasetDeleteLayer, libgdal), OGRErr, (GDALDatasetH, Cint), arg1, arg2)
+    aftercare(ccall((:GDALDatasetDeleteLayer, libgdal), OGRErr, (GDALDatasetH, Cint), arg1, arg2))
 end
 
 """
@@ -1427,7 +1427,7 @@ This function attempts to create a new layer on the dataset with the indicated n
 NULL is returned on failure, or a new OGRLayer handle on success.
 """
 function gdaldatasetcreatelayer(arg1, arg2, arg3, arg4, arg5)
-    failsafe(ccall((:GDALDatasetCreateLayer, libgdal), OGRLayerH, (GDALDatasetH, Cstring, OGRSpatialReferenceH, OGRwkbGeometryType, CSLConstList), arg1, arg2, arg3, arg4, arg5))
+    aftercare(ccall((:GDALDatasetCreateLayer, libgdal), OGRLayerH, (GDALDatasetH, Cstring, OGRSpatialReferenceH, OGRwkbGeometryType, CSLConstList), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -1448,7 +1448,7 @@ Duplicate an existing layer.
 an handle to the layer, or NULL if an error occurs.
 """
 function gdaldatasetcopylayer(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:GDALDatasetCopyLayer, libgdal), OGRLayerH, (GDALDatasetH, OGRLayerH, Cstring, CSLConstList), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:GDALDatasetCopyLayer, libgdal), OGRLayerH, (GDALDatasetH, OGRLayerH, Cstring, CSLConstList), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1460,7 +1460,7 @@ Reset feature reading to start on the first feature.
 * **hDS**: dataset handle
 """
 function gdaldatasetresetreading(arg1)
-    ccall((:GDALDatasetResetReading, libgdal), Cvoid, (GDALDatasetH,), arg1)
+    aftercare(ccall((:GDALDatasetResetReading, libgdal), Cvoid, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1483,7 +1483,7 @@ Fetch the next available feature from this dataset.
 a feature, or NULL if no more features are available.
 """
 function gdaldatasetgetnextfeature(hDS, phBelongingLayer, pdfProgressPct, pfnProgress, pProgressData)
-    failsafe(ccall((:GDALDatasetGetNextFeature, libgdal), OGRFeatureH, (GDALDatasetH, Ptr{OGRLayerH}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), hDS, phBelongingLayer, pdfProgressPct, pfnProgress, pProgressData))
+    aftercare(ccall((:GDALDatasetGetNextFeature, libgdal), OGRFeatureH, (GDALDatasetH, Ptr{OGRLayerH}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), hDS, phBelongingLayer, pdfProgressPct, pfnProgress, pProgressData))
 end
 
 """
@@ -1500,7 +1500,7 @@ Test if capability is available.
 TRUE if capability available otherwise FALSE.
 """
 function gdaldatasettestcapability(arg1, arg2)
-    ccall((:GDALDatasetTestCapability, libgdal), Cint, (GDALDatasetH, Cstring), arg1, arg2)
+    aftercare(ccall((:GDALDatasetTestCapability, libgdal), Cint, (GDALDatasetH, Cstring), arg1, arg2))
 end
 
 """
@@ -1521,7 +1521,7 @@ Execute an SQL statement against the data store.
 an OGRLayer containing the results of the query. Deallocate with ReleaseResultSet().
 """
 function gdaldatasetexecutesql(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:GDALDatasetExecuteSQL, libgdal), OGRLayerH, (GDALDatasetH, Cstring, OGRGeometryH, Cstring), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:GDALDatasetExecuteSQL, libgdal), OGRLayerH, (GDALDatasetH, Cstring, OGRGeometryH, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1535,7 +1535,7 @@ Release results of ExecuteSQL().
 * **hLayer**: the result of a previous ExecuteSQL() call.
 """
 function gdaldatasetreleaseresultset(arg1, arg2)
-    ccall((:GDALDatasetReleaseResultSet, libgdal), Cvoid, (GDALDatasetH, OGRLayerH), arg1, arg2)
+    aftercare(ccall((:GDALDatasetReleaseResultSet, libgdal), Cvoid, (GDALDatasetH, OGRLayerH), arg1, arg2))
 end
 
 """
@@ -1550,7 +1550,7 @@ Returns dataset style table.
 handle to a style table which should not be modified or freed by the caller.
 """
 function gdaldatasetgetstyletable(arg1)
-    failsafe(ccall((:GDALDatasetGetStyleTable, libgdal), OGRStyleTableH, (GDALDatasetH,), arg1))
+    aftercare(ccall((:GDALDatasetGetStyleTable, libgdal), OGRStyleTableH, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1564,7 +1564,7 @@ Set dataset style table.
 * **hStyleTable**: style table handle to set
 """
 function gdaldatasetsetstyletabledirectly(arg1, arg2)
-    ccall((:GDALDatasetSetStyleTableDirectly, libgdal), Cvoid, (GDALDatasetH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:GDALDatasetSetStyleTableDirectly, libgdal), Cvoid, (GDALDatasetH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -1578,7 +1578,7 @@ Set dataset style table.
 * **hStyleTable**: style table handle to set
 """
 function gdaldatasetsetstyletable(arg1, arg2)
-    ccall((:GDALDatasetSetStyleTable, libgdal), Cvoid, (GDALDatasetH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:GDALDatasetSetStyleTable, libgdal), Cvoid, (GDALDatasetH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -1595,7 +1595,7 @@ For datasources which support transactions, StartTransaction creates a transacti
 OGRERR_NONE on success.
 """
 function gdaldatasetstarttransaction(hDS, bForce)
-    ccall((:GDALDatasetStartTransaction, libgdal), OGRErr, (GDALDatasetH, Cint), hDS, bForce)
+    aftercare(ccall((:GDALDatasetStartTransaction, libgdal), OGRErr, (GDALDatasetH, Cint), hDS, bForce))
 end
 
 """
@@ -1607,7 +1607,7 @@ For datasources which support transactions, CommitTransaction commits a transact
 OGRERR_NONE on success.
 """
 function gdaldatasetcommittransaction(hDS)
-    ccall((:GDALDatasetCommitTransaction, libgdal), OGRErr, (GDALDatasetH,), hDS)
+    aftercare(ccall((:GDALDatasetCommitTransaction, libgdal), OGRErr, (GDALDatasetH,), hDS))
 end
 
 """
@@ -1619,7 +1619,7 @@ For datasources which support transactions, RollbackTransaction will roll back a
 OGRERR_NONE on success.
 """
 function gdaldatasetrollbacktransaction(hDS)
-    ccall((:GDALDatasetRollbackTransaction, libgdal), OGRErr, (GDALDatasetH,), hDS)
+    aftercare(ccall((:GDALDatasetRollbackTransaction, libgdal), OGRErr, (GDALDatasetH,), hDS))
 end
 
 """
@@ -1628,7 +1628,7 @@ end
 Fetch the pixel data type for this band.
 """
 function gdalgetrasterdatatype(arg1)
-    ccall((:GDALGetRasterDataType, libgdal), GDALDataType, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetRasterDataType, libgdal), GDALDataType, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1639,7 +1639,7 @@ end
 Fetch the "natural" block size of this band.
 """
 function gdalgetblocksize(arg1, pnXSize, pnYSize)
-    ccall((:GDALGetBlockSize, libgdal), Cvoid, (GDALRasterBandH, Ptr{Cint}, Ptr{Cint}), arg1, pnXSize, pnYSize)
+    aftercare(ccall((:GDALGetBlockSize, libgdal), Cvoid, (GDALRasterBandH, Ptr{Cint}, Ptr{Cint}), arg1, pnXSize, pnYSize))
 end
 
 """
@@ -1652,7 +1652,7 @@ end
 Retrieve the actual block size for a given block offset.
 """
 function gdalgetactualblocksize(arg1, nXBlockOff, nYBlockOff, pnXValid, pnYValid)
-    ccall((:GDALGetActualBlockSize, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cint}, Ptr{Cint}), arg1, nXBlockOff, nYBlockOff, pnXValid, pnYValid)
+    aftercare(ccall((:GDALGetActualBlockSize, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cint}, Ptr{Cint}), arg1, nXBlockOff, nYBlockOff, pnXValid, pnYValid))
 end
 
 """
@@ -1669,7 +1669,7 @@ end
 Advise driver of upcoming read requests.
 """
 function gdalrasteradviseread(hRB, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, papszOptions)
-    ccall((:GDALRasterAdviseRead, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, CSLConstList), hRB, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, papszOptions)
+    aftercare(ccall((:GDALRasterAdviseRead, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, CSLConstList), hRB, nDSXOff, nDSYOff, nDSXSize, nDSYSize, nBXSize, nBYSize, eBDataType, papszOptions))
 end
 
 """
@@ -1689,7 +1689,7 @@ end
 Read/write a region of image data for this band.
 """
 function gdalrasterio(hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace)
-    ccall((:GDALRasterIO, libgdal), CPLErr, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Cint), hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace)
+    aftercare(ccall((:GDALRasterIO, libgdal), CPLErr, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, Cint, Cint), hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace))
 end
 
 """
@@ -1710,7 +1710,7 @@ end
 Read/write a region of image data for this band.
 """
 function gdalrasterioex(hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace, psExtraArg)
-    ccall((:GDALRasterIOEx, libgdal), CPLErr, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, GSpacing, GSpacing, Ptr{GDALRasterIOExtraArg}), hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace, psExtraArg)
+    aftercare(ccall((:GDALRasterIOEx, libgdal), CPLErr, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Cvoid}, Cint, Cint, GDALDataType, GSpacing, GSpacing, Ptr{GDALRasterIOExtraArg}), hRBand, eRWFlag, nDSXOff, nDSYOff, nDSXSize, nDSYSize, pBuffer, nBXSize, nBYSize, eBDataType, nPixelSpace, nLineSpace, psExtraArg))
 end
 
 """
@@ -1722,7 +1722,7 @@ end
 Read a block of image data efficiently.
 """
 function gdalreadblock(arg1, arg2, arg3, arg4)
-    ccall((:GDALReadBlock, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALReadBlock, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1734,7 +1734,7 @@ end
 Write a block of image data efficiently.
 """
 function gdalwriteblock(arg1, arg2, arg3, arg4)
-    ccall((:GDALWriteBlock, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALWriteBlock, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1743,7 +1743,7 @@ end
 Fetch XSize of raster.
 """
 function gdalgetrasterbandxsize(arg1)
-    ccall((:GDALGetRasterBandXSize, libgdal), Cint, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetRasterBandXSize, libgdal), Cint, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1752,7 +1752,7 @@ end
 Fetch YSize of raster.
 """
 function gdalgetrasterbandysize(arg1)
-    ccall((:GDALGetRasterBandYSize, libgdal), Cint, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetRasterBandYSize, libgdal), Cint, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1761,7 +1761,7 @@ end
 Find out if we have update permission for this band.
 """
 function gdalgetrasteraccess(arg1)
-    ccall((:GDALGetRasterAccess, libgdal), GDALAccess, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetRasterAccess, libgdal), GDALAccess, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1770,7 +1770,7 @@ end
 Fetch the band number.
 """
 function gdalgetbandnumber(arg1)
-    ccall((:GDALGetBandNumber, libgdal), Cint, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetBandNumber, libgdal), Cint, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1779,7 +1779,7 @@ end
 Fetch the owning dataset handle.
 """
 function gdalgetbanddataset(arg1)
-    failsafe(ccall((:GDALGetBandDataset, libgdal), GDALDatasetH, (GDALRasterBandH,), arg1))
+    aftercare(ccall((:GDALGetBandDataset, libgdal), GDALDatasetH, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1788,7 +1788,7 @@ end
 How should this band be interpreted as color?
 """
 function gdalgetrastercolorinterpretation(arg1)
-    ccall((:GDALGetRasterColorInterpretation, libgdal), GDALColorInterp, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetRasterColorInterpretation, libgdal), GDALColorInterp, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1798,7 +1798,7 @@ end
 Set color interpretation of a band.
 """
 function gdalsetrastercolorinterpretation(arg1, arg2)
-    ccall((:GDALSetRasterColorInterpretation, libgdal), CPLErr, (GDALRasterBandH, GDALColorInterp), arg1, arg2)
+    aftercare(ccall((:GDALSetRasterColorInterpretation, libgdal), CPLErr, (GDALRasterBandH, GDALColorInterp), arg1, arg2))
 end
 
 """
@@ -1807,7 +1807,7 @@ end
 Fetch the color table associated with band.
 """
 function gdalgetrastercolortable(arg1)
-    failsafe(ccall((:GDALGetRasterColorTable, libgdal), GDALColorTableH, (GDALRasterBandH,), arg1))
+    aftercare(ccall((:GDALGetRasterColorTable, libgdal), GDALColorTableH, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1817,7 +1817,7 @@ end
 Set the raster color table.
 """
 function gdalsetrastercolortable(arg1, arg2)
-    ccall((:GDALSetRasterColorTable, libgdal), CPLErr, (GDALRasterBandH, GDALColorTableH), arg1, arg2)
+    aftercare(ccall((:GDALSetRasterColorTable, libgdal), CPLErr, (GDALRasterBandH, GDALColorTableH), arg1, arg2))
 end
 
 """
@@ -1826,7 +1826,7 @@ end
 Check for arbitrary overviews.
 """
 function gdalhasarbitraryoverviews(arg1)
-    ccall((:GDALHasArbitraryOverviews, libgdal), Cint, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALHasArbitraryOverviews, libgdal), Cint, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1835,7 +1835,7 @@ end
 Return the number of overview layers available.
 """
 function gdalgetoverviewcount(arg1)
-    ccall((:GDALGetOverviewCount, libgdal), Cint, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALGetOverviewCount, libgdal), Cint, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1845,7 +1845,7 @@ end
 Fetch overview raster band object.
 """
 function gdalgetoverview(arg1, arg2)
-    failsafe(ccall((:GDALGetOverview, libgdal), GDALRasterBandH, (GDALRasterBandH, Cint), arg1, arg2))
+    aftercare(ccall((:GDALGetOverview, libgdal), GDALRasterBandH, (GDALRasterBandH, Cint), arg1, arg2))
 end
 
 """
@@ -1855,7 +1855,7 @@ end
 Fetch the no data value for this band.
 """
 function gdalgetrasternodatavalue(arg1, arg2)
-    ccall((:GDALGetRasterNoDataValue, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:GDALGetRasterNoDataValue, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, arg2))
 end
 
 """
@@ -1865,7 +1865,7 @@ end
 Set the no data value for this band.
 """
 function gdalsetrasternodatavalue(arg1, arg2)
-    ccall((:GDALSetRasterNoDataValue, libgdal), CPLErr, (GDALRasterBandH, Cdouble), arg1, arg2)
+    aftercare(ccall((:GDALSetRasterNoDataValue, libgdal), CPLErr, (GDALRasterBandH, Cdouble), arg1, arg2))
 end
 
 """
@@ -1874,7 +1874,7 @@ end
 Remove the no data value for this band.
 """
 function gdaldeleterasternodatavalue(arg1)
-    ccall((:GDALDeleteRasterNoDataValue, libgdal), CPLErr, (GDALRasterBandH,), arg1)
+    aftercare(ccall((:GDALDeleteRasterNoDataValue, libgdal), CPLErr, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1883,7 +1883,7 @@ end
 Fetch the list of category names for this raster.
 """
 function gdalgetrastercategorynames(arg1)
-    unsafe_loadstringlist(ccall((:GDALGetRasterCategoryNames, libgdal), Ptr{Cstring}, (GDALRasterBandH,), arg1))
+    aftercare(ccall((:GDALGetRasterCategoryNames, libgdal), Ptr{Cstring}, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -1893,7 +1893,7 @@ end
 Set the category names for this band.
 """
 function gdalsetrastercategorynames(arg1, arg2)
-    ccall((:GDALSetRasterCategoryNames, libgdal), CPLErr, (GDALRasterBandH, CSLConstList), arg1, arg2)
+    aftercare(ccall((:GDALSetRasterCategoryNames, libgdal), CPLErr, (GDALRasterBandH, CSLConstList), arg1, arg2))
 end
 
 """
@@ -1903,7 +1903,7 @@ end
 Fetch the minimum value for this band.
 """
 function gdalgetrasterminimum(arg1, pbSuccess)
-    ccall((:GDALGetRasterMinimum, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess)
+    aftercare(ccall((:GDALGetRasterMinimum, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess))
 end
 
 """
@@ -1913,7 +1913,7 @@ end
 Fetch the maximum value for this band.
 """
 function gdalgetrastermaximum(arg1, pbSuccess)
-    ccall((:GDALGetRasterMaximum, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess)
+    aftercare(ccall((:GDALGetRasterMaximum, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess))
 end
 
 """
@@ -1928,7 +1928,7 @@ end
 Fetch image statistics.
 """
 function gdalgetrasterstatistics(arg1, bApproxOK, bForce, pdfMin, pdfMax, pdfMean, pdfStdDev)
-    ccall((:GDALGetRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, bApproxOK, bForce, pdfMin, pdfMax, pdfMean, pdfStdDev)
+    aftercare(ccall((:GDALGetRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, bApproxOK, bForce, pdfMin, pdfMax, pdfMean, pdfStdDev))
 end
 
 """
@@ -1944,7 +1944,7 @@ end
 Compute image statistics.
 """
 function gdalcomputerasterstatistics(arg1, bApproxOK, pdfMin, pdfMax, pdfMean, pdfStdDev, pfnProgress, pProgressData)
-    ccall((:GDALComputeRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), arg1, bApproxOK, pdfMin, pdfMax, pdfMean, pdfStdDev, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALComputeRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), arg1, bApproxOK, pdfMin, pdfMax, pdfMean, pdfStdDev, pfnProgress, pProgressData))
 end
 
 """
@@ -1957,7 +1957,7 @@ end
 Set statistics on band.
 """
 function gdalsetrasterstatistics(hBand, dfMin, dfMax, dfMean, dfStdDev)
-    ccall((:GDALSetRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cdouble, Cdouble), hBand, dfMin, dfMax, dfMean, dfStdDev)
+    aftercare(ccall((:GDALSetRasterStatistics, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cdouble, Cdouble), hBand, dfMin, dfMax, dfMean, dfStdDev))
 end
 
 """
@@ -1966,7 +1966,7 @@ end
 Return raster unit type.
 """
 function gdalgetrasterunittype(arg1)
-    string_or_nothing(ccall((:GDALGetRasterUnitType, libgdal), Cstring, (GDALRasterBandH,), arg1))
+    aftercare(ccall((:GDALGetRasterUnitType, libgdal), Cstring, (GDALRasterBandH,), arg1), false)
 end
 
 """
@@ -1976,7 +1976,7 @@ end
 Set unit type.
 """
 function gdalsetrasterunittype(hBand, pszNewValue)
-    ccall((:GDALSetRasterUnitType, libgdal), CPLErr, (GDALRasterBandH, Cstring), hBand, pszNewValue)
+    aftercare(ccall((:GDALSetRasterUnitType, libgdal), CPLErr, (GDALRasterBandH, Cstring), hBand, pszNewValue))
 end
 
 """
@@ -1986,7 +1986,7 @@ end
 Fetch the raster value offset.
 """
 function gdalgetrasteroffset(arg1, pbSuccess)
-    ccall((:GDALGetRasterOffset, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess)
+    aftercare(ccall((:GDALGetRasterOffset, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess))
 end
 
 """
@@ -1996,7 +1996,7 @@ end
 Set scaling offset.
 """
 function gdalsetrasteroffset(hBand, dfNewOffset)
-    ccall((:GDALSetRasterOffset, libgdal), CPLErr, (GDALRasterBandH, Cdouble), hBand, dfNewOffset)
+    aftercare(ccall((:GDALSetRasterOffset, libgdal), CPLErr, (GDALRasterBandH, Cdouble), hBand, dfNewOffset))
 end
 
 """
@@ -2006,7 +2006,7 @@ end
 Fetch the raster value scale.
 """
 function gdalgetrasterscale(arg1, pbSuccess)
-    ccall((:GDALGetRasterScale, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess)
+    aftercare(ccall((:GDALGetRasterScale, libgdal), Cdouble, (GDALRasterBandH, Ptr{Cint}), arg1, pbSuccess))
 end
 
 """
@@ -2016,7 +2016,7 @@ end
 Set scaling ratio.
 """
 function gdalsetrasterscale(hBand, dfNewOffset)
-    ccall((:GDALSetRasterScale, libgdal), CPLErr, (GDALRasterBandH, Cdouble), hBand, dfNewOffset)
+    aftercare(ccall((:GDALSetRasterScale, libgdal), CPLErr, (GDALRasterBandH, Cdouble), hBand, dfNewOffset))
 end
 
 """
@@ -2027,7 +2027,7 @@ end
 Compute the min/max values for a band.
 """
 function gdalcomputerasterminmax(hBand, bApproxOK, adfMinMax)
-    ccall((:GDALComputeRasterMinMax, libgdal), Cvoid, (GDALRasterBandH, Cint, Ptr{Cdouble}), hBand, bApproxOK, adfMinMax)
+    aftercare(ccall((:GDALComputeRasterMinMax, libgdal), Cvoid, (GDALRasterBandH, Cint, Ptr{Cdouble}), hBand, bApproxOK, adfMinMax))
 end
 
 """
@@ -2036,7 +2036,7 @@ end
 Flush raster data cache.
 """
 function gdalflushrastercache(hBand)
-    ccall((:GDALFlushRasterCache, libgdal), CPLErr, (GDALRasterBandH,), hBand)
+    aftercare(ccall((:GDALFlushRasterCache, libgdal), CPLErr, (GDALRasterBandH,), hBand))
 end
 
 """
@@ -2053,7 +2053,7 @@ end
 Compute raster histogram.
 """
 function gdalgetrasterhistogram(hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData)
-    ccall((:GDALGetRasterHistogram, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALGetRasterHistogram, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData))
 end
 
 """
@@ -2070,7 +2070,7 @@ end
 Compute raster histogram.
 """
 function gdalgetrasterhistogramex(hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData)
-    ccall((:GDALGetRasterHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{GUIntBig}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALGetRasterHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{GUIntBig}, Cint, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData))
 end
 
 """
@@ -2086,7 +2086,7 @@ end
 Fetch default raster histogram.
 """
 function gdalgetdefaulthistogram(hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData)
-    ccall((:GDALGetDefaultHistogram, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{Cint}}, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALGetDefaultHistogram, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{Cint}}, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData))
 end
 
 """
@@ -2102,7 +2102,7 @@ end
 Fetch default raster histogram.
 """
 function gdalgetdefaulthistogramex(hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData)
-    ccall((:GDALGetDefaultHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{GUIntBig}}, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALGetDefaultHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{GUIntBig}}, Cint, GDALProgressFunc, Ptr{Cvoid}), hBand, pdfMin, pdfMax, pnBuckets, ppanHistogram, bForce, pfnProgress, pProgressData))
 end
 
 """
@@ -2115,7 +2115,7 @@ end
 Set default histogram.
 """
 function gdalsetdefaulthistogram(hBand, dfMin, dfMax, nBuckets, panHistogram)
-    ccall((:GDALSetDefaultHistogram, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}), hBand, dfMin, dfMax, nBuckets, panHistogram)
+    aftercare(ccall((:GDALSetDefaultHistogram, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}), hBand, dfMin, dfMax, nBuckets, panHistogram))
 end
 
 """
@@ -2128,7 +2128,7 @@ end
 Set default histogram.
 """
 function gdalsetdefaulthistogramex(hBand, dfMin, dfMax, nBuckets, panHistogram)
-    ccall((:GDALSetDefaultHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{GUIntBig}), hBand, dfMin, dfMax, nBuckets, panHistogram)
+    aftercare(ccall((:GDALSetDefaultHistogramEx, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{GUIntBig}), hBand, dfMin, dfMax, nBuckets, panHistogram))
 end
 
 """
@@ -2147,7 +2147,7 @@ Undocumented.
 undocumented
 """
 function gdalgetrandomrastersample(arg1, arg2, arg3)
-    ccall((:GDALGetRandomRasterSample, libgdal), Cint, (GDALRasterBandH, Cint, Ptr{Cfloat}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALGetRandomRasterSample, libgdal), Cint, (GDALRasterBandH, Cint, Ptr{Cfloat}), arg1, arg2, arg3))
 end
 
 """
@@ -2157,7 +2157,7 @@ end
 Fetch best sampling overview.
 """
 function gdalgetrastersampleoverview(arg1, arg2)
-    failsafe(ccall((:GDALGetRasterSampleOverview, libgdal), GDALRasterBandH, (GDALRasterBandH, Cint), arg1, arg2))
+    aftercare(ccall((:GDALGetRasterSampleOverview, libgdal), GDALRasterBandH, (GDALRasterBandH, Cint), arg1, arg2))
 end
 
 """
@@ -2167,7 +2167,7 @@ end
 Fetch best sampling overview.
 """
 function gdalgetrastersampleoverviewex(arg1, arg2)
-    failsafe(ccall((:GDALGetRasterSampleOverviewEx, libgdal), GDALRasterBandH, (GDALRasterBandH, GUIntBig), arg1, arg2))
+    aftercare(ccall((:GDALGetRasterSampleOverviewEx, libgdal), GDALRasterBandH, (GDALRasterBandH, GUIntBig), arg1, arg2))
 end
 
 """
@@ -2178,7 +2178,7 @@ end
 Fill this band with a constant value.
 """
 function gdalfillraster(hBand, dfRealValue, dfImaginaryValue)
-    ccall((:GDALFillRaster, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble), hBand, dfRealValue, dfImaginaryValue)
+    aftercare(ccall((:GDALFillRaster, libgdal), CPLErr, (GDALRasterBandH, Cdouble, Cdouble), hBand, dfRealValue, dfImaginaryValue))
 end
 
 """
@@ -2203,7 +2203,7 @@ Undocumented.
 undocumented
 """
 function gdalcomputebandstats(hBand, nSampleStep, pdfMean, pdfStdDev, pfnProgress, pProgressData)
-    ccall((:GDALComputeBandStats, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), hBand, nSampleStep, pdfMean, pdfStdDev, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALComputeBandStats, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Cvoid}), hBand, nSampleStep, pdfMean, pdfStdDev, pfnProgress, pProgressData))
 end
 
 """
@@ -2226,7 +2226,7 @@ Undocumented.
 undocumented
 """
 function gdaloverviewmagnitudecorrection(hBaseBand, nOverviewCount, pahOverviews, pfnProgress, pProgressData)
-    ccall((:GDALOverviewMagnitudeCorrection, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, GDALProgressFunc, Ptr{Cvoid}), hBaseBand, nOverviewCount, pahOverviews, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALOverviewMagnitudeCorrection, libgdal), CPLErr, (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, GDALProgressFunc, Ptr{Cvoid}), hBaseBand, nOverviewCount, pahOverviews, pfnProgress, pProgressData))
 end
 
 """
@@ -2235,7 +2235,7 @@ end
 Fetch default Raster Attribute Table.
 """
 function gdalgetdefaultrat(hBand)
-    failsafe(ccall((:GDALGetDefaultRAT, libgdal), GDALRasterAttributeTableH, (GDALRasterBandH,), hBand))
+    aftercare(ccall((:GDALGetDefaultRAT, libgdal), GDALRasterAttributeTableH, (GDALRasterBandH,), hBand))
 end
 
 """
@@ -2245,7 +2245,7 @@ end
 Set default Raster Attribute Table.
 """
 function gdalsetdefaultrat(arg1, arg2)
-    ccall((:GDALSetDefaultRAT, libgdal), CPLErr, (GDALRasterBandH, GDALRasterAttributeTableH), arg1, arg2)
+    aftercare(ccall((:GDALSetDefaultRAT, libgdal), CPLErr, (GDALRasterBandH, GDALRasterAttributeTableH), arg1, arg2))
 end
 
 """
@@ -2262,7 +2262,7 @@ This adds a pixel function to the global list of available pixel functions for d
 CE_None, invalid (NULL) parameters are currently ignored.
 """
 function gdaladdderivedbandpixelfunc(pszName, pfnPixelFunc)
-    ccall((:GDALAddDerivedBandPixelFunc, libgdal), CPLErr, (Cstring, GDALDerivedPixelFunc), pszName, pfnPixelFunc)
+    aftercare(ccall((:GDALAddDerivedBandPixelFunc, libgdal), CPLErr, (Cstring, GDALDerivedPixelFunc), pszName, pfnPixelFunc))
 end
 
 """
@@ -2271,7 +2271,7 @@ end
 Return the mask band associated with the band.
 """
 function gdalgetmaskband(hBand)
-    failsafe(ccall((:GDALGetMaskBand, libgdal), GDALRasterBandH, (GDALRasterBandH,), hBand))
+    aftercare(ccall((:GDALGetMaskBand, libgdal), GDALRasterBandH, (GDALRasterBandH,), hBand))
 end
 
 """
@@ -2280,7 +2280,7 @@ end
 Return the status flags of the mask band associated with the band.
 """
 function gdalgetmaskflags(hBand)
-    ccall((:GDALGetMaskFlags, libgdal), Cint, (GDALRasterBandH,), hBand)
+    aftercare(ccall((:GDALGetMaskFlags, libgdal), Cint, (GDALRasterBandH,), hBand))
 end
 
 """
@@ -2290,7 +2290,7 @@ end
 Adds a mask band to the current band.
 """
 function gdalcreatemaskband(hBand, nFlags)
-    ccall((:GDALCreateMaskBand, libgdal), CPLErr, (GDALRasterBandH, Cint), hBand, nFlags)
+    aftercare(ccall((:GDALCreateMaskBand, libgdal), CPLErr, (GDALRasterBandH, Cint), hBand, nFlags))
 end
 
 """
@@ -2317,7 +2317,7 @@ Get the coverage status of a sub-window of the raster.
 a binary-or'ed combination of possible values GDAL_DATA_COVERAGE_STATUS_UNIMPLEMENTED, GDAL_DATA_COVERAGE_STATUS_DATA and GDAL_DATA_COVERAGE_STATUS_EMPTY
 """
 function gdalgetdatacoveragestatus(hBand, nXOff, nYOff, nXSize, nYSize, nMaskFlagStop, pdfDataPct)
-    ccall((:GDALGetDataCoverageStatus, libgdal), Cint, (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Ptr{Cdouble}), hBand, nXOff, nYOff, nXSize, nYSize, nMaskFlagStop, pdfDataPct)
+    aftercare(ccall((:GDALGetDataCoverageStatus, libgdal), Cint, (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Ptr{Cdouble}), hBand, nXOff, nYOff, nXSize, nYSize, nMaskFlagStop, pdfDataPct))
 end
 
 """
@@ -2342,7 +2342,7 @@ Get async IO update.
 GARIO_ status, details described above.
 """
 function gdalargetnextupdatedregion(hARIO, dfTimeout, pnXBufOff, pnYBufOff, pnXBufSize, pnYBufSize)
-    ccall((:GDALARGetNextUpdatedRegion, libgdal), GDALAsyncStatusType, (GDALAsyncReaderH, Cdouble, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), hARIO, dfTimeout, pnXBufOff, pnYBufOff, pnXBufSize, pnYBufSize)
+    aftercare(ccall((:GDALARGetNextUpdatedRegion, libgdal), GDALAsyncStatusType, (GDALAsyncReaderH, Cdouble, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), hARIO, dfTimeout, pnXBufOff, pnYBufOff, pnXBufSize, pnYBufSize))
 end
 
 """
@@ -2359,7 +2359,7 @@ Lock image buffer.
 TRUE if successful, or FALSE on an error.
 """
 function gdalarlockbuffer(hARIO, dfTimeout)
-    ccall((:GDALARLockBuffer, libgdal), Cint, (GDALAsyncReaderH, Cdouble), hARIO, dfTimeout)
+    aftercare(ccall((:GDALARLockBuffer, libgdal), Cint, (GDALAsyncReaderH, Cdouble), hARIO, dfTimeout))
 end
 
 """
@@ -2371,7 +2371,7 @@ Unlock image buffer.
 * **hARIO**: handle to async reader.
 """
 function gdalarunlockbuffer(hARIO)
-    ccall((:GDALARUnlockBuffer, libgdal), Cvoid, (GDALAsyncReaderH,), hARIO)
+    aftercare(ccall((:GDALARUnlockBuffer, libgdal), Cvoid, (GDALAsyncReaderH,), hARIO))
 end
 
 """
@@ -2390,7 +2390,7 @@ General utility option processing.
 updated nArgc argument count. Return of 0 requests terminate without error, return of -1 requests exit with error code.
 """
 function gdalgeneralcmdlineprocessor(nArgc, ppapszArgv, nOptions)
-    ccall((:GDALGeneralCmdLineProcessor, libgdal), Cint, (Cint, Ptr{Ptr{Cstring}}, Cint), nArgc, ppapszArgv, nOptions)
+    aftercare(ccall((:GDALGeneralCmdLineProcessor, libgdal), Cint, (Cint, Ptr{Ptr{Cstring}}, Cint), nArgc, ppapszArgv, nOptions))
 end
 
 """
@@ -2408,7 +2408,7 @@ Byte swap words in-place.
 * **nWordSkip**: the byte offset from the start of one word to the start of the next. For packed buffers this is the same as nWordSize.
 """
 function gdalswapwords(pData, nWordSize, nWordCount, nWordSkip)
-    ccall((:GDALSwapWords, libgdal), Cvoid, (Ptr{Cvoid}, Cint, Cint, Cint), pData, nWordSize, nWordCount, nWordSkip)
+    aftercare(ccall((:GDALSwapWords, libgdal), Cvoid, (Ptr{Cvoid}, Cint, Cint, Cint), pData, nWordSize, nWordCount, nWordSkip))
 end
 
 """
@@ -2426,7 +2426,7 @@ Byte swap words in-place.
 * **nWordSkip**: the byte offset from the start of one word to the start of the next. For packed buffers this is the same as nWordSize.
 """
 function gdalswapwordsex(pData, nWordSize, nWordCount, nWordSkip)
-    ccall((:GDALSwapWordsEx, libgdal), Cvoid, (Ptr{Cvoid}, Cint, Csize_t, Cint), pData, nWordSize, nWordCount, nWordSkip)
+    aftercare(ccall((:GDALSwapWordsEx, libgdal), Cvoid, (Ptr{Cvoid}, Cint, Csize_t, Cint), pData, nWordSize, nWordCount, nWordSkip))
 end
 
 """
@@ -2441,7 +2441,7 @@ end
 Copy pixel words from buffer to buffer.
 """
 function gdalcopywords(pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount)
-    ccall((:GDALCopyWords, libgdal), Cvoid, (Ptr{Cvoid}, GDALDataType, Cint, Ptr{Cvoid}, GDALDataType, Cint, Cint), pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount)
+    aftercare(ccall((:GDALCopyWords, libgdal), Cvoid, (Ptr{Cvoid}, GDALDataType, Cint, Ptr{Cvoid}, GDALDataType, Cint, Cint), pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount))
 end
 
 """
@@ -2465,7 +2465,7 @@ Copy pixel words from buffer to buffer.
 * **nWordCount**: number of words to be copied
 """
 function gdalcopywords64(pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount)
-    ccall((:GDALCopyWords64, libgdal), Cvoid, (Ptr{Cvoid}, GDALDataType, Cint, Ptr{Cvoid}, GDALDataType, Cint, GPtrDiff_t), pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount)
+    aftercare(ccall((:GDALCopyWords64, libgdal), Cvoid, (Ptr{Cvoid}, GDALDataType, Cint, Ptr{Cvoid}, GDALDataType, Cint, GPtrDiff_t), pSrcData, eSrcType, nSrcPixelOffset, pDstData, eDstType, nDstPixelOffset, nWordCount))
 end
 
 """
@@ -2491,7 +2491,7 @@ Bitwise word copying.
 * **nStepCount**: the number of words to copy.
 """
 function gdalcopybits(pabySrcData, nSrcOffset, nSrcStep, pabyDstData, nDstOffset, nDstStep, nBitCount, nStepCount)
-    ccall((:GDALCopyBits, libgdal), Cvoid, (Ptr{GByte}, Cint, Cint, Ptr{GByte}, Cint, Cint, Cint, Cint), pabySrcData, nSrcOffset, nSrcStep, pabyDstData, nDstOffset, nDstStep, nBitCount, nStepCount)
+    aftercare(ccall((:GDALCopyBits, libgdal), Cvoid, (Ptr{GByte}, Cint, Cint, Ptr{GByte}, Cint, Cint, Cint, Cint), pabySrcData, nSrcOffset, nSrcStep, pabyDstData, nDstOffset, nDstStep, nBitCount, nStepCount))
 end
 
 """
@@ -2508,7 +2508,7 @@ Read ESRI world file.
 TRUE on success or FALSE on failure.
 """
 function gdalloadworldfile(arg1, arg2)
-    ccall((:GDALLoadWorldFile, libgdal), Cint, (Cstring, Ptr{Cdouble}), arg1, arg2)
+    aftercare(ccall((:GDALLoadWorldFile, libgdal), Cint, (Cstring, Ptr{Cdouble}), arg1, arg2))
 end
 
 """
@@ -2527,7 +2527,7 @@ Read ESRI world file.
 TRUE on success or FALSE on failure.
 """
 function gdalreadworldfile(arg1, arg2, arg3)
-    ccall((:GDALReadWorldFile, libgdal), Cint, (Cstring, Cstring, Ptr{Cdouble}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALReadWorldFile, libgdal), Cint, (Cstring, Cstring, Ptr{Cdouble}), arg1, arg2, arg3))
 end
 
 """
@@ -2546,7 +2546,7 @@ Write ESRI world file.
 TRUE on success or FALSE on failure.
 """
 function gdalwriteworldfile(arg1, arg2, arg3)
-    ccall((:GDALWriteWorldFile, libgdal), Cint, (Cstring, Cstring, Ptr{Cdouble}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALWriteWorldFile, libgdal), Cint, (Cstring, Cstring, Ptr{Cdouble}), arg1, arg2, arg3))
 end
 
 """
@@ -2569,7 +2569,7 @@ Helper function for translator implementer wanting support for MapInfo .tab file
 TRUE in case of success, FALSE otherwise.
 """
 function gdalloadtabfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALLoadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALLoadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -2592,7 +2592,7 @@ Helper function for translator implementer wanting support for MapInfo .tab file
 TRUE in case of success, FALSE otherwise.
 """
 function gdalreadtabfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALReadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALReadTabFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -2615,7 +2615,7 @@ Helper function for translator implementer wanting support for OZI .map.
 TRUE in case of success, FALSE otherwise.
 """
 function gdalloadozimapfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALLoadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALLoadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -2638,7 +2638,7 @@ Helper function for translator implementer wanting support for OZI .map.
 TRUE in case of success, FALSE otherwise.
 """
 function gdalreadozimapfile(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALReadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALReadOziMapFile, libgdal), Cint, (Cstring, Ptr{Cdouble}, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -2649,7 +2649,7 @@ end
 Translate a decimal degrees value to a DMS string with hemisphere.
 """
 function gdaldectodms(arg1, arg2, arg3)
-    string_or_nothing(ccall((:GDALDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), arg1, arg2, arg3))
+    aftercare(ccall((:GDALDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), arg1, arg2, arg3), false)
 end
 
 """
@@ -2658,7 +2658,7 @@ end
 Convert a packed DMS value (DDDMMMSSS.SS) into decimal degrees.
 """
 function gdalpackeddmstodec(arg1)
-    ccall((:GDALPackedDMSToDec, libgdal), Cdouble, (Cdouble,), arg1)
+    aftercare(ccall((:GDALPackedDMSToDec, libgdal), Cdouble, (Cdouble,), arg1))
 end
 
 """
@@ -2667,7 +2667,7 @@ end
 Convert decimal degrees into packed DMS value (DDDMMMSSS.SS).
 """
 function gdaldectopackeddms(arg1)
-    ccall((:GDALDecToPackedDMS, libgdal), Cdouble, (Cdouble,), arg1)
+    aftercare(ccall((:GDALDecToPackedDMS, libgdal), Cdouble, (Cdouble,), arg1))
 end
 
 """
@@ -2684,7 +2684,7 @@ Extract RPC info from metadata, and apply to an RPCInfo structure.
 TRUE in case of success. FALSE in case of failure.
 """
 function gdalextractrpcinfo(arg1, arg2)
-    ccall((:GDALExtractRPCInfo, libgdal), Cint, (CSLConstList, Ptr{GDALRPCInfo}), arg1, arg2)
+    aftercare(ccall((:GDALExtractRPCInfo, libgdal), Cint, (CSLConstList, Ptr{GDALRPCInfo}), arg1, arg2))
 end
 
 """
@@ -2693,7 +2693,7 @@ end
 Construct a new color table.
 """
 function gdalcreatecolortable(arg1)
-    failsafe(ccall((:GDALCreateColorTable, libgdal), GDALColorTableH, (GDALPaletteInterp,), arg1))
+    aftercare(ccall((:GDALCreateColorTable, libgdal), GDALColorTableH, (GDALPaletteInterp,), arg1))
 end
 
 """
@@ -2702,7 +2702,7 @@ end
 Destroys a color table.
 """
 function gdaldestroycolortable(arg1)
-    ccall((:GDALDestroyColorTable, libgdal), Cvoid, (GDALColorTableH,), arg1)
+    aftercare(ccall((:GDALDestroyColorTable, libgdal), Cvoid, (GDALColorTableH,), arg1))
 end
 
 """
@@ -2711,7 +2711,7 @@ end
 Make a copy of a color table.
 """
 function gdalclonecolortable(arg1)
-    failsafe(ccall((:GDALCloneColorTable, libgdal), GDALColorTableH, (GDALColorTableH,), arg1))
+    aftercare(ccall((:GDALCloneColorTable, libgdal), GDALColorTableH, (GDALColorTableH,), arg1))
 end
 
 """
@@ -2720,7 +2720,7 @@ end
 Fetch palette interpretation.
 """
 function gdalgetpaletteinterpretation(arg1)
-    ccall((:GDALGetPaletteInterpretation, libgdal), GDALPaletteInterp, (GDALColorTableH,), arg1)
+    aftercare(ccall((:GDALGetPaletteInterpretation, libgdal), GDALPaletteInterp, (GDALColorTableH,), arg1))
 end
 
 """
@@ -2729,7 +2729,7 @@ end
 Get number of color entries in table.
 """
 function gdalgetcolorentrycount(arg1)
-    ccall((:GDALGetColorEntryCount, libgdal), Cint, (GDALColorTableH,), arg1)
+    aftercare(ccall((:GDALGetColorEntryCount, libgdal), Cint, (GDALColorTableH,), arg1))
 end
 
 """
@@ -2739,7 +2739,7 @@ end
 Fetch a color entry from table.
 """
 function gdalgetcolorentry(arg1, arg2)
-    ccall((:GDALGetColorEntry, libgdal), Ptr{GDALColorEntry}, (GDALColorTableH, Cint), arg1, arg2)
+    aftercare(ccall((:GDALGetColorEntry, libgdal), Ptr{GDALColorEntry}, (GDALColorTableH, Cint), arg1, arg2))
 end
 
 """
@@ -2750,7 +2750,7 @@ end
 Fetch a table entry in RGB format.
 """
 function gdalgetcolorentryasrgb(arg1, arg2, arg3)
-    ccall((:GDALGetColorEntryAsRGB, libgdal), Cint, (GDALColorTableH, Cint, Ptr{GDALColorEntry}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALGetColorEntryAsRGB, libgdal), Cint, (GDALColorTableH, Cint, Ptr{GDALColorEntry}), arg1, arg2, arg3))
 end
 
 """
@@ -2761,7 +2761,7 @@ end
 Set entry in color table.
 """
 function gdalsetcolorentry(arg1, arg2, arg3)
-    ccall((:GDALSetColorEntry, libgdal), Cvoid, (GDALColorTableH, Cint, Ptr{GDALColorEntry}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALSetColorEntry, libgdal), Cvoid, (GDALColorTableH, Cint, Ptr{GDALColorEntry}), arg1, arg2, arg3))
 end
 
 """
@@ -2774,7 +2774,7 @@ end
 Create color ramp.
 """
 function gdalcreatecolorramp(hTable, nStartIndex, psStartColor, nEndIndex, psEndColor)
-    ccall((:GDALCreateColorRamp, libgdal), Cvoid, (GDALColorTableH, Cint, Ptr{GDALColorEntry}, Cint, Ptr{GDALColorEntry}), hTable, nStartIndex, psStartColor, nEndIndex, psEndColor)
+    aftercare(ccall((:GDALCreateColorRamp, libgdal), Cvoid, (GDALColorTableH, Cint, Ptr{GDALColorEntry}, Cint, Ptr{GDALColorEntry}), hTable, nStartIndex, psStartColor, nEndIndex, psEndColor))
 end
 
 """
@@ -2783,7 +2783,7 @@ end
 Construct empty table.
 """
 function gdalcreaterasterattributetable()
-    failsafe(ccall((:GDALCreateRasterAttributeTable, libgdal), GDALRasterAttributeTableH, ()))
+    aftercare(ccall((:GDALCreateRasterAttributeTable, libgdal), GDALRasterAttributeTableH, ()))
 end
 
 """
@@ -2792,7 +2792,7 @@ end
 Destroys a RAT.
 """
 function gdaldestroyrasterattributetable(arg1)
-    ccall((:GDALDestroyRasterAttributeTable, libgdal), Cvoid, (GDALRasterAttributeTableH,), arg1)
+    aftercare(ccall((:GDALDestroyRasterAttributeTable, libgdal), Cvoid, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -2801,7 +2801,7 @@ end
 Fetch table column count.
 """
 function gdalratgetcolumncount(arg1)
-    ccall((:GDALRATGetColumnCount, libgdal), Cint, (GDALRasterAttributeTableH,), arg1)
+    aftercare(ccall((:GDALRATGetColumnCount, libgdal), Cint, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -2818,7 +2818,7 @@ Fetch name of indicated column.
 name.
 """
 function gdalratgetnameofcol(arg1, arg2)
-    string_or_nothing(ccall((:GDALRATGetNameOfCol, libgdal), Cstring, (GDALRasterAttributeTableH, Cint), arg1, arg2))
+    aftercare(ccall((:GDALRATGetNameOfCol, libgdal), Cstring, (GDALRasterAttributeTableH, Cint), arg1, arg2), false)
 end
 
 """
@@ -2835,7 +2835,7 @@ Fetch column usage value.
 usage.
 """
 function gdalratgetusageofcol(arg1, arg2)
-    ccall((:GDALRATGetUsageOfCol, libgdal), GDALRATFieldUsage, (GDALRasterAttributeTableH, Cint), arg1, arg2)
+    aftercare(ccall((:GDALRATGetUsageOfCol, libgdal), GDALRATFieldUsage, (GDALRasterAttributeTableH, Cint), arg1, arg2))
 end
 
 """
@@ -2852,7 +2852,7 @@ Fetch column type.
 type.
 """
 function gdalratgettypeofcol(arg1, arg2)
-    ccall((:GDALRATGetTypeOfCol, libgdal), GDALRATFieldType, (GDALRasterAttributeTableH, Cint), arg1, arg2)
+    aftercare(ccall((:GDALRATGetTypeOfCol, libgdal), GDALRATFieldType, (GDALRasterAttributeTableH, Cint), arg1, arg2))
 end
 
 """
@@ -2862,7 +2862,7 @@ end
 Fetch column index for given usage.
 """
 function gdalratgetcolofusage(arg1, arg2)
-    ccall((:GDALRATGetColOfUsage, libgdal), Cint, (GDALRasterAttributeTableH, GDALRATFieldUsage), arg1, arg2)
+    aftercare(ccall((:GDALRATGetColOfUsage, libgdal), Cint, (GDALRasterAttributeTableH, GDALRATFieldUsage), arg1, arg2))
 end
 
 """
@@ -2871,7 +2871,7 @@ end
 Fetch row count.
 """
 function gdalratgetrowcount(arg1)
-    ccall((:GDALRATGetRowCount, libgdal), Cint, (GDALRasterAttributeTableH,), arg1)
+    aftercare(ccall((:GDALRATGetRowCount, libgdal), Cint, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -2882,7 +2882,7 @@ end
 Fetch field value as a string.
 """
 function gdalratgetvalueasstring(arg1, arg2, arg3)
-    string_or_nothing(ccall((:GDALRATGetValueAsString, libgdal), Cstring, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3))
+    aftercare(ccall((:GDALRATGetValueAsString, libgdal), Cstring, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3), false)
 end
 
 """
@@ -2893,7 +2893,7 @@ end
 Fetch field value as a integer.
 """
 function gdalratgetvalueasint(arg1, arg2, arg3)
-    ccall((:GDALRATGetValueAsInt, libgdal), Cint, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:GDALRATGetValueAsInt, libgdal), Cint, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -2904,7 +2904,7 @@ end
 Fetch field value as a double.
 """
 function gdalratgetvalueasdouble(arg1, arg2, arg3)
-    ccall((:GDALRATGetValueAsDouble, libgdal), Cdouble, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:GDALRATGetValueAsDouble, libgdal), Cdouble, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -2922,7 +2922,7 @@ Set field value from string.
 * **pszValue**: value.
 """
 function gdalratsetvalueasstring(arg1, arg2, arg3, arg4)
-    ccall((:GDALRATSetValueAsString, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALRATSetValueAsString, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -2934,7 +2934,7 @@ end
 Set field value from integer.
 """
 function gdalratsetvalueasint(arg1, arg2, arg3, arg4)
-    ccall((:GDALRATSetValueAsInt, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cint), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALRATSetValueAsInt, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cint), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -2946,7 +2946,7 @@ end
 Set field value from double.
 """
 function gdalratsetvalueasdouble(arg1, arg2, arg3, arg4)
-    ccall((:GDALRATSetValueAsDouble, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALRATSetValueAsDouble, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint, Cint, Cdouble), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -2955,7 +2955,7 @@ end
 Determine whether changes made to this RAT are reflected directly in the dataset.
 """
 function gdalratchangesarewrittentofile(hRAT)
-    ccall((:GDALRATChangesAreWrittenToFile, libgdal), Cint, (GDALRasterAttributeTableH,), hRAT)
+    aftercare(ccall((:GDALRATChangesAreWrittenToFile, libgdal), Cint, (GDALRasterAttributeTableH,), hRAT))
 end
 
 """
@@ -2969,7 +2969,7 @@ end
 Read or Write a block of doubles to/from the Attribute Table.
 """
 function gdalratvaluesioasdouble(hRAT, eRWFlag, iField, iStartRow, iLength, pdfData)
-    ccall((:GDALRATValuesIOAsDouble, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, Ptr{Cdouble}), hRAT, eRWFlag, iField, iStartRow, iLength, pdfData)
+    aftercare(ccall((:GDALRATValuesIOAsDouble, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, Ptr{Cdouble}), hRAT, eRWFlag, iField, iStartRow, iLength, pdfData))
 end
 
 """
@@ -2983,7 +2983,7 @@ end
 Read or Write a block of ints to/from the Attribute Table.
 """
 function gdalratvaluesioasinteger(hRAT, eRWFlag, iField, iStartRow, iLength, pnData)
-    ccall((:GDALRATValuesIOAsInteger, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, Ptr{Cint}), hRAT, eRWFlag, iField, iStartRow, iLength, pnData)
+    aftercare(ccall((:GDALRATValuesIOAsInteger, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, Ptr{Cint}), hRAT, eRWFlag, iField, iStartRow, iLength, pnData))
 end
 
 """
@@ -2997,7 +2997,7 @@ end
 Read or Write a block of strings to/from the Attribute Table.
 """
 function gdalratvaluesioasstring(hRAT, eRWFlag, iField, iStartRow, iLength, papszStrList)
-    ccall((:GDALRATValuesIOAsString, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, CSLConstList), hRAT, eRWFlag, iField, iStartRow, iLength, papszStrList)
+    aftercare(ccall((:GDALRATValuesIOAsString, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRWFlag, Cint, Cint, Cint, CSLConstList), hRAT, eRWFlag, iField, iStartRow, iLength, papszStrList))
 end
 
 """
@@ -3011,7 +3011,7 @@ Set row count.
 * **nNewCount**: the new number of rows.
 """
 function gdalratsetrowcount(arg1, arg2)
-    ccall((:GDALRATSetRowCount, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint), arg1, arg2)
+    aftercare(ccall((:GDALRATSetRowCount, libgdal), Cvoid, (GDALRasterAttributeTableH, Cint), arg1, arg2))
 end
 
 """
@@ -3023,7 +3023,7 @@ end
 Create new column.
 """
 function gdalratcreatecolumn(arg1, arg2, arg3, arg4)
-    ccall((:GDALRATCreateColumn, libgdal), CPLErr, (GDALRasterAttributeTableH, Cstring, GDALRATFieldType, GDALRATFieldUsage), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:GDALRATCreateColumn, libgdal), CPLErr, (GDALRasterAttributeTableH, Cstring, GDALRATFieldType, GDALRATFieldUsage), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3034,7 +3034,7 @@ end
 Set linear binning information.
 """
 function gdalratsetlinearbinning(arg1, arg2, arg3)
-    ccall((:GDALRATSetLinearBinning, libgdal), CPLErr, (GDALRasterAttributeTableH, Cdouble, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:GDALRATSetLinearBinning, libgdal), CPLErr, (GDALRasterAttributeTableH, Cdouble, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -3045,7 +3045,7 @@ end
 Get linear binning information.
 """
 function gdalratgetlinearbinning(arg1, arg2, arg3)
-    ccall((:GDALRATGetLinearBinning, libgdal), Cint, (GDALRasterAttributeTableH, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3)
+    aftercare(ccall((:GDALRATGetLinearBinning, libgdal), Cint, (GDALRasterAttributeTableH, Ptr{Cdouble}, Ptr{Cdouble}), arg1, arg2, arg3))
 end
 
 """
@@ -3055,7 +3055,7 @@ end
 Set RAT Table Type.
 """
 function gdalratsettabletype(hRAT, eInTableType)
-    ccall((:GDALRATSetTableType, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRATTableType), hRAT, eInTableType)
+    aftercare(ccall((:GDALRATSetTableType, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALRATTableType), hRAT, eInTableType))
 end
 
 """
@@ -3064,7 +3064,7 @@ end
 Get Rat Table Type.
 """
 function gdalratgettabletype(hRAT)
-    ccall((:GDALRATGetTableType, libgdal), GDALRATTableType, (GDALRasterAttributeTableH,), hRAT)
+    aftercare(ccall((:GDALRATGetTableType, libgdal), GDALRATTableType, (GDALRasterAttributeTableH,), hRAT))
 end
 
 """
@@ -3074,7 +3074,7 @@ end
 Initialize from color table.
 """
 function gdalratinitializefromcolortable(arg1, arg2)
-    ccall((:GDALRATInitializeFromColorTable, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALColorTableH), arg1, arg2)
+    aftercare(ccall((:GDALRATInitializeFromColorTable, libgdal), CPLErr, (GDALRasterAttributeTableH, GDALColorTableH), arg1, arg2))
 end
 
 """
@@ -3084,7 +3084,7 @@ end
 Translate to a color table.
 """
 function gdalrattranslatetocolortable(arg1, nEntryCount)
-    failsafe(ccall((:GDALRATTranslateToColorTable, libgdal), GDALColorTableH, (GDALRasterAttributeTableH, Cint), arg1, nEntryCount))
+    aftercare(ccall((:GDALRATTranslateToColorTable, libgdal), GDALColorTableH, (GDALRasterAttributeTableH, Cint), arg1, nEntryCount))
 end
 
 """
@@ -3094,7 +3094,7 @@ end
 Dump RAT in readable form.
 """
 function gdalratdumpreadable(arg1, arg2)
-    ccall((:GDALRATDumpReadable, libgdal), Cvoid, (GDALRasterAttributeTableH, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:GDALRATDumpReadable, libgdal), Cvoid, (GDALRasterAttributeTableH, Ptr{Cint}), arg1, arg2))
 end
 
 """
@@ -3103,7 +3103,7 @@ end
 Copy Raster Attribute Table.
 """
 function gdalratclone(arg1)
-    failsafe(ccall((:GDALRATClone, libgdal), GDALRasterAttributeTableH, (GDALRasterAttributeTableH,), arg1))
+    aftercare(ccall((:GDALRATClone, libgdal), GDALRasterAttributeTableH, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -3112,7 +3112,7 @@ end
 Serialize Raster Attribute Table in Json format.
 """
 function gdalratserializejson(arg1)
-    failsafe(ccall((:GDALRATSerializeJSON, libgdal), Ptr{Cvoid}, (GDALRasterAttributeTableH,), arg1))
+    aftercare(ccall((:GDALRATSerializeJSON, libgdal), Ptr{Cvoid}, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -3122,7 +3122,7 @@ end
 Get row for pixel value.
 """
 function gdalratgetrowofvalue(arg1, arg2)
-    ccall((:GDALRATGetRowOfValue, libgdal), Cint, (GDALRasterAttributeTableH, Cdouble), arg1, arg2)
+    aftercare(ccall((:GDALRATGetRowOfValue, libgdal), Cint, (GDALRasterAttributeTableH, Cdouble), arg1, arg2))
 end
 
 """
@@ -3131,7 +3131,7 @@ end
 Remove Statistics from RAT.
 """
 function gdalratremovestatistics(arg1)
-    ccall((:GDALRATRemoveStatistics, libgdal), Cvoid, (GDALRasterAttributeTableH,), arg1)
+    aftercare(ccall((:GDALRATRemoveStatistics, libgdal), Cvoid, (GDALRasterAttributeTableH,), arg1))
 end
 
 """
@@ -3143,7 +3143,7 @@ Set maximum cache memory.
 * **nNewSizeInBytes**: the maximum number of bytes for caching.
 """
 function gdalsetcachemax(nBytes)
-    ccall((:GDALSetCacheMax, libgdal), Cvoid, (Cint,), nBytes)
+    aftercare(ccall((:GDALSetCacheMax, libgdal), Cvoid, (Cint,), nBytes))
 end
 
 """
@@ -3155,7 +3155,7 @@ Get maximum cache memory.
 maximum in bytes.
 """
 function gdalgetcachemax()
-    ccall((:GDALGetCacheMax, libgdal), Cint, ())
+    aftercare(ccall((:GDALGetCacheMax, libgdal), Cint, ()))
 end
 
 """
@@ -3167,7 +3167,7 @@ Get cache memory used.
 the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
 """
 function gdalgetcacheused()
-    ccall((:GDALGetCacheUsed, libgdal), Cint, ())
+    aftercare(ccall((:GDALGetCacheUsed, libgdal), Cint, ()))
 end
 
 """
@@ -3179,7 +3179,7 @@ Set maximum cache memory.
 * **nNewSizeInBytes**: the maximum number of bytes for caching.
 """
 function gdalsetcachemax64(nBytes)
-    ccall((:GDALSetCacheMax64, libgdal), Cvoid, (GIntBig,), nBytes)
+    aftercare(ccall((:GDALSetCacheMax64, libgdal), Cvoid, (GIntBig,), nBytes))
 end
 
 """
@@ -3191,7 +3191,7 @@ Get maximum cache memory.
 maximum in bytes.
 """
 function gdalgetcachemax64()
-    ccall((:GDALGetCacheMax64, libgdal), GIntBig, ())
+    aftercare(ccall((:GDALGetCacheMax64, libgdal), GIntBig, ()))
 end
 
 """
@@ -3203,7 +3203,7 @@ Get cache memory used.
 the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
 """
 function gdalgetcacheused64()
-    ccall((:GDALGetCacheUsed64, libgdal), GIntBig, ())
+    aftercare(ccall((:GDALGetCacheUsed64, libgdal), GIntBig, ()))
 end
 
 """
@@ -3215,7 +3215,7 @@ Try to flush one cached raster block.
 TRUE if one block was flushed, FALSE if there are no cached blocks or if they are currently locked.
 """
 function gdalflushcacheblock()
-    ccall((:GDALFlushCacheBlock, libgdal), Cint, ())
+    aftercare(ccall((:GDALFlushCacheBlock, libgdal), Cint, ()))
 end
 
 """
@@ -3264,7 +3264,7 @@ Create a CPLVirtualMem object from a GDAL dataset object.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function gdaldatasetgetvirtualmem(hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
-    failsafe(ccall((:GDALDatasetGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, GIntBig, GIntBig, Csize_t, Csize_t, Cint, CSLConstList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions))
+    aftercare(ccall((:GDALDatasetGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, GIntBig, GIntBig, Csize_t, Csize_t, Cint, CSLConstList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions))
 end
 
 """
@@ -3307,7 +3307,7 @@ Create a CPLVirtualMem object from a GDAL raster band object.
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function gdalrasterbandgetvirtualmem(hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions)
-    failsafe(ccall((:GDALRasterBandGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, GIntBig, Csize_t, Csize_t, Cint, CSLConstList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions))
+    aftercare(ccall((:GDALRasterBandGetVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, GIntBig, Csize_t, Csize_t, Cint, CSLConstList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, nCacheSize, nPageSizeHint, bSingleThreadUsage, papszOptions))
 end
 
 """
@@ -3320,7 +3320,7 @@ end
 Create a CPLVirtualMem object from a GDAL raster band object.
 """
 function gdalgetvirtualmemauto(hBand, eRWFlag, pnPixelSpace, pnLineSpace, papszOptions)
-    failsafe(ccall((:GDALGetVirtualMemAuto, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Ptr{Cint}, Ptr{GIntBig}, CSLConstList), hBand, eRWFlag, pnPixelSpace, pnLineSpace, papszOptions))
+    aftercare(ccall((:GDALGetVirtualMemAuto, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Ptr{Cint}, Ptr{GIntBig}, CSLConstList), hBand, eRWFlag, pnPixelSpace, pnLineSpace, papszOptions))
 end
 
 """
@@ -3363,7 +3363,7 @@ Create a CPLVirtualMem object from a GDAL dataset object, with tiling organizati
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function gdaldatasetgettiledvirtualmem(hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nBandCount, panBandMap, eTileOrganization, nCacheSize, bSingleThreadUsage, papszOptions)
-    failsafe(ccall((:GDALDatasetGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GDALTileOrganization, Csize_t, Cint, CSLConstList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nBandCount, panBandMap, eTileOrganization, nCacheSize, bSingleThreadUsage, papszOptions))
+    aftercare(ccall((:GDALDatasetGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, GDALTileOrganization, Csize_t, Cint, CSLConstList), hDS, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nBandCount, panBandMap, eTileOrganization, nCacheSize, bSingleThreadUsage, papszOptions))
 end
 
 """
@@ -3400,7 +3400,7 @@ Create a CPLVirtualMem object from a GDAL rasterband object, with tiling organiz
 a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
 """
 function gdalrasterbandgettiledvirtualmem(hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nCacheSize, bSingleThreadUsage, papszOptions)
-    failsafe(ccall((:GDALRasterBandGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Csize_t, Cint, CSLConstList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nCacheSize, bSingleThreadUsage, papszOptions))
+    aftercare(ccall((:GDALRasterBandGetTiledVirtualMem, libgdal), Ptr{CPLVirtualMem}, (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Csize_t, Cint, CSLConstList), hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, nTileXSize, nTileYSize, eBufType, nCacheSize, bSingleThreadUsage, papszOptions))
 end
 
 """
@@ -3421,7 +3421,7 @@ Create a virtual pansharpened dataset.
 NULL on failure, or a new virtual dataset handle on success to be closed with GDALClose().
 """
 function gdalcreatepansharpenedvrt(pszXML, hPanchroBand, nInputSpectralBands, pahInputSpectralBands)
-    failsafe(ccall((:GDALCreatePansharpenedVRT, libgdal), GDALDatasetH, (Cstring, GDALRasterBandH, Cint, Ptr{GDALRasterBandH}), pszXML, hPanchroBand, nInputSpectralBands, pahInputSpectralBands))
+    aftercare(ccall((:GDALCreatePansharpenedVRT, libgdal), GDALDatasetH, (Cstring, GDALRasterBandH, Cint, Ptr{GDALRasterBandH}), pszXML, hPanchroBand, nInputSpectralBands, pahInputSpectralBands))
 end
 
 """
@@ -3438,5 +3438,5 @@ Dump the structure of a JPEG2000 file as a XML tree.
 XML tree (to be freed with CPLDestroyXMLNode()) or NULL in case of error
 """
 function gdalgetjpeg2000structure(pszFilename, papszOptions)
-    ccall((:GDALGetJPEG2000Structure, libgdal), Ptr{CPLXMLNode}, (Cstring, CSLConstList), pszFilename, papszOptions)
+    aftercare(ccall((:GDALGetJPEG2000Structure, libgdal), Ptr{CPLXMLNode}, (Cstring, CSLConstList), pszFilename, papszOptions))
 end

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -107,7 +107,7 @@ Get name of data type.
 string corresponding to existing data type or NULL pointer if invalid type given.
 """
 function gdalgetdatatypename(arg1)
-    unsafe_string(ccall((:GDALGetDataTypeName, libgdal), Cstring, (GDALDataType,), arg1))
+    string_or_nothing(ccall((:GDALGetDataTypeName, libgdal), Cstring, (GDALDataType,), arg1))
 end
 
 """
@@ -264,7 +264,7 @@ Get name of AsyncStatus data type.
 string corresponding to type.
 """
 function gdalgetasyncstatustypename(arg1)
-    unsafe_string(ccall((:GDALGetAsyncStatusTypeName, libgdal), Cstring, (GDALAsyncStatusType,), arg1))
+    string_or_nothing(ccall((:GDALGetAsyncStatusTypeName, libgdal), Cstring, (GDALAsyncStatusType,), arg1))
 end
 
 """
@@ -294,7 +294,7 @@ Get name of color interpretation.
 string corresponding to color interpretation or NULL pointer if invalid enumerator given.
 """
 function gdalgetcolorinterpretationname(arg1)
-    unsafe_string(ccall((:GDALGetColorInterpretationName, libgdal), Cstring, (GDALColorInterp,), arg1))
+    string_or_nothing(ccall((:GDALGetColorInterpretationName, libgdal), Cstring, (GDALColorInterp,), arg1))
 end
 
 """
@@ -324,7 +324,7 @@ Get name of palette interpretation.
 string corresponding to palette interpretation.
 """
 function gdalgetpaletteinterpretationname(arg1)
-    unsafe_string(ccall((:GDALGetPaletteInterpretationName, libgdal), Cstring, (GDALPaletteInterp,), arg1))
+    string_or_nothing(ccall((:GDALGetPaletteInterpretationName, libgdal), Cstring, (GDALPaletteInterp,), arg1))
 end
 
 """
@@ -624,7 +624,7 @@ Return the short name of a driver.
 the short name of the driver. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdrivershortname(arg1)
-    unsafe_string(ccall((:GDALGetDriverShortName, libgdal), Cstring, (GDALDriverH,), arg1))
+    string_or_nothing(ccall((:GDALGetDriverShortName, libgdal), Cstring, (GDALDriverH,), arg1))
 end
 
 """
@@ -639,7 +639,7 @@ Return the long name of a driver.
 the long name of the driver or empty string. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdriverlongname(arg1)
-    unsafe_string(ccall((:GDALGetDriverLongName, libgdal), Cstring, (GDALDriverH,), arg1))
+    string_or_nothing(ccall((:GDALGetDriverLongName, libgdal), Cstring, (GDALDriverH,), arg1))
 end
 
 """
@@ -654,7 +654,7 @@ Return the URL to the help that describes the driver.
 the URL to the help that describes the driver or NULL. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdriverhelptopic(arg1)
-    unsafe_string(ccall((:GDALGetDriverHelpTopic, libgdal), Cstring, (GDALDriverH,), arg1))
+    string_or_nothing(ccall((:GDALGetDriverHelpTopic, libgdal), Cstring, (GDALDriverH,), arg1))
 end
 
 """
@@ -669,7 +669,7 @@ Return the list of creation options of the driver.
 an XML string that describes the list of creation options or empty string. The returned string should not be freed and is owned by the driver.
 """
 function gdalgetdrivercreationoptionlist(arg1)
-    unsafe_string(ccall((:GDALGetDriverCreationOptionList, libgdal), Cstring, (GDALDriverH,), arg1))
+    string_or_nothing(ccall((:GDALGetDriverCreationOptionList, libgdal), Cstring, (GDALDriverH,), arg1))
 end
 
 """
@@ -826,7 +826,7 @@ end
 Fetch single metadata item.
 """
 function gdalgetmetadataitem(arg1, arg2, arg3)
-    unsafe_string(ccall((:GDALGetMetadataItem, libgdal), Cstring, (GDALMajorObjectH, Cstring, Cstring), arg1, arg2, arg3))
+    string_or_nothing(ccall((:GDALGetMetadataItem, libgdal), Cstring, (GDALMajorObjectH, Cstring, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -847,7 +847,7 @@ end
 Fetch object description.
 """
 function gdalgetdescription(arg1)
-    unsafe_string(ccall((:GDALGetDescription, libgdal), Cstring, (GDALMajorObjectH,), arg1))
+    string_or_nothing(ccall((:GDALGetDescription, libgdal), Cstring, (GDALMajorObjectH,), arg1))
 end
 
 """
@@ -1067,7 +1067,7 @@ end
 Fetch the projection definition string for this dataset.
 """
 function gdalgetprojectionref(arg1)
-    unsafe_string(ccall((:GDALGetProjectionRef, libgdal), Cstring, (GDALDatasetH,), arg1))
+    string_or_nothing(ccall((:GDALGetProjectionRef, libgdal), Cstring, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1134,7 +1134,7 @@ end
 Get output projection for GCPs.
 """
 function gdalgetgcpprojection(arg1)
-    unsafe_string(ccall((:GDALGetGCPProjection, libgdal), Cstring, (GDALDatasetH,), arg1))
+    string_or_nothing(ccall((:GDALGetGCPProjection, libgdal), Cstring, (GDALDatasetH,), arg1))
 end
 
 """
@@ -1966,7 +1966,7 @@ end
 Return raster unit type.
 """
 function gdalgetrasterunittype(arg1)
-    unsafe_string(ccall((:GDALGetRasterUnitType, libgdal), Cstring, (GDALRasterBandH,), arg1))
+    string_or_nothing(ccall((:GDALGetRasterUnitType, libgdal), Cstring, (GDALRasterBandH,), arg1))
 end
 
 """
@@ -2649,7 +2649,7 @@ end
 Translate a decimal degrees value to a DMS string with hemisphere.
 """
 function gdaldectodms(arg1, arg2, arg3)
-    unsafe_string(ccall((:GDALDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), arg1, arg2, arg3))
+    string_or_nothing(ccall((:GDALDecToDMS, libgdal), Cstring, (Cdouble, Cstring, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -2818,7 +2818,7 @@ Fetch name of indicated column.
 name.
 """
 function gdalratgetnameofcol(arg1, arg2)
-    unsafe_string(ccall((:GDALRATGetNameOfCol, libgdal), Cstring, (GDALRasterAttributeTableH, Cint), arg1, arg2))
+    string_or_nothing(ccall((:GDALRATGetNameOfCol, libgdal), Cstring, (GDALRasterAttributeTableH, Cint), arg1, arg2))
 end
 
 """
@@ -2882,7 +2882,7 @@ end
 Fetch field value as a string.
 """
 function gdalratgetvalueasstring(arg1, arg2, arg3)
-    unsafe_string(ccall((:GDALRATGetValueAsString, libgdal), Cstring, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3))
+    string_or_nothing(ccall((:GDALRATGetValueAsString, libgdal), Cstring, (GDALRasterAttributeTableH, Cint, Cint), arg1, arg2, arg3))
 end
 
 """

--- a/src/gdal_utils.jl
+++ b/src/gdal_utils.jl
@@ -45,7 +45,7 @@ Lists various information about a GDAL supported raster dataset.
 string corresponding to the information about the raster dataset (must be freed with CPLFree()), or NULL in case of error.
 """
 function gdalinfo(hDataset, psOptions)
-    unsafe_string(ccall((:GDALInfo, libgdal), Cstring, (GDALDatasetH, Ptr{GDALInfoOptions}), hDataset, psOptions))
+    string_or_nothing(ccall((:GDALInfo, libgdal), Cstring, (GDALDatasetH, Ptr{GDALInfoOptions}), hDataset, psOptions))
 end
 
 """

--- a/src/gdal_utils.jl
+++ b/src/gdal_utils.jl
@@ -16,7 +16,7 @@ Allocates a GDALInfoOptions struct.
 pointer to the allocated GDALInfoOptions struct. Must be freed with GDALInfoOptionsFree().
 """
 function gdalinfooptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALInfoOptionsNew, libgdal), Ptr{GDALInfoOptions}, (Ptr{Cstring}, Ptr{GDALInfoOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALInfoOptionsNew, libgdal), Ptr{GDALInfoOptions}, (Ptr{Cstring}, Ptr{GDALInfoOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -28,7 +28,7 @@ Frees the GDALInfoOptions struct.
 * **psOptions**: the options struct for GDALInfo().
 """
 function gdalinfooptionsfree(psOptions)
-    ccall((:GDALInfoOptionsFree, libgdal), Cvoid, (Ptr{GDALInfoOptions},), psOptions)
+    aftercare(ccall((:GDALInfoOptionsFree, libgdal), Cvoid, (Ptr{GDALInfoOptions},), psOptions))
 end
 
 """
@@ -45,7 +45,7 @@ Lists various information about a GDAL supported raster dataset.
 string corresponding to the information about the raster dataset (must be freed with CPLFree()), or NULL in case of error.
 """
 function gdalinfo(hDataset, psOptions)
-    string_or_nothing(ccall((:GDALInfo, libgdal), Cstring, (GDALDatasetH, Ptr{GDALInfoOptions}), hDataset, psOptions))
+    aftercare(ccall((:GDALInfo, libgdal), Cstring, (GDALDatasetH, Ptr{GDALInfoOptions}), hDataset, psOptions), true)
 end
 
 """
@@ -62,7 +62,7 @@ Allocates a GDALTranslateOptions struct.
 pointer to the allocated GDALTranslateOptions struct. Must be freed with GDALTranslateOptionsFree().
 """
 function gdaltranslateoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALTranslateOptionsNew, libgdal), Ptr{GDALTranslateOptions}, (Ptr{Cstring}, Ptr{GDALTranslateOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALTranslateOptionsNew, libgdal), Ptr{GDALTranslateOptions}, (Ptr{Cstring}, Ptr{GDALTranslateOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -74,7 +74,7 @@ Frees the GDALTranslateOptions struct.
 * **psOptions**: the options struct for GDALTranslate().
 """
 function gdaltranslateoptionsfree(psOptions)
-    ccall((:GDALTranslateOptionsFree, libgdal), Cvoid, (Ptr{GDALTranslateOptions},), psOptions)
+    aftercare(ccall((:GDALTranslateOptionsFree, libgdal), Cvoid, (Ptr{GDALTranslateOptions},), psOptions))
 end
 
 """
@@ -90,7 +90,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdaltranslateoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALTranslateOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALTranslateOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALTranslateOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALTranslateOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -111,7 +111,7 @@ Converts raster data between different formats.
 the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
 """
 function gdaltranslate(pszDestFilename, hSrcDataset, psOptions, pbUsageError)
-    failsafe(ccall((:GDALTranslate, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Ptr{GDALTranslateOptions}, Ptr{Cint}), pszDestFilename, hSrcDataset, psOptions, pbUsageError))
+    aftercare(ccall((:GDALTranslate, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Ptr{GDALTranslateOptions}, Ptr{Cint}), pszDestFilename, hSrcDataset, psOptions, pbUsageError))
 end
 
 """
@@ -128,7 +128,7 @@ Allocates a GDALWarpAppOptions struct.
 pointer to the allocated GDALWarpAppOptions struct. Must be freed with GDALWarpAppOptionsFree().
 """
 function gdalwarpappoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALWarpAppOptionsNew, libgdal), Ptr{GDALWarpAppOptions}, (Ptr{Cstring}, Ptr{GDALWarpAppOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALWarpAppOptionsNew, libgdal), Ptr{GDALWarpAppOptions}, (Ptr{Cstring}, Ptr{GDALWarpAppOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -140,7 +140,7 @@ Frees the GDALWarpAppOptions struct.
 * **psOptions**: the options struct for GDALWarp().
 """
 function gdalwarpappoptionsfree(psOptions)
-    ccall((:GDALWarpAppOptionsFree, libgdal), Cvoid, (Ptr{GDALWarpAppOptions},), psOptions)
+    aftercare(ccall((:GDALWarpAppOptionsFree, libgdal), Cvoid, (Ptr{GDALWarpAppOptions},), psOptions))
 end
 
 """
@@ -156,7 +156,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalwarpappoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALWarpAppOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALWarpAppOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -170,7 +170,7 @@ Set a progress function.
 * **bQuiet**: whether GDALWarp() should emit messages on stdout.
 """
 function gdalwarpappoptionssetquiet(psOptions, bQuiet)
-    ccall((:GDALWarpAppOptionsSetQuiet, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, Cint), psOptions, bQuiet)
+    aftercare(ccall((:GDALWarpAppOptionsSetQuiet, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, Cint), psOptions, bQuiet))
 end
 
 """
@@ -186,7 +186,7 @@ Set a warp option.
 * **pszValue**: value.
 """
 function gdalwarpappoptionssetwarpoption(psOptions, pszKey, pszValue)
-    ccall((:GDALWarpAppOptionsSetWarpOption, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, Cstring, Cstring), psOptions, pszKey, pszValue)
+    aftercare(ccall((:GDALWarpAppOptionsSetWarpOption, libgdal), Cvoid, (Ptr{GDALWarpAppOptions}, Cstring, Cstring), psOptions, pszKey, pszValue))
 end
 
 """
@@ -211,7 +211,7 @@ Image reprojection and warping function.
 the output dataset (new dataset that must be closed using GDALClose(), or hDstDS if not NULL) or NULL in case of error.
 """
 function gdalwarp(pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError)
-    failsafe(ccall((:GDALWarp, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cint, Ptr{GDALDatasetH}, Ptr{GDALWarpAppOptions}, Ptr{Cint}), pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError))
+    aftercare(ccall((:GDALWarp, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cint, Ptr{GDALDatasetH}, Ptr{GDALWarpAppOptions}, Ptr{Cint}), pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError))
 end
 
 """
@@ -228,7 +228,7 @@ allocates a GDALVectorTranslateOptions struct.
 pointer to the allocated GDALVectorTranslateOptions struct. Must be freed with GDALVectorTranslateOptionsFree().
 """
 function gdalvectortranslateoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALVectorTranslateOptionsNew, libgdal), Ptr{GDALVectorTranslateOptions}, (Ptr{Cstring}, Ptr{GDALVectorTranslateOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALVectorTranslateOptionsNew, libgdal), Ptr{GDALVectorTranslateOptions}, (Ptr{Cstring}, Ptr{GDALVectorTranslateOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -240,7 +240,7 @@ Frees the GDALVectorTranslateOptions struct.
 * **psOptions**: the options struct for GDALVectorTranslate().
 """
 function gdalvectortranslateoptionsfree(psOptions)
-    ccall((:GDALVectorTranslateOptionsFree, libgdal), Cvoid, (Ptr{GDALVectorTranslateOptions},), psOptions)
+    aftercare(ccall((:GDALVectorTranslateOptionsFree, libgdal), Cvoid, (Ptr{GDALVectorTranslateOptions},), psOptions))
 end
 
 """
@@ -256,7 +256,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalvectortranslateoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALVectorTranslateOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALVectorTranslateOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALVectorTranslateOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALVectorTranslateOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -281,7 +281,7 @@ Converts vector data between file formats.
 the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL in case of error.
 """
 function gdalvectortranslate(pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError)
-    failsafe(ccall((:GDALVectorTranslate, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cint, Ptr{GDALDatasetH}, Ptr{GDALVectorTranslateOptions}, Ptr{Cint}), pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError))
+    aftercare(ccall((:GDALVectorTranslate, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cint, Ptr{GDALDatasetH}, Ptr{GDALVectorTranslateOptions}, Ptr{Cint}), pszDest, hDstDS, nSrcCount, pahSrcDS, psOptions, pbUsageError))
 end
 
 """
@@ -298,7 +298,7 @@ Allocates a GDALDEMProcessingOptions struct.
 pointer to the allocated GDALDEMProcessingOptions struct. Must be freed with GDALDEMProcessingOptionsFree().
 """
 function gdaldemprocessingoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALDEMProcessingOptionsNew, libgdal), Ptr{GDALDEMProcessingOptions}, (Ptr{Cstring}, Ptr{GDALDEMProcessingOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALDEMProcessingOptionsNew, libgdal), Ptr{GDALDEMProcessingOptions}, (Ptr{Cstring}, Ptr{GDALDEMProcessingOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -310,7 +310,7 @@ Frees the GDALDEMProcessingOptions struct.
 * **psOptions**: the options struct for GDALDEMProcessing().
 """
 function gdaldemprocessingoptionsfree(psOptions)
-    ccall((:GDALDEMProcessingOptionsFree, libgdal), Cvoid, (Ptr{GDALDEMProcessingOptions},), psOptions)
+    aftercare(ccall((:GDALDEMProcessingOptionsFree, libgdal), Cvoid, (Ptr{GDALDEMProcessingOptions},), psOptions))
 end
 
 """
@@ -326,7 +326,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdaldemprocessingoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALDEMProcessingOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALDEMProcessingOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALDEMProcessingOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALDEMProcessingOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -351,7 +351,7 @@ Apply a DEM processing.
 the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
 """
 function gdaldemprocessing(pszDestFilename, hSrcDataset, pszProcessing, pszColorFilename, psOptions, pbUsageError)
-    failsafe(ccall((:GDALDEMProcessing, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cstring, Cstring, Ptr{GDALDEMProcessingOptions}, Ptr{Cint}), pszDestFilename, hSrcDataset, pszProcessing, pszColorFilename, psOptions, pbUsageError))
+    aftercare(ccall((:GDALDEMProcessing, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Cstring, Cstring, Ptr{GDALDEMProcessingOptions}, Ptr{Cint}), pszDestFilename, hSrcDataset, pszProcessing, pszColorFilename, psOptions, pbUsageError))
 end
 
 """
@@ -368,7 +368,7 @@ Allocates a GDALNearblackOptions struct.
 pointer to the allocated GDALNearblackOptions struct. Must be freed with GDALNearblackOptionsFree().
 """
 function gdalnearblackoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALNearblackOptionsNew, libgdal), Ptr{GDALNearblackOptions}, (Ptr{Cstring}, Ptr{GDALNearblackOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALNearblackOptionsNew, libgdal), Ptr{GDALNearblackOptions}, (Ptr{Cstring}, Ptr{GDALNearblackOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -380,7 +380,7 @@ Frees the GDALNearblackOptions struct.
 * **psOptions**: the options struct for GDALNearblack().
 """
 function gdalnearblackoptionsfree(psOptions)
-    ccall((:GDALNearblackOptionsFree, libgdal), Cvoid, (Ptr{GDALNearblackOptions},), psOptions)
+    aftercare(ccall((:GDALNearblackOptionsFree, libgdal), Cvoid, (Ptr{GDALNearblackOptions},), psOptions))
 end
 
 """
@@ -396,7 +396,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalnearblackoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALNearblackOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALNearblackOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALNearblackOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALNearblackOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -419,7 +419,7 @@ Convert nearly black/white borders to exact value.
 the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL in case of error.
 """
 function gdalnearblack(pszDest, hDstDS, hSrcDS, psOptions, pbUsageError)
-    failsafe(ccall((:GDALNearblack, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, GDALDatasetH, Ptr{GDALNearblackOptions}, Ptr{Cint}), pszDest, hDstDS, hSrcDS, psOptions, pbUsageError))
+    aftercare(ccall((:GDALNearblack, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, GDALDatasetH, Ptr{GDALNearblackOptions}, Ptr{Cint}), pszDest, hDstDS, hSrcDS, psOptions, pbUsageError))
 end
 
 """
@@ -436,7 +436,7 @@ Allocates a GDALGridOptions struct.
 pointer to the allocated GDALGridOptions struct. Must be freed with GDALGridOptionsFree().
 """
 function gdalgridoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALGridOptionsNew, libgdal), Ptr{GDALGridOptions}, (Ptr{Cstring}, Ptr{GDALGridOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALGridOptionsNew, libgdal), Ptr{GDALGridOptions}, (Ptr{Cstring}, Ptr{GDALGridOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -448,7 +448,7 @@ Frees the GDALGridOptions struct.
 * **psOptions**: the options struct for GDALGrid().
 """
 function gdalgridoptionsfree(psOptions)
-    ccall((:GDALGridOptionsFree, libgdal), Cvoid, (Ptr{GDALGridOptions},), psOptions)
+    aftercare(ccall((:GDALGridOptionsFree, libgdal), Cvoid, (Ptr{GDALGridOptions},), psOptions))
 end
 
 """
@@ -464,7 +464,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalgridoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALGridOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALGridOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALGridOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALGridOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -485,7 +485,7 @@ Create raster from the scattered data.
 the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
 """
 function gdalgrid(pszDest, hSrcDS, psOptions, pbUsageError)
-    failsafe(ccall((:GDALGrid, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Ptr{GDALGridOptions}, Ptr{Cint}), pszDest, hSrcDS, psOptions, pbUsageError))
+    aftercare(ccall((:GDALGrid, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, Ptr{GDALGridOptions}, Ptr{Cint}), pszDest, hSrcDS, psOptions, pbUsageError))
 end
 
 """
@@ -502,7 +502,7 @@ Allocates a GDALRasterizeOptions struct.
 pointer to the allocated GDALRasterizeOptions struct. Must be freed with GDALRasterizeOptionsFree().
 """
 function gdalrasterizeoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALRasterizeOptionsNew, libgdal), Ptr{GDALRasterizeOptions}, (Ptr{Cstring}, Ptr{GDALRasterizeOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALRasterizeOptionsNew, libgdal), Ptr{GDALRasterizeOptions}, (Ptr{Cstring}, Ptr{GDALRasterizeOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -514,7 +514,7 @@ Frees the GDALRasterizeOptions struct.
 * **psOptions**: the options struct for GDALRasterize().
 """
 function gdalrasterizeoptionsfree(psOptions)
-    ccall((:GDALRasterizeOptionsFree, libgdal), Cvoid, (Ptr{GDALRasterizeOptions},), psOptions)
+    aftercare(ccall((:GDALRasterizeOptionsFree, libgdal), Cvoid, (Ptr{GDALRasterizeOptions},), psOptions))
 end
 
 """
@@ -530,7 +530,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalrasterizeoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALRasterizeOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALRasterizeOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALRasterizeOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALRasterizeOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -553,7 +553,7 @@ Burns vector geometries into a raster.
 the output dataset (new dataset that must be closed using GDALClose(), or hDstDS is not NULL) or NULL in case of error.
 """
 function gdalrasterize(pszDest, hDstDS, hSrcDS, psOptions, pbUsageError)
-    failsafe(ccall((:GDALRasterize, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, GDALDatasetH, Ptr{GDALRasterizeOptions}, Ptr{Cint}), pszDest, hDstDS, hSrcDS, psOptions, pbUsageError))
+    aftercare(ccall((:GDALRasterize, libgdal), GDALDatasetH, (Cstring, GDALDatasetH, GDALDatasetH, Ptr{GDALRasterizeOptions}, Ptr{Cint}), pszDest, hDstDS, hSrcDS, psOptions, pbUsageError))
 end
 
 """
@@ -570,7 +570,7 @@ Allocates a GDALBuildVRTOptions struct.
 pointer to the allocated GDALBuildVRTOptions struct. Must be freed with GDALBuildVRTOptionsFree().
 """
 function gdalbuildvrtoptionsnew(papszArgv, psOptionsForBinary)
-    failsafe(ccall((:GDALBuildVRTOptionsNew, libgdal), Ptr{GDALBuildVRTOptions}, (Ptr{Cstring}, Ptr{GDALBuildVRTOptionsForBinary}), papszArgv, psOptionsForBinary))
+    aftercare(ccall((:GDALBuildVRTOptionsNew, libgdal), Ptr{GDALBuildVRTOptions}, (Ptr{Cstring}, Ptr{GDALBuildVRTOptionsForBinary}), papszArgv, psOptionsForBinary))
 end
 
 """
@@ -582,7 +582,7 @@ Frees the GDALBuildVRTOptions struct.
 * **psOptions**: the options struct for GDALBuildVRT().
 """
 function gdalbuildvrtoptionsfree(psOptions)
-    ccall((:GDALBuildVRTOptionsFree, libgdal), Cvoid, (Ptr{GDALBuildVRTOptions},), psOptions)
+    aftercare(ccall((:GDALBuildVRTOptionsFree, libgdal), Cvoid, (Ptr{GDALBuildVRTOptions},), psOptions))
 end
 
 """
@@ -598,7 +598,7 @@ Set a progress function.
 * **pProgressData**: the user data for the progress callback.
 """
 function gdalbuildvrtoptionssetprogress(psOptions, pfnProgress, pProgressData)
-    ccall((:GDALBuildVRTOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALBuildVRTOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData)
+    aftercare(ccall((:GDALBuildVRTOptionsSetProgress, libgdal), Cvoid, (Ptr{GDALBuildVRTOptions}, GDALProgressFunc, Ptr{Cvoid}), psOptions, pfnProgress, pProgressData))
 end
 
 """
@@ -623,5 +623,5 @@ Build a VRT from a list of datasets.
 the output dataset (new dataset that must be closed using GDALClose()) or NULL in case of error.
 """
 function gdalbuildvrt(pszDest, nSrcCount, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError)
-    failsafe(ccall((:GDALBuildVRT, libgdal), GDALDatasetH, (Cstring, Cint, Ptr{GDALDatasetH}, Ptr{Cstring}, Ptr{GDALBuildVRTOptions}, Ptr{Cint}), pszDest, nSrcCount, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError))
+    aftercare(ccall((:GDALBuildVRT, libgdal), GDALDatasetH, (Cstring, Cint, Ptr{GDALDatasetH}, Ptr{Cstring}, Ptr{GDALBuildVRTOptions}, Ptr{Cint}), pszDest, nSrcCount, pahSrcDS, papszSrcDSNames, psOptions, pbUsageError))
 end

--- a/src/gdal_vrt.jl
+++ b/src/gdal_vrt.jl
@@ -7,14 +7,14 @@
               int nYSize) -> VRTDatasetH
 """
 function vrtcreate(arg1, arg2)
-    failsafe(ccall((:VRTCreate, libgdal), VRTDatasetH, (Cint, Cint), arg1, arg2))
+    aftercare(ccall((:VRTCreate, libgdal), VRTDatasetH, (Cint, Cint), arg1, arg2))
 end
 
 """
     VRTFlushCache(VRTDatasetH hDataset) -> void
 """
 function vrtflushcache(arg1)
-    ccall((:VRTFlushCache, libgdal), Cvoid, (VRTDatasetH,), arg1)
+    aftercare(ccall((:VRTFlushCache, libgdal), Cvoid, (VRTDatasetH,), arg1))
 end
 
 """
@@ -22,7 +22,7 @@ end
                       const char * pszVRTPath) -> CPLXMLNode *
 """
 function vrtserializetoxml(arg1, arg2)
-    ccall((:VRTSerializeToXML, libgdal), Ptr{CPLXMLNode}, (VRTDatasetH, Cstring), arg1, arg2)
+    aftercare(ccall((:VRTSerializeToXML, libgdal), Ptr{CPLXMLNode}, (VRTDatasetH, Cstring), arg1, arg2))
 end
 
 """
@@ -31,7 +31,7 @@ end
                char ** papszOptions) -> int
 """
 function vrtaddband(arg1, arg2, arg3)
-    ccall((:VRTAddBand, libgdal), Cint, (VRTDatasetH, GDALDataType, Ptr{Cstring}), arg1, arg2, arg3)
+    aftercare(ccall((:VRTAddBand, libgdal), Cint, (VRTDatasetH, GDALDataType, Ptr{Cstring}), arg1, arg2, arg3))
 end
 
 """
@@ -39,7 +39,7 @@ end
                  VRTSourceH hNewSource) -> CPLErr
 """
 function vrtaddsource(arg1, arg2)
-    ccall((:VRTAddSource, libgdal), CPLErr, (VRTSourcedRasterBandH, VRTSourceH), arg1, arg2)
+    aftercare(ccall((:VRTAddSource, libgdal), CPLErr, (VRTSourcedRasterBandH, VRTSourceH), arg1, arg2))
 end
 
 """
@@ -57,7 +57,7 @@ end
                        double dfNoDataValue) -> CPLErr
 """
 function vrtaddsimplesource(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
-    ccall((:VRTAddSimpleSource, libgdal), CPLErr, (VRTSourcedRasterBandH, GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cstring, Cdouble), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+    aftercare(ccall((:VRTAddSimpleSource, libgdal), CPLErr, (VRTSourcedRasterBandH, GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cstring, Cdouble), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12))
 end
 
 """
@@ -76,7 +76,7 @@ end
                         double dfNoDataValue) -> CPLErr
 """
 function vrtaddcomplexsource(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
-    ccall((:VRTAddComplexSource, libgdal), CPLErr, (VRTSourcedRasterBandH, GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
+    aftercare(ccall((:VRTAddComplexSource, libgdal), CPLErr, (VRTSourcedRasterBandH, GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13))
 end
 
 """
@@ -86,5 +86,5 @@ end
                      double dfNoDataValue) -> CPLErr
 """
 function vrtaddfuncsource(arg1, arg2, arg3, arg4)
-    ccall((:VRTAddFuncSource, libgdal), CPLErr, (VRTSourcedRasterBandH, VRTImageReadFunc, Ptr{Cvoid}, Cdouble), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:VRTAddFuncSource, libgdal), CPLErr, (VRTSourcedRasterBandH, VRTImageReadFunc, Ptr{Cvoid}, Cdouble), arg1, arg2, arg3, arg4))
 end

--- a/src/gdalwarper.jl
+++ b/src/gdalwarper.jl
@@ -16,7 +16,7 @@
                          int * pbOutAllValid) -> CPLErr
 """
 function gdalwarpnodatamasker(pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, papabyImageData, bMaskIsFloat, pValidityMask, pbOutAllValid)
-    ccall((:GDALWarpNoDataMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}, Ptr{Cint}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, papabyImageData, bMaskIsFloat, pValidityMask, pbOutAllValid)
+    aftercare(ccall((:GDALWarpNoDataMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}, Ptr{Cint}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, papabyImageData, bMaskIsFloat, pValidityMask, pbOutAllValid))
 end
 
 """
@@ -32,7 +32,7 @@ end
                            void * pValidityMask) -> CPLErr
 """
 function gdalwarpdstalphamasker(pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
-    ccall((:GDALWarpDstAlphaMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
+    aftercare(ccall((:GDALWarpDstAlphaMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask))
 end
 
 """
@@ -49,7 +49,7 @@ end
                            int * pbOutAllOpaque) -> CPLErr
 """
 function gdalwarpsrcalphamasker(pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask, pbOutAllOpaque)
-    ccall((:GDALWarpSrcAlphaMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}, Ptr{Cint}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask, pbOutAllOpaque)
+    aftercare(ccall((:GDALWarpSrcAlphaMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}, Ptr{Cint}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask, pbOutAllOpaque))
 end
 
 """
@@ -65,7 +65,7 @@ end
                           void * pValidityMask) -> CPLErr
 """
 function gdalwarpsrcmaskmasker(pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
-    ccall((:GDALWarpSrcMaskMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
+    aftercare(ccall((:GDALWarpSrcMaskMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask))
 end
 
 """
@@ -81,7 +81,7 @@ end
                           void * pValidityMask) -> CPLErr
 """
 function gdalwarpcutlinemasker(pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
-    ccall((:GDALWarpCutlineMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask)
+    aftercare(ccall((:GDALWarpCutlineMasker, libgdal), CPLErr, (Ptr{Cvoid}, Cint, GDALDataType, Cint, Cint, Cint, Cint, Ptr{Ptr{GByte}}, Cint, Ptr{Cvoid}), pMaskFuncArg, nBandCount, eType, nXOff, nYOff, nXSize, nYSize, arg1, bMaskIsFloat, pValidityMask))
 end
 
 """
@@ -90,7 +90,7 @@ end
 Create a warp options structure.
 """
 function gdalcreatewarpoptions()
-    ccall((:GDALCreateWarpOptions, libgdal), Ptr{GDALWarpOptions}, ())
+    aftercare(ccall((:GDALCreateWarpOptions, libgdal), Ptr{GDALWarpOptions}, ()))
 end
 
 """
@@ -99,7 +99,7 @@ end
 Destroy a warp options structure.
 """
 function gdaldestroywarpoptions(arg1)
-    ccall((:GDALDestroyWarpOptions, libgdal), Cvoid, (Ptr{GDALWarpOptions},), arg1)
+    aftercare(ccall((:GDALDestroyWarpOptions, libgdal), Cvoid, (Ptr{GDALWarpOptions},), arg1))
 end
 
 """
@@ -108,7 +108,7 @@ end
 Clone a warp options structure.
 """
 function gdalclonewarpoptions(arg1)
-    ccall((:GDALCloneWarpOptions, libgdal), Ptr{GDALWarpOptions}, (Ptr{GDALWarpOptions},), arg1)
+    aftercare(ccall((:GDALCloneWarpOptions, libgdal), Ptr{GDALWarpOptions}, (Ptr{GDALWarpOptions},), arg1))
 end
 
 """
@@ -122,7 +122,7 @@ Initialize padfDstNoDataReal with specified value.
 * **dNoDataReal**: value to initialize to.
 """
 function gdalwarpinitdstnodatareal(arg1, dNoDataReal)
-    ccall((:GDALWarpInitDstNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal)
+    aftercare(ccall((:GDALWarpInitDstNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal))
 end
 
 """
@@ -136,7 +136,7 @@ Initialize padfSrcNoDataReal with specified value.
 * **dNoDataReal**: value to initialize to.
 """
 function gdalwarpinitsrcnodatareal(arg1, dNoDataReal)
-    ccall((:GDALWarpInitSrcNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal)
+    aftercare(ccall((:GDALWarpInitSrcNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal))
 end
 
 """
@@ -150,7 +150,7 @@ Initialize padfSrcNoDataReal and padfDstNoDataReal with specified value.
 * **dNoDataReal**: value to initialize to.
 """
 function gdalwarpinitnodatareal(arg1, dNoDataReal)
-    ccall((:GDALWarpInitNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal)
+    aftercare(ccall((:GDALWarpInitNoDataReal, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataReal))
 end
 
 """
@@ -164,7 +164,7 @@ Initialize padfDstNoDataImag with specified value.
 * **dNoDataImag**: value to initialize to.
 """
 function gdalwarpinitdstnodataimag(arg1, dNoDataImag)
-    ccall((:GDALWarpInitDstNoDataImag, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataImag)
+    aftercare(ccall((:GDALWarpInitDstNoDataImag, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataImag))
 end
 
 """
@@ -178,7 +178,7 @@ Initialize padfSrcNoDataImag with specified value.
 * **dNoDataImag**: value to initialize to.
 """
 function gdalwarpinitsrcnodataimag(arg1, dNoDataImag)
-    ccall((:GDALWarpInitSrcNoDataImag, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataImag)
+    aftercare(ccall((:GDALWarpInitSrcNoDataImag, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cdouble), arg1, dNoDataImag))
 end
 
 """
@@ -190,7 +190,7 @@ If the working data type is unknown, this method will determine a valid working 
 * **psOptions**: options to initialize.
 """
 function gdalwarpresolveworkingdatatype(arg1)
-    ccall((:GDALWarpResolveWorkingDataType, libgdal), Cvoid, (Ptr{GDALWarpOptions},), arg1)
+    aftercare(ccall((:GDALWarpResolveWorkingDataType, libgdal), Cvoid, (Ptr{GDALWarpOptions},), arg1))
 end
 
 """
@@ -204,21 +204,21 @@ Init src and dst band mappings such that Bands[i] = i+1 for nBandCount Does noth
 * **nBandCount**: bands to initialize for.
 """
 function gdalwarpinitdefaultbandmapping(arg1, nBandCount)
-    ccall((:GDALWarpInitDefaultBandMapping, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cint), arg1, nBandCount)
+    aftercare(ccall((:GDALWarpInitDefaultBandMapping, libgdal), Cvoid, (Ptr{GDALWarpOptions}, Cint), arg1, nBandCount))
 end
 
 """
     GDALSerializeWarpOptions(const GDALWarpOptions * psWO) -> CPLXMLNode *
 """
 function gdalserializewarpoptions(arg1)
-    ccall((:GDALSerializeWarpOptions, libgdal), Ptr{CPLXMLNode}, (Ptr{GDALWarpOptions},), arg1)
+    aftercare(ccall((:GDALSerializeWarpOptions, libgdal), Ptr{CPLXMLNode}, (Ptr{GDALWarpOptions},), arg1))
 end
 
 """
     GDALDeserializeWarpOptions(CPLXMLNode * psTree) -> GDALWarpOptions *
 """
 function gdaldeserializewarpoptions(arg1)
-    ccall((:GDALDeserializeWarpOptions, libgdal), Ptr{GDALWarpOptions}, (Ptr{CPLXMLNode},), arg1)
+    aftercare(ccall((:GDALDeserializeWarpOptions, libgdal), Ptr{GDALWarpOptions}, (Ptr{CPLXMLNode},), arg1))
 end
 
 """
@@ -251,7 +251,7 @@ Reproject image.
 CE_None on success or CE_Failure if something goes wrong.
 """
 function gdalreprojectimage(hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions)
-    ccall((:GDALReprojectImage, libgdal), CPLErr, (GDALDatasetH, Cstring, GDALDatasetH, Cstring, GDALResampleAlg, Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions)
+    aftercare(ccall((:GDALReprojectImage, libgdal), CPLErr, (GDALDatasetH, Cstring, GDALDatasetH, Cstring, GDALResampleAlg, Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions))
 end
 
 """
@@ -271,7 +271,7 @@ end
 Reproject an image and create the target reprojected image.
 """
 function gdalcreateandreprojectimage(hSrcDS, pszSrcWKT, pszDstFilename, pszDstWKT, hDstDriver, papszCreateOptions, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions)
-    ccall((:GDALCreateAndReprojectImage, libgdal), CPLErr, (GDALDatasetH, Cstring, Cstring, Cstring, GDALDriverH, Ptr{Cstring}, GDALResampleAlg, Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, pszDstFilename, pszDstWKT, hDstDriver, papszCreateOptions, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions)
+    aftercare(ccall((:GDALCreateAndReprojectImage, libgdal), CPLErr, (GDALDatasetH, Cstring, Cstring, Cstring, GDALDriverH, Ptr{Cstring}, GDALResampleAlg, Cdouble, Cdouble, GDALProgressFunc, Ptr{Cvoid}, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, pszDstFilename, pszDstWKT, hDstDriver, papszCreateOptions, eResampleAlg, dfWarpMemoryLimit, dfMaxError, pfnProgress, pProgressArg, psOptions))
 end
 
 """
@@ -296,7 +296,7 @@ Create virtual warped dataset automatically.
 NULL on failure, or a new virtual dataset handle on success.
 """
 function gdalautocreatewarpedvrt(hSrcDS, pszSrcWKT, pszDstWKT, eResampleAlg, dfMaxError, psOptions)
-    failsafe(ccall((:GDALAutoCreateWarpedVRT, libgdal), GDALDatasetH, (GDALDatasetH, Cstring, Cstring, GDALResampleAlg, Cdouble, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, pszDstWKT, eResampleAlg, dfMaxError, psOptions))
+    aftercare(ccall((:GDALAutoCreateWarpedVRT, libgdal), GDALDatasetH, (GDALDatasetH, Cstring, Cstring, GDALResampleAlg, Cdouble, Ptr{GDALWarpOptions}), hSrcDS, pszSrcWKT, pszDstWKT, eResampleAlg, dfMaxError, psOptions))
 end
 
 """
@@ -319,7 +319,7 @@ Create virtual warped dataset.
 NULL on failure, or a new virtual dataset handle on success.
 """
 function gdalcreatewarpedvrt(hSrcDS, nPixels, nLines, padfGeoTransform, psOptions)
-    failsafe(ccall((:GDALCreateWarpedVRT, libgdal), GDALDatasetH, (GDALDatasetH, Cint, Cint, Ptr{Cdouble}, Ptr{GDALWarpOptions}), hSrcDS, nPixels, nLines, padfGeoTransform, psOptions))
+    aftercare(ccall((:GDALCreateWarpedVRT, libgdal), GDALDatasetH, (GDALDatasetH, Cint, Cint, Ptr{Cdouble}, Ptr{GDALWarpOptions}), hSrcDS, nPixels, nLines, padfGeoTransform, psOptions))
 end
 
 """
@@ -336,21 +336,21 @@ Set warp info on virtual warped dataset.
 CE_None on success or CE_Failure if an error occurs.
 """
 function gdalinitializewarpedvrt(hDS, psWO)
-    ccall((:GDALInitializeWarpedVRT, libgdal), CPLErr, (GDALDatasetH, Ptr{GDALWarpOptions}), hDS, psWO)
+    aftercare(ccall((:GDALInitializeWarpedVRT, libgdal), CPLErr, (GDALDatasetH, Ptr{GDALWarpOptions}), hDS, psWO))
 end
 
 """
     GDALCreateWarpOperation(const GDALWarpOptions * psNewOptions) -> GDALWarpOperationH
 """
 function gdalcreatewarpoperation(arg1)
-    failsafe(ccall((:GDALCreateWarpOperation, libgdal), GDALWarpOperationH, (Ptr{GDALWarpOptions},), arg1))
+    aftercare(ccall((:GDALCreateWarpOperation, libgdal), GDALWarpOperationH, (Ptr{GDALWarpOptions},), arg1))
 end
 
 """
     GDALDestroyWarpOperation(GDALWarpOperationH hOperation) -> void
 """
 function gdaldestroywarpoperation(arg1)
-    ccall((:GDALDestroyWarpOperation, libgdal), Cvoid, (GDALWarpOperationH,), arg1)
+    aftercare(ccall((:GDALDestroyWarpOperation, libgdal), Cvoid, (GDALWarpOperationH,), arg1))
 end
 
 """
@@ -361,7 +361,7 @@ end
                           int nDstYSize) -> CPLErr
 """
 function gdalchunkandwarpimage(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALChunkAndWarpImage, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALChunkAndWarpImage, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -372,7 +372,7 @@ end
                           int nDstYSize) -> CPLErr
 """
 function gdalchunkandwarpmulti(arg1, arg2, arg3, arg4, arg5)
-    ccall((:GDALChunkAndWarpMulti, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:GDALChunkAndWarpMulti, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -387,7 +387,7 @@ end
                    int nSrcYSize) -> CPLErr
 """
 function gdalwarpregion(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    ccall((:GDALWarpRegion, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    aftercare(ccall((:GDALWarpRegion, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
 end
 
 """
@@ -404,26 +404,26 @@ end
                            int nSrcYSize) -> CPLErr
 """
 function gdalwarpregiontobuffer(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
-    ccall((:GDALWarpRegionToBuffer, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint, Ptr{Cvoid}, GDALDataType, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
+    aftercare(ccall((:GDALWarpRegionToBuffer, libgdal), CPLErr, (GDALWarpOperationH, Cint, Cint, Cint, Cint, Ptr{Cvoid}, GDALDataType, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11))
 end
 
 """
     GWKGetFilterRadius(GDALResampleAlg eResampleAlg) -> int
 """
 function gwkgetfilterradius(eResampleAlg)
-    ccall((:GWKGetFilterRadius, libgdal), Cint, (GDALResampleAlg,), eResampleAlg)
+    aftercare(ccall((:GWKGetFilterRadius, libgdal), Cint, (GDALResampleAlg,), eResampleAlg))
 end
 
 """
     GWKGetFilterFunc(GDALResampleAlg eResampleAlg) -> FilterFuncType
 """
 function gwkgetfilterfunc(eResampleAlg)
-    failsafe(ccall((:GWKGetFilterFunc, libgdal), FilterFuncType, (GDALResampleAlg,), eResampleAlg))
+    aftercare(ccall((:GWKGetFilterFunc, libgdal), FilterFuncType, (GDALResampleAlg,), eResampleAlg))
 end
 
 """
     GWKGetFilterFunc4Values(GDALResampleAlg eResampleAlg) -> FilterFunc4ValuesType
 """
 function gwkgetfilterfunc4values(eResampleAlg)
-    failsafe(ccall((:GWKGetFilterFunc4Values, libgdal), FilterFunc4ValuesType, (GDALResampleAlg,), eResampleAlg))
+    aftercare(ccall((:GWKGetFilterFunc4Values, libgdal), FilterFunc4ValuesType, (GDALResampleAlg,), eResampleAlg))
 end

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -20,7 +20,7 @@ Create a geometry object of the appropriate type from its well known binary repr
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function ogr_g_createfromwkb(arg1, arg2, arg3, arg4)
-    ccall((:OGR_G_CreateFromWkb, libgdal), OGRErr, (Ptr{Cvoid}, OGRSpatialReferenceH, Ptr{OGRGeometryH}, Cint), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_CreateFromWkb, libgdal), OGRErr, (Ptr{Cvoid}, OGRSpatialReferenceH, Ptr{OGRGeometryH}, Cint), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -39,7 +39,7 @@ Create a geometry object of the appropriate type from its well known text repres
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function ogr_g_createfromwkt(arg1, arg2, arg3)
-    ccall((:OGR_G_CreateFromWkt, libgdal), OGRErr, (Ptr{Cstring}, OGRSpatialReferenceH, Ptr{OGRGeometryH}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_CreateFromWkt, libgdal), OGRErr, (Ptr{Cstring}, OGRSpatialReferenceH, Ptr{OGRGeometryH}), arg1, arg2, arg3))
 end
 
 """
@@ -52,7 +52,7 @@ end
 Create a geometry object of the appropriate type from its FGF (FDO Geometry Format) binary representation.
 """
 function ogr_g_createfromfgf(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OGR_G_CreateFromFgf, libgdal), OGRErr, (Ptr{Cvoid}, OGRSpatialReferenceH, Ptr{OGRGeometryH}, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OGR_G_CreateFromFgf, libgdal), OGRErr, (Ptr{Cvoid}, OGRSpatialReferenceH, Ptr{OGRGeometryH}, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -64,7 +64,7 @@ Destroy geometry object.
 * **hGeom**: handle to the geometry to delete.
 """
 function ogr_g_destroygeometry(arg1)
-    ccall((:OGR_G_DestroyGeometry, libgdal), Cvoid, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_DestroyGeometry, libgdal), Cvoid, (OGRGeometryH,), arg1))
 end
 
 """
@@ -79,7 +79,7 @@ Create an empty geometry of desired type.
 handle to the newly create geometry or NULL on failure. Should be freed with OGR_G_DestroyGeometry() after use.
 """
 function ogr_g_creategeometry(arg1)
-    failsafe(ccall((:OGR_G_CreateGeometry, libgdal), OGRGeometryH, (OGRwkbGeometryType,), arg1))
+    aftercare(ccall((:OGR_G_CreateGeometry, libgdal), OGRGeometryH, (OGRwkbGeometryType,), arg1))
 end
 
 """
@@ -110,7 +110,7 @@ Stroke arc to linestring.
 OGRLineString geometry representing an approximation of the arc.
 """
 function ogr_g_approximatearcangles(dfCenterX, dfCenterY, dfZ, dfPrimaryRadius, dfSecondaryAxis, dfRotation, dfStartAngle, dfEndAngle, dfMaxAngleStepSizeDegrees)
-    failsafe(ccall((:OGR_G_ApproximateArcAngles, libgdal), OGRGeometryH, (Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), dfCenterX, dfCenterY, dfZ, dfPrimaryRadius, dfSecondaryAxis, dfRotation, dfStartAngle, dfEndAngle, dfMaxAngleStepSizeDegrees))
+    aftercare(ccall((:OGR_G_ApproximateArcAngles, libgdal), OGRGeometryH, (Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), dfCenterX, dfCenterY, dfZ, dfPrimaryRadius, dfSecondaryAxis, dfRotation, dfStartAngle, dfEndAngle, dfMaxAngleStepSizeDegrees))
 end
 
 """
@@ -125,7 +125,7 @@ Convert to polygon.
 the converted geometry (ownership to caller).
 """
 function ogr_g_forcetopolygon(arg1)
-    failsafe(ccall((:OGR_G_ForceToPolygon, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ForceToPolygon, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -140,7 +140,7 @@ Convert to line string.
 the converted geometry (ownership to caller).
 """
 function ogr_g_forcetolinestring(arg1)
-    failsafe(ccall((:OGR_G_ForceToLineString, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ForceToLineString, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -155,7 +155,7 @@ Convert to multipolygon.
 the converted geometry (ownership to caller).
 """
 function ogr_g_forcetomultipolygon(arg1)
-    failsafe(ccall((:OGR_G_ForceToMultiPolygon, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ForceToMultiPolygon, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -170,7 +170,7 @@ Convert to multipoint.
 the converted geometry (ownership to caller).
 """
 function ogr_g_forcetomultipoint(arg1)
-    failsafe(ccall((:OGR_G_ForceToMultiPoint, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ForceToMultiPoint, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -185,7 +185,7 @@ Convert to multilinestring.
 the converted geometry (ownership to caller).
 """
 function ogr_g_forcetomultilinestring(arg1)
-    failsafe(ccall((:OGR_G_ForceToMultiLineString, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ForceToMultiLineString, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -204,7 +204,7 @@ Convert to another geometry type.
 new geometry.
 """
 function ogr_g_forceto(hGeom, eTargetType, papszOptions)
-    failsafe(ccall((:OGR_G_ForceTo, libgdal), OGRGeometryH, (OGRGeometryH, OGRwkbGeometryType, Ptr{Cstring}), hGeom, eTargetType, papszOptions))
+    aftercare(ccall((:OGR_G_ForceTo, libgdal), OGRGeometryH, (OGRGeometryH, OGRwkbGeometryType, Ptr{Cstring}), hGeom, eTargetType, papszOptions))
 end
 
 """
@@ -219,7 +219,7 @@ Get the dimension of this geometry.
 0 for points, 1 for lines and 2 for surfaces.
 """
 function ogr_g_getdimension(arg1)
-    ccall((:OGR_G_GetDimension, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetDimension, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -234,7 +234,7 @@ Get the dimension of the coordinates in this geometry.
 this will return 2 or 3.
 """
 function ogr_g_getcoordinatedimension(arg1)
-    ccall((:OGR_G_GetCoordinateDimension, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetCoordinateDimension, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -249,7 +249,7 @@ Get the dimension of the coordinates in this geometry.
 this will return 2 for XY, 3 for XYZ and XYM, and 4 for XYZM data.
 """
 function ogr_g_coordinatedimension(arg1)
-    ccall((:OGR_G_CoordinateDimension, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_CoordinateDimension, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -263,7 +263,7 @@ Set the coordinate dimension.
 * **nNewDimension**: New coordinate dimension value, either 2 or 3.
 """
 function ogr_g_setcoordinatedimension(arg1, arg2)
-    ccall((:OGR_G_SetCoordinateDimension, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_SetCoordinateDimension, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -278,7 +278,7 @@ See whether this geometry has Z coordinates.
 TRUE if the geometry has Z coordinates.
 """
 function ogr_g_is3d(arg1)
-    ccall((:OGR_G_Is3D, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_Is3D, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -293,7 +293,7 @@ See whether this geometry is measured.
 TRUE if the geometry has M coordinates.
 """
 function ogr_g_ismeasured(arg1)
-    ccall((:OGR_G_IsMeasured, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_IsMeasured, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -307,7 +307,7 @@ Add or remove the Z coordinate dimension.
 * **bIs3D**: Should the geometry have a Z dimension, either TRUE or FALSE.
 """
 function ogr_g_set3d(arg1, arg2)
-    ccall((:OGR_G_Set3D, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_Set3D, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -321,7 +321,7 @@ Add or remove the M coordinate dimension.
 * **bIsMeasured**: Should the geometry have a M dimension, either TRUE or FALSE.
 """
 function ogr_g_setmeasured(arg1, arg2)
-    ccall((:OGR_G_SetMeasured, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_SetMeasured, libgdal), Cvoid, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -336,7 +336,7 @@ Make a copy of this object.
 an handle on the copy of the geometry with the spatial reference system as the original.
 """
 function ogr_g_clone(arg1)
-    failsafe(ccall((:OGR_G_Clone, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_Clone, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -350,7 +350,7 @@ Computes and returns the bounding envelope for this geometry in the passed psEnv
 * **psEnvelope**: the structure in which to place the results.
 """
 function ogr_g_getenvelope(arg1, arg2)
-    ccall((:OGR_G_GetEnvelope, libgdal), Cvoid, (OGRGeometryH, Ptr{OGREnvelope}), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetEnvelope, libgdal), Cvoid, (OGRGeometryH, Ptr{OGREnvelope}), arg1, arg2))
 end
 
 """
@@ -364,7 +364,7 @@ Computes and returns the bounding envelope (3D) for this geometry in the passed 
 * **psEnvelope**: the structure in which to place the results.
 """
 function ogr_g_getenvelope3d(arg1, arg2)
-    ccall((:OGR_G_GetEnvelope3D, libgdal), Cvoid, (OGRGeometryH, Ptr{OGREnvelope3D}), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetEnvelope3D, libgdal), Cvoid, (OGRGeometryH, Ptr{OGREnvelope3D}), arg1, arg2))
 end
 
 """
@@ -383,7 +383,7 @@ Assign geometry from well known binary data.
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function ogr_g_importfromwkb(arg1, arg2, arg3)
-    ccall((:OGR_G_ImportFromWkb, libgdal), OGRErr, (OGRGeometryH, Ptr{Cvoid}, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_ImportFromWkb, libgdal), OGRErr, (OGRGeometryH, Ptr{Cvoid}, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -402,7 +402,7 @@ Convert a geometry well known binary format.
 Currently OGRERR_NONE is always returned.
 """
 function ogr_g_exporttowkb(arg1, arg2, arg3)
-    ccall((:OGR_G_ExportToWkb, libgdal), OGRErr, (OGRGeometryH, OGRwkbByteOrder, Ptr{Cuchar}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_ExportToWkb, libgdal), OGRErr, (OGRGeometryH, OGRwkbByteOrder, Ptr{Cuchar}), arg1, arg2, arg3))
 end
 
 """
@@ -421,7 +421,7 @@ Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known binary format.
 Currently OGRERR_NONE is always returned.
 """
 function ogr_g_exporttoisowkb(arg1, arg2, arg3)
-    ccall((:OGR_G_ExportToIsoWkb, libgdal), OGRErr, (OGRGeometryH, OGRwkbByteOrder, Ptr{Cuchar}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_ExportToIsoWkb, libgdal), OGRErr, (OGRGeometryH, OGRwkbByteOrder, Ptr{Cuchar}), arg1, arg2, arg3))
 end
 
 """
@@ -436,7 +436,7 @@ Returns size of related binary representation.
 size of binary representation in bytes.
 """
 function ogr_g_wkbsize(hGeom)
-    ccall((:OGR_G_WkbSize, libgdal), Cint, (OGRGeometryH,), hGeom)
+    aftercare(ccall((:OGR_G_WkbSize, libgdal), Cint, (OGRGeometryH,), hGeom))
 end
 
 """
@@ -453,7 +453,7 @@ Assign geometry from well known text data.
 OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
 """
 function ogr_g_importfromwkt(arg1, arg2)
-    ccall((:OGR_G_ImportFromWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OGR_G_ImportFromWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -470,7 +470,7 @@ Convert a geometry into well known text format.
 Currently OGRERR_NONE is always returned.
 """
 function ogr_g_exporttowkt(arg1, arg2)
-    ccall((:OGR_G_ExportToWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OGR_G_ExportToWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -487,7 +487,7 @@ Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
 Currently OGRERR_NONE is always returned.
 """
 function ogr_g_exporttoisowkt(arg1, arg2)
-    ccall((:OGR_G_ExportToIsoWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OGR_G_ExportToIsoWkt, libgdal), OGRErr, (OGRGeometryH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -502,7 +502,7 @@ Fetch geometry type.
 the geometry type code.
 """
 function ogr_g_getgeometrytype(arg1)
-    ccall((:OGR_G_GetGeometryType, libgdal), OGRwkbGeometryType, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetGeometryType, libgdal), OGRwkbGeometryType, (OGRGeometryH,), arg1))
 end
 
 """
@@ -517,7 +517,7 @@ Fetch WKT name for geometry type.
 name used for this geometry type in well known text format.
 """
 function ogr_g_getgeometryname(arg1)
-    string_or_nothing(ccall((:OGR_G_GetGeometryName, libgdal), Cstring, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_GetGeometryName, libgdal), Cstring, (OGRGeometryH,), arg1), false)
 end
 
 """
@@ -533,7 +533,7 @@ Dump geometry in well known text format to indicated output file.
 * **pszPrefix**: the prefix to put on each line of output.
 """
 function ogr_g_dumpreadable(arg1, arg2, arg3)
-    ccall((:OGR_G_DumpReadable, libgdal), Cvoid, (OGRGeometryH, Ptr{Cint}, Cstring), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_DumpReadable, libgdal), Cvoid, (OGRGeometryH, Ptr{Cint}, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -545,7 +545,7 @@ Convert geometry to strictly 2D.
 * **hGeom**: handle on the geometry to convert.
 """
 function ogr_g_flattento2d(arg1)
-    ccall((:OGR_G_FlattenTo2D, libgdal), Cvoid, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_FlattenTo2D, libgdal), Cvoid, (OGRGeometryH,), arg1))
 end
 
 """
@@ -557,7 +557,7 @@ Force rings to be closed.
 * **hGeom**: handle to the geometry.
 """
 function ogr_g_closerings(arg1)
-    ccall((:OGR_G_CloseRings, libgdal), Cvoid, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_CloseRings, libgdal), Cvoid, (OGRGeometryH,), arg1))
 end
 
 """
@@ -572,7 +572,7 @@ Create geometry from GML.
 a geometry on success, or NULL on error.
 """
 function ogr_g_createfromgml(arg1)
-    failsafe(ccall((:OGR_G_CreateFromGML, libgdal), OGRGeometryH, (Cstring,), arg1))
+    aftercare(ccall((:OGR_G_CreateFromGML, libgdal), OGRGeometryH, (Cstring,), arg1))
 end
 
 """
@@ -587,7 +587,7 @@ Convert a geometry into GML format.
 A GML fragment or NULL in case of error.
 """
 function ogr_g_exporttogml(arg1)
-    string_or_nothing(ccall((:OGR_G_ExportToGML, libgdal), Cstring, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ExportToGML, libgdal), Cstring, (OGRGeometryH,), arg1), false)
 end
 
 """
@@ -604,7 +604,7 @@ Convert a geometry into GML format.
 A GML fragment or NULL in case of error.
 """
 function ogr_g_exporttogmlex(arg1, papszOptions)
-    string_or_nothing(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
+    aftercare(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions), false)
 end
 
 """
@@ -613,7 +613,7 @@ end
 Create geometry from GML.
 """
 function ogr_g_createfromgmltree(arg1)
-    failsafe(ccall((:OGR_G_CreateFromGMLTree, libgdal), OGRGeometryH, (Ptr{CPLXMLNode},), arg1))
+    aftercare(ccall((:OGR_G_CreateFromGMLTree, libgdal), OGRGeometryH, (Ptr{CPLXMLNode},), arg1))
 end
 
 """
@@ -622,7 +622,7 @@ end
 Convert a geometry into GML format.
 """
 function ogr_g_exporttogmltree(arg1)
-    ccall((:OGR_G_ExportToGMLTree, libgdal), Ptr{CPLXMLNode}, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_ExportToGMLTree, libgdal), Ptr{CPLXMLNode}, (OGRGeometryH,), arg1))
 end
 
 """
@@ -631,7 +631,7 @@ end
 Export the envelope of a geometry as a gml:Box.
 """
 function ogr_g_exportenvelopetogmltree(arg1)
-    ccall((:OGR_G_ExportEnvelopeToGMLTree, libgdal), Ptr{CPLXMLNode}, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_ExportEnvelopeToGMLTree, libgdal), Ptr{CPLXMLNode}, (OGRGeometryH,), arg1))
 end
 
 """
@@ -648,7 +648,7 @@ Convert a geometry into KML format.
 A KML fragment or NULL in case of error.
 """
 function ogr_g_exporttokml(arg1, pszAltitudeMode)
-    string_or_nothing(ccall((:OGR_G_ExportToKML, libgdal), Cstring, (OGRGeometryH, Cstring), arg1, pszAltitudeMode))
+    aftercare(ccall((:OGR_G_ExportToKML, libgdal), Cstring, (OGRGeometryH, Cstring), arg1, pszAltitudeMode), false)
 end
 
 """
@@ -663,7 +663,7 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 function ogr_g_exporttojson(arg1)
-    string_or_nothing(ccall((:OGR_G_ExportToJson, libgdal), Cstring, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ExportToJson, libgdal), Cstring, (OGRGeometryH,), arg1), false)
 end
 
 """
@@ -680,7 +680,7 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 function ogr_g_exporttojsonex(arg1, papszOptions)
-    string_or_nothing(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
+    aftercare(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions), false)
 end
 
 """
@@ -689,7 +689,7 @@ end
 Create a OGR geometry from a GeoJSON geometry object.
 """
 function ogr_g_creategeometryfromjson(arg1)
-    failsafe(ccall((:OGR_G_CreateGeometryFromJson, libgdal), OGRGeometryH, (Cstring,), arg1))
+    aftercare(ccall((:OGR_G_CreateGeometryFromJson, libgdal), OGRGeometryH, (Cstring,), arg1))
 end
 
 """
@@ -703,7 +703,7 @@ Assign spatial reference to this object.
 * **hSRS**: handle on the new spatial reference system to apply.
 """
 function ogr_g_assignspatialreference(arg1, arg2)
-    ccall((:OGR_G_AssignSpatialReference, libgdal), Cvoid, (OGRGeometryH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:OGR_G_AssignSpatialReference, libgdal), Cvoid, (OGRGeometryH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -718,7 +718,7 @@ Returns spatial reference system for geometry.
 a reference to the spatial reference geometry.
 """
 function ogr_g_getspatialreference(arg1)
-    failsafe(ccall((:OGR_G_GetSpatialReference, libgdal), OGRSpatialReferenceH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_GetSpatialReference, libgdal), OGRSpatialReferenceH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -735,7 +735,7 @@ Apply arbitrary coordinate transformation to geometry.
 OGRERR_NONE on success or an error code.
 """
 function ogr_g_transform(arg1, arg2)
-    ccall((:OGR_G_Transform, libgdal), OGRErr, (OGRGeometryH, OGRCoordinateTransformationH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Transform, libgdal), OGRErr, (OGRGeometryH, OGRCoordinateTransformationH), arg1, arg2))
 end
 
 """
@@ -752,7 +752,7 @@ Transform geometry to new spatial reference system.
 OGRERR_NONE on success, or an error code.
 """
 function ogr_g_transformto(arg1, arg2)
-    ccall((:OGR_G_TransformTo, libgdal), OGRErr, (OGRGeometryH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:OGR_G_TransformTo, libgdal), OGRErr, (OGRGeometryH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -769,7 +769,7 @@ Compute a simplified geometry.
 the simplified geometry or NULL if an error occurs.
 """
 function ogr_g_simplify(hThis, tolerance)
-    failsafe(ccall((:OGR_G_Simplify, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), hThis, tolerance))
+    aftercare(ccall((:OGR_G_Simplify, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), hThis, tolerance))
 end
 
 """
@@ -786,7 +786,7 @@ Simplify the geometry while preserving topology.
 the simplified geometry or NULL if an error occurs.
 """
 function ogr_g_simplifypreservetopology(hThis, tolerance)
-    failsafe(ccall((:OGR_G_SimplifyPreserveTopology, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), hThis, tolerance))
+    aftercare(ccall((:OGR_G_SimplifyPreserveTopology, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), hThis, tolerance))
 end
 
 """
@@ -805,7 +805,7 @@ Return a Delaunay triangulation of the vertices of the geometry.
 the geometry resulting from the Delaunay triangulation or NULL if an error occurs.
 """
 function ogr_g_delaunaytriangulation(hThis, dfTolerance, bOnlyEdges)
-    failsafe(ccall((:OGR_G_DelaunayTriangulation, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Cint), hThis, dfTolerance, bOnlyEdges))
+    aftercare(ccall((:OGR_G_DelaunayTriangulation, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Cint), hThis, dfTolerance, bOnlyEdges))
 end
 
 """
@@ -819,7 +819,7 @@ Modify the geometry such it has no segment longer then the given distance.
 * **dfMaxLength**: the maximum distance between 2 points after segmentization
 """
 function ogr_g_segmentize(hGeom, dfMaxLength)
-    ccall((:OGR_G_Segmentize, libgdal), Cvoid, (OGRGeometryH, Cdouble), hGeom, dfMaxLength)
+    aftercare(ccall((:OGR_G_Segmentize, libgdal), Cvoid, (OGRGeometryH, Cdouble), hGeom, dfMaxLength))
 end
 
 """
@@ -836,7 +836,7 @@ Do these features intersect?
 TRUE if the geometries intersect, otherwise FALSE.
 """
 function ogr_g_intersects(arg1, arg2)
-    ccall((:OGR_G_Intersects, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Intersects, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -853,7 +853,7 @@ Returns TRUE if two geometries are equivalent.
 TRUE if equivalent or FALSE otherwise.
 """
 function ogr_g_equals(arg1, arg2)
-    ccall((:OGR_G_Equals, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Equals, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -870,7 +870,7 @@ Test for disjointness.
 TRUE if they are disjoint, otherwise FALSE.
 """
 function ogr_g_disjoint(arg1, arg2)
-    ccall((:OGR_G_Disjoint, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Disjoint, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -887,7 +887,7 @@ Test for touching.
 TRUE if they are touching, otherwise FALSE.
 """
 function ogr_g_touches(arg1, arg2)
-    ccall((:OGR_G_Touches, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Touches, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -904,7 +904,7 @@ Test for crossing.
 TRUE if they are crossing, otherwise FALSE.
 """
 function ogr_g_crosses(arg1, arg2)
-    ccall((:OGR_G_Crosses, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Crosses, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -921,7 +921,7 @@ Test for containment.
 TRUE if hThis is within hOther, otherwise FALSE.
 """
 function ogr_g_within(arg1, arg2)
-    ccall((:OGR_G_Within, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Within, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -938,7 +938,7 @@ Test for containment.
 TRUE if hThis contains hOther geometry, otherwise FALSE.
 """
 function ogr_g_contains(arg1, arg2)
-    ccall((:OGR_G_Contains, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Contains, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -955,7 +955,7 @@ Test for overlap.
 TRUE if they are overlapping, otherwise FALSE.
 """
 function ogr_g_overlaps(arg1, arg2)
-    ccall((:OGR_G_Overlaps, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Overlaps, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -970,7 +970,7 @@ Compute boundary.
 a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
 """
 function ogr_g_boundary(arg1)
-    failsafe(ccall((:OGR_G_Boundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_Boundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -985,7 +985,7 @@ Compute convex hull.
 a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
 """
 function ogr_g_convexhull(arg1)
-    failsafe(ccall((:OGR_G_ConvexHull, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_ConvexHull, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1004,7 +1004,7 @@ Compute buffer of geometry.
 the newly created geometry, or NULL if an error occurs.
 """
 function ogr_g_buffer(arg1, arg2, arg3)
-    failsafe(ccall((:OGR_G_Buffer, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Cint), arg1, arg2, arg3))
+    aftercare(ccall((:OGR_G_Buffer, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -1021,7 +1021,7 @@ Compute intersection.
 a new geometry representing the intersection or NULL if there is no intersection or an error occurs.
 """
 function ogr_g_intersection(arg1, arg2)
-    failsafe(ccall((:OGR_G_Intersection, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
+    aftercare(ccall((:OGR_G_Intersection, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1038,7 +1038,7 @@ Compute union.
 a new geometry representing the union or NULL if an error occurs.
 """
 function ogr_g_union(arg1, arg2)
-    failsafe(ccall((:OGR_G_Union, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
+    aftercare(ccall((:OGR_G_Union, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1053,7 +1053,7 @@ Compute union using cascading.
 a new geometry representing the union or NULL if an error occurs.
 """
 function ogr_g_unioncascaded(arg1)
-    failsafe(ccall((:OGR_G_UnionCascaded, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_UnionCascaded, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1068,7 +1068,7 @@ Returns a point guaranteed to lie on the surface.
 a point guaranteed to lie on the surface or NULL if an error occurred.
 """
 function ogr_g_pointonsurface(arg1)
-    failsafe(ccall((:OGR_G_PointOnSurface, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_PointOnSurface, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1085,7 +1085,7 @@ Compute difference.
 a new geometry representing the difference or NULL if the difference is empty or an error occurs.
 """
 function ogr_g_difference(arg1, arg2)
-    failsafe(ccall((:OGR_G_Difference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
+    aftercare(ccall((:OGR_G_Difference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1102,7 +1102,7 @@ Compute symmetric difference.
 a new geometry representing the symmetric difference or NULL if the difference is empty or an error occurs.
 """
 function ogr_g_symdifference(arg1, arg2)
-    failsafe(ccall((:OGR_G_SymDifference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
+    aftercare(ccall((:OGR_G_SymDifference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1119,7 +1119,7 @@ Compute distance between two geometries.
 the distance between the geometries or -1 if an error occurs.
 """
 function ogr_g_distance(arg1, arg2)
-    ccall((:OGR_G_Distance, libgdal), Cdouble, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Distance, libgdal), Cdouble, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1136,7 +1136,7 @@ Returns the 3D distance between two geometries.
 distance between the two geometries
 """
 function ogr_g_distance3d(arg1, arg2)
-    ccall((:OGR_G_Distance3D, libgdal), Cdouble, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Distance3D, libgdal), Cdouble, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1151,7 +1151,7 @@ Compute length of a geometry.
 the length or 0.0 for unsupported geometry types.
 """
 function ogr_g_length(arg1)
-    ccall((:OGR_G_Length, libgdal), Cdouble, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_Length, libgdal), Cdouble, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1166,7 +1166,7 @@ Compute geometry area.
 the area or 0.0 for unsupported geometry types.
 """
 function ogr_g_area(arg1)
-    ccall((:OGR_G_Area, libgdal), Cdouble, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_Area, libgdal), Cdouble, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1179,7 +1179,7 @@ Compute the geometry centroid.
 OGRERR_NONE on success or OGRERR_FAILURE on error.
 """
 function ogr_g_centroid(arg1, arg2)
-    ccall((:OGR_G_Centroid, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Centroid, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1196,7 +1196,7 @@ Fetch point at given distance along curve.
 a point or NULL.
 """
 function ogr_g_value(arg1, dfDistance)
-    failsafe(ccall((:OGR_G_Value, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), arg1, dfDistance))
+    aftercare(ccall((:OGR_G_Value, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble), arg1, dfDistance))
 end
 
 """
@@ -1208,7 +1208,7 @@ Clear geometry information.
 * **hGeom**: handle on the geometry to empty.
 """
 function ogr_g_empty(arg1)
-    ccall((:OGR_G_Empty, libgdal), Cvoid, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_Empty, libgdal), Cvoid, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1223,7 +1223,7 @@ Test if the geometry is empty.
 TRUE if the geometry has no points, otherwise FALSE.
 """
 function ogr_g_isempty(arg1)
-    ccall((:OGR_G_IsEmpty, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_IsEmpty, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1238,7 +1238,7 @@ Test if the geometry is valid.
 TRUE if the geometry has no points, otherwise FALSE.
 """
 function ogr_g_isvalid(arg1)
-    ccall((:OGR_G_IsValid, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_IsValid, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1253,7 +1253,7 @@ Attempts to make an invalid geometry valid without losing vertices.
 a newly allocated geometry now owned by the caller, or NULL on failure.
 """
 function ogr_g_makevalid(arg1)
-    failsafe(ccall((:OGR_G_MakeValid, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_MakeValid, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1268,7 +1268,7 @@ Returns TRUE if the geometry is simple.
 TRUE if object is simple, otherwise FALSE.
 """
 function ogr_g_issimple(arg1)
-    ccall((:OGR_G_IsSimple, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_IsSimple, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1283,7 +1283,7 @@ Test if the geometry is a ring.
 TRUE if the geometry has no points, otherwise FALSE.
 """
 function ogr_g_isring(arg1)
-    ccall((:OGR_G_IsRing, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_IsRing, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1298,15 +1298,15 @@ Polygonizes a set of sparse edges.
 a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
 """
 function ogr_g_polygonize(arg1)
-    failsafe(ccall((:OGR_G_Polygonize, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_Polygonize, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 function ogr_g_intersect(arg1, arg2)
-    ccall((:OGR_G_Intersect, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Intersect, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 function ogr_g_equal(arg1, arg2)
-    ccall((:OGR_G_Equal, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_Equal, libgdal), Cint, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1316,7 +1316,7 @@ end
 Compute symmetric difference (deprecated)
 """
 function ogr_g_symmetricdifference(arg1, arg2)
-    failsafe(ccall((:OGR_G_SymmetricDifference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
+    aftercare(ccall((:OGR_G_SymmetricDifference, libgdal), OGRGeometryH, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1325,7 +1325,7 @@ end
 Compute geometry area (deprecated)
 """
 function ogr_g_getarea(arg1)
-    ccall((:OGR_G_GetArea, libgdal), Cdouble, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetArea, libgdal), Cdouble, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1334,7 +1334,7 @@ end
 Compute boundary (deprecated)
 """
 function ogr_g_getboundary(arg1)
-    failsafe(ccall((:OGR_G_GetBoundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
+    aftercare(ccall((:OGR_G_GetBoundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1349,7 +1349,7 @@ Fetch number of points from a geometry.
 the number of points.
 """
 function ogr_g_getpointcount(arg1)
-    ccall((:OGR_G_GetPointCount, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetPointCount, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1376,7 +1376,7 @@ Returns all points of line string.
 the number of points
 """
 function ogr_g_getpoints(hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride)
-    ccall((:OGR_G_GetPoints, libgdal), Cint, (OGRGeometryH, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride)
+    aftercare(ccall((:OGR_G_GetPoints, libgdal), Cint, (OGRGeometryH, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride))
 end
 
 """
@@ -1407,7 +1407,7 @@ Returns all points of line string.
 the number of points
 """
 function ogr_g_getpointszm(hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride)
-    ccall((:OGR_G_GetPointsZM, libgdal), Cint, (OGRGeometryH, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride)
+    aftercare(ccall((:OGR_G_GetPointsZM, libgdal), Cint, (OGRGeometryH, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride))
 end
 
 """
@@ -1424,7 +1424,7 @@ Fetch the x coordinate of a point from a geometry.
 the X coordinate of this point.
 """
 function ogr_g_getx(arg1, arg2)
-    ccall((:OGR_G_GetX, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetX, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -1441,7 +1441,7 @@ Fetch the x coordinate of a point from a geometry.
 the Y coordinate of this point.
 """
 function ogr_g_gety(arg1, arg2)
-    ccall((:OGR_G_GetY, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetY, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -1458,7 +1458,7 @@ Fetch the z coordinate of a point from a geometry.
 the Z coordinate of this point.
 """
 function ogr_g_getz(arg1, arg2)
-    ccall((:OGR_G_GetZ, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetZ, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -1475,7 +1475,7 @@ Fetch the m coordinate of a point from a geometry.
 the M coordinate of this point.
 """
 function ogr_g_getm(arg1, arg2)
-    ccall((:OGR_G_GetM, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_G_GetM, libgdal), Cdouble, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -1495,7 +1495,7 @@ Fetch a point in line string or a point geometry.
 * **pdfZ**: value of z coordinate.
 """
 function ogr_g_getpoint(arg1, iPoint, arg2, arg3, arg4)
-    ccall((:OGR_G_GetPoint, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, iPoint, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_GetPoint, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, iPoint, arg2, arg3, arg4))
 end
 
 """
@@ -1517,7 +1517,7 @@ Fetch a point in line string or a point geometry.
 * **pdfM**: value of m coordinate.
 """
 function ogr_g_getpointzm(arg1, iPoint, arg2, arg3, arg4, arg5)
-    ccall((:OGR_G_GetPointZM, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, iPoint, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OGR_G_GetPointZM, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), arg1, iPoint, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -1531,7 +1531,7 @@ Set number of points in a geometry.
 * **nNewPointCount**: the new number of points for geometry.
 """
 function ogr_g_setpointcount(hGeom, nNewPointCount)
-    ccall((:OGR_G_SetPointCount, libgdal), Cvoid, (OGRGeometryH, Cint), hGeom, nNewPointCount)
+    aftercare(ccall((:OGR_G_SetPointCount, libgdal), Cvoid, (OGRGeometryH, Cint), hGeom, nNewPointCount))
 end
 
 """
@@ -1551,7 +1551,7 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfZ**: input Z coordinate to assign (defaults to zero).
 """
 function ogr_g_setpoint(arg1, iPoint, arg2, arg3, arg4)
-    ccall((:OGR_G_SetPoint, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_SetPoint, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4))
 end
 
 """
@@ -1569,7 +1569,7 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfY**: input Y coordinate to assign.
 """
 function ogr_g_setpoint_2d(arg1, iPoint, arg2, arg3)
-    ccall((:OGR_G_SetPoint_2D, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble), arg1, iPoint, arg2, arg3)
+    aftercare(ccall((:OGR_G_SetPoint_2D, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble), arg1, iPoint, arg2, arg3))
 end
 
 """
@@ -1589,7 +1589,7 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfM**: input M coordinate to assign.
 """
 function ogr_g_setpointm(arg1, iPoint, arg2, arg3, arg4)
-    ccall((:OGR_G_SetPointM, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_SetPointM, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4))
 end
 
 """
@@ -1611,7 +1611,7 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfM**: input M coordinate to assign.
 """
 function ogr_g_setpointzm(arg1, iPoint, arg2, arg3, arg4, arg5)
-    ccall((:OGR_G_SetPointZM, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OGR_G_SetPointZM, libgdal), Cvoid, (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble, Cdouble), arg1, iPoint, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -1629,7 +1629,7 @@ Add a point to a geometry (line string or point).
 * **dfZ**: z coordinate of point to add.
 """
 function ogr_g_addpoint(arg1, arg2, arg3, arg4)
-    ccall((:OGR_G_AddPoint, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_AddPoint, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1645,7 +1645,7 @@ Add a point to a geometry (line string or point).
 * **dfY**: y coordinate of point to add.
 """
 function ogr_g_addpoint_2d(arg1, arg2, arg3)
-    ccall((:OGR_G_AddPoint_2D, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_AddPoint_2D, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -1663,7 +1663,7 @@ Add a point to a geometry (line string or point).
 * **dfM**: m coordinate of point to add.
 """
 function ogr_g_addpointm(arg1, arg2, arg3, arg4)
-    ccall((:OGR_G_AddPointM, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_G_AddPointM, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -1683,7 +1683,7 @@ Add a point to a geometry (line string or point).
 * **dfM**: m coordinate of point to add.
 """
 function ogr_g_addpointzm(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OGR_G_AddPointZM, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OGR_G_AddPointZM, libgdal), Cvoid, (OGRGeometryH, Cdouble, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -1709,7 +1709,7 @@ Assign all points in a point or a line string geometry.
 * **nZStride**: the number of bytes between 2 elements of pabyZ.
 """
 function ogr_g_setpoints(hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride)
-    ccall((:OGR_G_SetPoints, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride)
+    aftercare(ccall((:OGR_G_SetPoints, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride))
 end
 
 """
@@ -1739,7 +1739,7 @@ Assign all points in a point or a line string geometry.
 * **nMStride**: the number of bytes between 2 elements of pM.
 """
 function ogr_g_setpointszm(hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride)
-    ccall((:OGR_G_SetPointsZM, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride)
+    aftercare(ccall((:OGR_G_SetPointsZM, libgdal), Cvoid, (OGRGeometryH, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint), hGeom, nPointsIn, pabyX, nXStride, pabyY, nYStride, pabyZ, nZStride, pabyM, nMStride))
 end
 
 """
@@ -1751,7 +1751,7 @@ Swap x and y coordinates.
 * **hGeom**: geometry.
 """
 function ogr_g_swapxy(hGeom)
-    ccall((:OGR_G_SwapXY, libgdal), Cvoid, (OGRGeometryH,), hGeom)
+    aftercare(ccall((:OGR_G_SwapXY, libgdal), Cvoid, (OGRGeometryH,), hGeom))
 end
 
 """
@@ -1766,7 +1766,7 @@ Fetch the number of elements in a geometry or number of geometries in container.
 the number of elements.
 """
 function ogr_g_getgeometrycount(arg1)
-    ccall((:OGR_G_GetGeometryCount, libgdal), Cint, (OGRGeometryH,), arg1)
+    aftercare(ccall((:OGR_G_GetGeometryCount, libgdal), Cint, (OGRGeometryH,), arg1))
 end
 
 """
@@ -1783,7 +1783,7 @@ Fetch geometry from a geometry container.
 handle to the requested geometry.
 """
 function ogr_g_getgeometryref(arg1, arg2)
-    failsafe(ccall((:OGR_G_GetGeometryRef, libgdal), OGRGeometryH, (OGRGeometryH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_G_GetGeometryRef, libgdal), OGRGeometryH, (OGRGeometryH, Cint), arg1, arg2))
 end
 
 """
@@ -1800,7 +1800,7 @@ Add a geometry to a geometry container.
 OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of existing geometry.
 """
 function ogr_g_addgeometry(arg1, arg2)
-    ccall((:OGR_G_AddGeometry, libgdal), OGRErr, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_AddGeometry, libgdal), OGRErr, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1817,7 +1817,7 @@ Add a geometry directly to an existing geometry container.
 OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of geometry container.
 """
 function ogr_g_addgeometrydirectly(arg1, arg2)
-    ccall((:OGR_G_AddGeometryDirectly, libgdal), OGRErr, (OGRGeometryH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_G_AddGeometryDirectly, libgdal), OGRErr, (OGRGeometryH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -1836,7 +1836,7 @@ Remove a geometry from an exiting geometry container.
 OGRERR_NONE if successful, or OGRERR_FAILURE if the index is out of range.
 """
 function ogr_g_removegeometry(arg1, arg2, arg3)
-    ccall((:OGR_G_RemoveGeometry, libgdal), OGRErr, (OGRGeometryH, Cint, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_G_RemoveGeometry, libgdal), OGRErr, (OGRGeometryH, Cint, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -1853,7 +1853,7 @@ Returns if this geometry is or has curve geometry.
 TRUE if this geometry is or has curve geometry.
 """
 function ogr_g_hascurvegeometry(arg1, bLookForNonLinear)
-    ccall((:OGR_G_HasCurveGeometry, libgdal), Cint, (OGRGeometryH, Cint), arg1, bLookForNonLinear)
+    aftercare(ccall((:OGR_G_HasCurveGeometry, libgdal), Cint, (OGRGeometryH, Cint), arg1, bLookForNonLinear))
 end
 
 """
@@ -1872,7 +1872,7 @@ Return, possibly approximate, linear version of this geometry.
 a new geometry.
 """
 function ogr_g_getlineargeometry(hGeom, dfMaxAngleStepSizeDegrees, papszOptions)
-    failsafe(ccall((:OGR_G_GetLinearGeometry, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Ptr{Cstring}), hGeom, dfMaxAngleStepSizeDegrees, papszOptions))
+    aftercare(ccall((:OGR_G_GetLinearGeometry, libgdal), OGRGeometryH, (OGRGeometryH, Cdouble, Ptr{Cstring}), hGeom, dfMaxAngleStepSizeDegrees, papszOptions))
 end
 
 """
@@ -1889,7 +1889,7 @@ Return curve version of this geometry.
 a new geometry.
 """
 function ogr_g_getcurvegeometry(hGeom, papszOptions)
-    failsafe(ccall((:OGR_G_GetCurveGeometry, libgdal), OGRGeometryH, (OGRGeometryH, Ptr{Cstring}), hGeom, papszOptions))
+    aftercare(ccall((:OGR_G_GetCurveGeometry, libgdal), OGRGeometryH, (OGRGeometryH, Ptr{Cstring}), hGeom, papszOptions))
 end
 
 """
@@ -1912,7 +1912,7 @@ Build a ring from a bunch of arcs.
 an handle to the new geometry, a polygon.
 """
 function ogrbuildpolygonfromedges(hLinesAsCollection, bBestEffort, bAutoClose, dfTolerance, peErr)
-    failsafe(ccall((:OGRBuildPolygonFromEdges, libgdal), OGRGeometryH, (OGRGeometryH, Cint, Cint, Cdouble, Ptr{OGRErr}), hLinesAsCollection, bBestEffort, bAutoClose, dfTolerance, peErr))
+    aftercare(ccall((:OGRBuildPolygonFromEdges, libgdal), OGRGeometryH, (OGRGeometryH, Cint, Cint, Cdouble, Ptr{OGRErr}), hLinesAsCollection, bBestEffort, bAutoClose, dfTolerance, peErr))
 end
 
 """
@@ -1921,14 +1921,14 @@ end
 Special entry point to enable the hack for generating DB2 V7.2 style WKB.
 """
 function ogrsetgenerate_db2_v72_byte_order(bGenerate_DB2_V72_BYTE_ORDER)
-    ccall((:OGRSetGenerate_DB2_V72_BYTE_ORDER, libgdal), OGRErr, (Cint,), bGenerate_DB2_V72_BYTE_ORDER)
+    aftercare(ccall((:OGRSetGenerate_DB2_V72_BYTE_ORDER, libgdal), OGRErr, (Cint,), bGenerate_DB2_V72_BYTE_ORDER))
 end
 
 """
     OGRGetGenerate_DB2_V72_BYTE_ORDER() -> int
 """
 function ogrgetgenerate_db2_v72_byte_order()
-    ccall((:OGRGetGenerate_DB2_V72_BYTE_ORDER, libgdal), Cint, ())
+    aftercare(ccall((:OGRGetGenerate_DB2_V72_BYTE_ORDER, libgdal), Cint, ()))
 end
 
 """
@@ -1940,7 +1940,7 @@ Set flag to enable/disable returning non-linear geometries in the C API.
 * **bFlag**: TRUE if non-linear geometries might be returned (default value). FALSE to ask for non-linear geometries to be approximated as linear geometries.
 """
 function ogrsetnonlineargeometriesenabledflag(bFlag)
-    ccall((:OGRSetNonLinearGeometriesEnabledFlag, libgdal), Cvoid, (Cint,), bFlag)
+    aftercare(ccall((:OGRSetNonLinearGeometriesEnabledFlag, libgdal), Cvoid, (Cint,), bFlag))
 end
 
 """
@@ -1949,7 +1949,7 @@ end
 Get flag to enable/disable returning non-linear geometries in the C API.
 """
 function ogrgetnonlineargeometriesenabledflag()
-    ccall((:OGRGetNonLinearGeometriesEnabledFlag, libgdal), Cint, ())
+    aftercare(ccall((:OGRGetNonLinearGeometriesEnabledFlag, libgdal), Cint, ()))
 end
 
 """
@@ -1966,7 +1966,7 @@ Create a new field definition.
 handle to the new field definition.
 """
 function ogr_fld_create(arg1, arg2)
-    failsafe(ccall((:OGR_Fld_Create, libgdal), OGRFieldDefnH, (Cstring, OGRFieldType), arg1, arg2))
+    aftercare(ccall((:OGR_Fld_Create, libgdal), OGRFieldDefnH, (Cstring, OGRFieldType), arg1, arg2))
 end
 
 """
@@ -1978,7 +1978,7 @@ Destroy a field definition.
 * **hDefn**: handle to the field definition to destroy.
 """
 function ogr_fld_destroy(arg1)
-    ccall((:OGR_Fld_Destroy, libgdal), Cvoid, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_Destroy, libgdal), Cvoid, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -1992,7 +1992,7 @@ Reset the name of this field.
 * **pszName**: the new name to apply.
 """
 function ogr_fld_setname(arg1, arg2)
-    ccall((:OGR_Fld_SetName, libgdal), Cvoid, (OGRFieldDefnH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetName, libgdal), Cvoid, (OGRFieldDefnH, Cstring), arg1, arg2))
 end
 
 """
@@ -2007,7 +2007,7 @@ Fetch name of this field.
 the name of the field definition.
 """
 function ogr_fld_getnameref(arg1)
-    string_or_nothing(ccall((:OGR_Fld_GetNameRef, libgdal), Cstring, (OGRFieldDefnH,), arg1))
+    aftercare(ccall((:OGR_Fld_GetNameRef, libgdal), Cstring, (OGRFieldDefnH,), arg1), false)
 end
 
 """
@@ -2022,7 +2022,7 @@ Fetch type of this field.
 field type.
 """
 function ogr_fld_gettype(arg1)
-    ccall((:OGR_Fld_GetType, libgdal), OGRFieldType, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_GetType, libgdal), OGRFieldType, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2036,7 +2036,7 @@ Set the type of this field.
 * **eType**: the new field type.
 """
 function ogr_fld_settype(arg1, arg2)
-    ccall((:OGR_Fld_SetType, libgdal), Cvoid, (OGRFieldDefnH, OGRFieldType), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetType, libgdal), Cvoid, (OGRFieldDefnH, OGRFieldType), arg1, arg2))
 end
 
 """
@@ -2051,7 +2051,7 @@ Fetch subtype of this field.
 field subtype.
 """
 function ogr_fld_getsubtype(arg1)
-    ccall((:OGR_Fld_GetSubType, libgdal), OGRFieldSubType, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_GetSubType, libgdal), OGRFieldSubType, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2065,7 +2065,7 @@ Set the subtype of this field.
 * **eSubType**: the new field subtype.
 """
 function ogr_fld_setsubtype(arg1, arg2)
-    ccall((:OGR_Fld_SetSubType, libgdal), Cvoid, (OGRFieldDefnH, OGRFieldSubType), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetSubType, libgdal), Cvoid, (OGRFieldDefnH, OGRFieldSubType), arg1, arg2))
 end
 
 """
@@ -2080,7 +2080,7 @@ Get the justification for this field.
 the justification.
 """
 function ogr_fld_getjustify(arg1)
-    ccall((:OGR_Fld_GetJustify, libgdal), OGRJustification, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_GetJustify, libgdal), OGRJustification, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2094,7 +2094,7 @@ Set the justification for this field.
 * **eJustify**: the new justification.
 """
 function ogr_fld_setjustify(arg1, arg2)
-    ccall((:OGR_Fld_SetJustify, libgdal), Cvoid, (OGRFieldDefnH, OGRJustification), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetJustify, libgdal), Cvoid, (OGRFieldDefnH, OGRJustification), arg1, arg2))
 end
 
 """
@@ -2109,7 +2109,7 @@ Get the formatting width for this field.
 the width, zero means no specified width.
 """
 function ogr_fld_getwidth(arg1)
-    ccall((:OGR_Fld_GetWidth, libgdal), Cint, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_GetWidth, libgdal), Cint, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2123,7 +2123,7 @@ Set the formatting width for this field in characters.
 * **nNewWidth**: the new width.
 """
 function ogr_fld_setwidth(arg1, arg2)
-    ccall((:OGR_Fld_SetWidth, libgdal), Cvoid, (OGRFieldDefnH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetWidth, libgdal), Cvoid, (OGRFieldDefnH, Cint), arg1, arg2))
 end
 
 """
@@ -2138,7 +2138,7 @@ Get the formatting precision for this field.
 the precision.
 """
 function ogr_fld_getprecision(arg1)
-    ccall((:OGR_Fld_GetPrecision, libgdal), Cint, (OGRFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_Fld_GetPrecision, libgdal), Cint, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2152,7 +2152,7 @@ Set the formatting precision for this field in characters.
 * **nPrecision**: the new precision.
 """
 function ogr_fld_setprecision(arg1, arg2)
-    ccall((:OGR_Fld_SetPrecision, libgdal), Cvoid, (OGRFieldDefnH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_Fld_SetPrecision, libgdal), Cvoid, (OGRFieldDefnH, Cint), arg1, arg2))
 end
 
 """
@@ -2174,7 +2174,7 @@ Set defining parameters for a field in one call.
 * **eJustifyIn**: the formatting justification (OJLeft or OJRight), defaults to OJUndefined.
 """
 function ogr_fld_set(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_Fld_Set, libgdal), Cvoid, (OGRFieldDefnH, Cstring, OGRFieldType, Cint, Cint, OGRJustification), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_Fld_Set, libgdal), Cvoid, (OGRFieldDefnH, Cstring, OGRFieldType, Cint, Cint, OGRJustification), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -2189,7 +2189,7 @@ Return whether this field should be omitted when fetching features.
 ignore state
 """
 function ogr_fld_isignored(hDefn)
-    ccall((:OGR_Fld_IsIgnored, libgdal), Cint, (OGRFieldDefnH,), hDefn)
+    aftercare(ccall((:OGR_Fld_IsIgnored, libgdal), Cint, (OGRFieldDefnH,), hDefn))
 end
 
 """
@@ -2203,7 +2203,7 @@ Set whether this field should be omitted when fetching features.
 * **ignore**: ignore state
 """
 function ogr_fld_setignored(hDefn, arg1)
-    ccall((:OGR_Fld_SetIgnored, libgdal), Cvoid, (OGRFieldDefnH, Cint), hDefn, arg1)
+    aftercare(ccall((:OGR_Fld_SetIgnored, libgdal), Cvoid, (OGRFieldDefnH, Cint), hDefn, arg1))
 end
 
 """
@@ -2218,7 +2218,7 @@ Return whether this field can receive null values.
 TRUE if the field is authorized to be null.
 """
 function ogr_fld_isnullable(hDefn)
-    ccall((:OGR_Fld_IsNullable, libgdal), Cint, (OGRFieldDefnH,), hDefn)
+    aftercare(ccall((:OGR_Fld_IsNullable, libgdal), Cint, (OGRFieldDefnH,), hDefn))
 end
 
 """
@@ -2232,7 +2232,7 @@ Set whether this field can receive null values.
 * **bNullableIn**: FALSE if the field must have a not-null constraint.
 """
 function ogr_fld_setnullable(hDefn, arg1)
-    ccall((:OGR_Fld_SetNullable, libgdal), Cvoid, (OGRFieldDefnH, Cint), hDefn, arg1)
+    aftercare(ccall((:OGR_Fld_SetNullable, libgdal), Cvoid, (OGRFieldDefnH, Cint), hDefn, arg1))
 end
 
 """
@@ -2247,7 +2247,7 @@ Get default field value.
 default field value or NULL.
 """
 function ogr_fld_getdefault(hDefn)
-    string_or_nothing(ccall((:OGR_Fld_GetDefault, libgdal), Cstring, (OGRFieldDefnH,), hDefn))
+    aftercare(ccall((:OGR_Fld_GetDefault, libgdal), Cstring, (OGRFieldDefnH,), hDefn), false)
 end
 
 """
@@ -2261,7 +2261,7 @@ Set default field value.
 * **pszDefault**: new default field value or NULL pointer.
 """
 function ogr_fld_setdefault(hDefn, arg1)
-    ccall((:OGR_Fld_SetDefault, libgdal), Cvoid, (OGRFieldDefnH, Cstring), hDefn, arg1)
+    aftercare(ccall((:OGR_Fld_SetDefault, libgdal), Cvoid, (OGRFieldDefnH, Cstring), hDefn, arg1))
 end
 
 """
@@ -2276,7 +2276,7 @@ Returns whether the default value is driver specific.
 TRUE if the default value is driver specific.
 """
 function ogr_fld_isdefaultdriverspecific(hDefn)
-    ccall((:OGR_Fld_IsDefaultDriverSpecific, libgdal), Cint, (OGRFieldDefnH,), hDefn)
+    aftercare(ccall((:OGR_Fld_IsDefaultDriverSpecific, libgdal), Cint, (OGRFieldDefnH,), hDefn))
 end
 
 """
@@ -2291,7 +2291,7 @@ Fetch human readable name for a field type.
 the name.
 """
 function ogr_getfieldtypename(arg1)
-    string_or_nothing(ccall((:OGR_GetFieldTypeName, libgdal), Cstring, (OGRFieldType,), arg1))
+    aftercare(ccall((:OGR_GetFieldTypeName, libgdal), Cstring, (OGRFieldType,), arg1), false)
 end
 
 """
@@ -2306,7 +2306,7 @@ Fetch human readable name for a field subtype.
 the name.
 """
 function ogr_getfieldsubtypename(arg1)
-    string_or_nothing(ccall((:OGR_GetFieldSubTypeName, libgdal), Cstring, (OGRFieldSubType,), arg1))
+    aftercare(ccall((:OGR_GetFieldSubTypeName, libgdal), Cstring, (OGRFieldSubType,), arg1), false)
 end
 
 """
@@ -2323,7 +2323,7 @@ Return if type and subtype are compatible.
 TRUE if type and subtype are compatible
 """
 function ogr_aretypesubtypecompatible(eType, eSubType)
-    ccall((:OGR_AreTypeSubTypeCompatible, libgdal), Cint, (OGRFieldType, OGRFieldSubType), eType, eSubType)
+    aftercare(ccall((:OGR_AreTypeSubTypeCompatible, libgdal), Cint, (OGRFieldType, OGRFieldSubType), eType, eSubType))
 end
 
 """
@@ -2340,7 +2340,7 @@ Create a new field geometry definition.
 handle to the new field definition.
 """
 function ogr_gfld_create(arg1, arg2)
-    failsafe(ccall((:OGR_GFld_Create, libgdal), OGRGeomFieldDefnH, (Cstring, OGRwkbGeometryType), arg1, arg2))
+    aftercare(ccall((:OGR_GFld_Create, libgdal), OGRGeomFieldDefnH, (Cstring, OGRwkbGeometryType), arg1, arg2))
 end
 
 """
@@ -2352,7 +2352,7 @@ Destroy a geometry field definition.
 * **hDefn**: handle to the geometry field definition to destroy.
 """
 function ogr_gfld_destroy(arg1)
-    ccall((:OGR_GFld_Destroy, libgdal), Cvoid, (OGRGeomFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_GFld_Destroy, libgdal), Cvoid, (OGRGeomFieldDefnH,), arg1))
 end
 
 """
@@ -2366,7 +2366,7 @@ Reset the name of this field.
 * **pszName**: the new name to apply.
 """
 function ogr_gfld_setname(arg1, arg2)
-    ccall((:OGR_GFld_SetName, libgdal), Cvoid, (OGRGeomFieldDefnH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_GFld_SetName, libgdal), Cvoid, (OGRGeomFieldDefnH, Cstring), arg1, arg2))
 end
 
 """
@@ -2381,7 +2381,7 @@ Fetch name of this field.
 the name of the geometry field definition.
 """
 function ogr_gfld_getnameref(arg1)
-    string_or_nothing(ccall((:OGR_GFld_GetNameRef, libgdal), Cstring, (OGRGeomFieldDefnH,), arg1))
+    aftercare(ccall((:OGR_GFld_GetNameRef, libgdal), Cstring, (OGRGeomFieldDefnH,), arg1), false)
 end
 
 """
@@ -2396,7 +2396,7 @@ Fetch geometry type of this field.
 field geometry type.
 """
 function ogr_gfld_gettype(arg1)
-    ccall((:OGR_GFld_GetType, libgdal), OGRwkbGeometryType, (OGRGeomFieldDefnH,), arg1)
+    aftercare(ccall((:OGR_GFld_GetType, libgdal), OGRwkbGeometryType, (OGRGeomFieldDefnH,), arg1))
 end
 
 """
@@ -2410,7 +2410,7 @@ Set the geometry type of this field.
 * **eType**: the new field geometry type.
 """
 function ogr_gfld_settype(arg1, arg2)
-    ccall((:OGR_GFld_SetType, libgdal), Cvoid, (OGRGeomFieldDefnH, OGRwkbGeometryType), arg1, arg2)
+    aftercare(ccall((:OGR_GFld_SetType, libgdal), Cvoid, (OGRGeomFieldDefnH, OGRwkbGeometryType), arg1, arg2))
 end
 
 """
@@ -2425,7 +2425,7 @@ Fetch spatial reference system of this field.
 field spatial reference system.
 """
 function ogr_gfld_getspatialref(arg1)
-    failsafe(ccall((:OGR_GFld_GetSpatialRef, libgdal), OGRSpatialReferenceH, (OGRGeomFieldDefnH,), arg1))
+    aftercare(ccall((:OGR_GFld_GetSpatialRef, libgdal), OGRSpatialReferenceH, (OGRGeomFieldDefnH,), arg1))
 end
 
 """
@@ -2439,7 +2439,7 @@ Set the spatial reference of this field.
 * **hSRS**: the new SRS to apply.
 """
 function ogr_gfld_setspatialref(arg1, hSRS)
-    ccall((:OGR_GFld_SetSpatialRef, libgdal), Cvoid, (OGRGeomFieldDefnH, OGRSpatialReferenceH), arg1, hSRS)
+    aftercare(ccall((:OGR_GFld_SetSpatialRef, libgdal), Cvoid, (OGRGeomFieldDefnH, OGRSpatialReferenceH), arg1, hSRS))
 end
 
 """
@@ -2454,7 +2454,7 @@ Return whether this geometry field can receive null values.
 TRUE if the field is authorized to be null.
 """
 function ogr_gfld_isnullable(hDefn)
-    ccall((:OGR_GFld_IsNullable, libgdal), Cint, (OGRGeomFieldDefnH,), hDefn)
+    aftercare(ccall((:OGR_GFld_IsNullable, libgdal), Cint, (OGRGeomFieldDefnH,), hDefn))
 end
 
 """
@@ -2468,7 +2468,7 @@ Set whether this geometry field can receive null values.
 * **bNullableIn**: FALSE if the field must have a not-null constraint.
 """
 function ogr_gfld_setnullable(hDefn, arg1)
-    ccall((:OGR_GFld_SetNullable, libgdal), Cvoid, (OGRGeomFieldDefnH, Cint), hDefn, arg1)
+    aftercare(ccall((:OGR_GFld_SetNullable, libgdal), Cvoid, (OGRGeomFieldDefnH, Cint), hDefn, arg1))
 end
 
 """
@@ -2483,7 +2483,7 @@ Return whether this field should be omitted when fetching features.
 ignore state
 """
 function ogr_gfld_isignored(hDefn)
-    ccall((:OGR_GFld_IsIgnored, libgdal), Cint, (OGRGeomFieldDefnH,), hDefn)
+    aftercare(ccall((:OGR_GFld_IsIgnored, libgdal), Cint, (OGRGeomFieldDefnH,), hDefn))
 end
 
 """
@@ -2497,7 +2497,7 @@ Set whether this field should be omitted when fetching features.
 * **ignore**: ignore state
 """
 function ogr_gfld_setignored(hDefn, arg1)
-    ccall((:OGR_GFld_SetIgnored, libgdal), Cvoid, (OGRGeomFieldDefnH, Cint), hDefn, arg1)
+    aftercare(ccall((:OGR_GFld_SetIgnored, libgdal), Cvoid, (OGRGeomFieldDefnH, Cint), hDefn, arg1))
 end
 
 """
@@ -2512,7 +2512,7 @@ Create a new feature definition object to hold the field definitions.
 handle to the newly created feature definition.
 """
 function ogr_fd_create(arg1)
-    failsafe(ccall((:OGR_FD_Create, libgdal), OGRFeatureDefnH, (Cstring,), arg1))
+    aftercare(ccall((:OGR_FD_Create, libgdal), OGRFeatureDefnH, (Cstring,), arg1))
 end
 
 """
@@ -2524,7 +2524,7 @@ Destroy a feature definition object and release all memory associated with it.
 * **hDefn**: handle to the feature definition to be destroyed.
 """
 function ogr_fd_destroy(arg1)
-    ccall((:OGR_FD_Destroy, libgdal), Cvoid, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_Destroy, libgdal), Cvoid, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2536,7 +2536,7 @@ Drop a reference, and destroy if unreferenced.
 * **hDefn**: handle to the feature definition to be released.
 """
 function ogr_fd_release(arg1)
-    ccall((:OGR_FD_Release, libgdal), Cvoid, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_Release, libgdal), Cvoid, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2551,7 +2551,7 @@ Get name of the OGRFeatureDefn passed as an argument.
 the name. This name is internal and should not be modified, or freed.
 """
 function ogr_fd_getname(arg1)
-    string_or_nothing(ccall((:OGR_FD_GetName, libgdal), Cstring, (OGRFeatureDefnH,), arg1))
+    aftercare(ccall((:OGR_FD_GetName, libgdal), Cstring, (OGRFeatureDefnH,), arg1), false)
 end
 
 """
@@ -2566,7 +2566,7 @@ Fetch number of fields on the passed feature definition.
 count of fields.
 """
 function ogr_fd_getfieldcount(arg1)
-    ccall((:OGR_FD_GetFieldCount, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_GetFieldCount, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2583,7 +2583,7 @@ Fetch field definition of the passed feature definition.
 an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
 """
 function ogr_fd_getfielddefn(arg1, arg2)
-    failsafe(ccall((:OGR_FD_GetFieldDefn, libgdal), OGRFieldDefnH, (OGRFeatureDefnH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_FD_GetFieldDefn, libgdal), OGRFieldDefnH, (OGRFeatureDefnH, Cint), arg1, arg2))
 end
 
 """
@@ -2600,7 +2600,7 @@ Find field by name.
 the field index, or -1 if no match found.
 """
 function ogr_fd_getfieldindex(arg1, arg2)
-    ccall((:OGR_FD_GetFieldIndex, libgdal), Cint, (OGRFeatureDefnH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_FD_GetFieldIndex, libgdal), Cint, (OGRFeatureDefnH, Cstring), arg1, arg2))
 end
 
 """
@@ -2614,7 +2614,7 @@ Add a new field definition to the passed feature definition.
 * **hNewField**: handle to the new field definition.
 """
 function ogr_fd_addfielddefn(arg1, arg2)
-    ccall((:OGR_FD_AddFieldDefn, libgdal), Cvoid, (OGRFeatureDefnH, OGRFieldDefnH), arg1, arg2)
+    aftercare(ccall((:OGR_FD_AddFieldDefn, libgdal), Cvoid, (OGRFeatureDefnH, OGRFieldDefnH), arg1, arg2))
 end
 
 """
@@ -2631,7 +2631,7 @@ Delete an existing field definition.
 OGRERR_NONE in case of success.
 """
 function ogr_fd_deletefielddefn(hDefn, iField)
-    ccall((:OGR_FD_DeleteFieldDefn, libgdal), OGRErr, (OGRFeatureDefnH, Cint), hDefn, iField)
+    aftercare(ccall((:OGR_FD_DeleteFieldDefn, libgdal), OGRErr, (OGRFeatureDefnH, Cint), hDefn, iField))
 end
 
 """
@@ -2648,7 +2648,7 @@ Reorder the field definitions in the array of the feature definition.
 OGRERR_NONE in case of success.
 """
 function ogr_fd_reorderfielddefns(hDefn, panMap)
-    ccall((:OGR_FD_ReorderFieldDefns, libgdal), OGRErr, (OGRFeatureDefnH, Ptr{Cint}), hDefn, panMap)
+    aftercare(ccall((:OGR_FD_ReorderFieldDefns, libgdal), OGRErr, (OGRFeatureDefnH, Ptr{Cint}), hDefn, panMap))
 end
 
 """
@@ -2663,7 +2663,7 @@ Fetch the geometry base type of the passed feature definition.
 the base type for all geometry related to this definition.
 """
 function ogr_fd_getgeomtype(arg1)
-    ccall((:OGR_FD_GetGeomType, libgdal), OGRwkbGeometryType, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_GetGeomType, libgdal), OGRwkbGeometryType, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2677,7 +2677,7 @@ Assign the base geometry type for the passed layer (the same as the feature defi
 * **eType**: the new type to assign.
 """
 function ogr_fd_setgeomtype(arg1, arg2)
-    ccall((:OGR_FD_SetGeomType, libgdal), Cvoid, (OGRFeatureDefnH, OGRwkbGeometryType), arg1, arg2)
+    aftercare(ccall((:OGR_FD_SetGeomType, libgdal), Cvoid, (OGRFeatureDefnH, OGRwkbGeometryType), arg1, arg2))
 end
 
 """
@@ -2692,7 +2692,7 @@ Determine whether the geometry can be omitted when fetching features.
 ignore state
 """
 function ogr_fd_isgeometryignored(arg1)
-    ccall((:OGR_FD_IsGeometryIgnored, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_IsGeometryIgnored, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2706,7 +2706,7 @@ Set whether the geometry can be omitted when fetching features.
 * **bIgnore**: ignore state
 """
 function ogr_fd_setgeometryignored(arg1, arg2)
-    ccall((:OGR_FD_SetGeometryIgnored, libgdal), Cvoid, (OGRFeatureDefnH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_FD_SetGeometryIgnored, libgdal), Cvoid, (OGRFeatureDefnH, Cint), arg1, arg2))
 end
 
 """
@@ -2721,7 +2721,7 @@ Determine whether the style can be omitted when fetching features.
 ignore state
 """
 function ogr_fd_isstyleignored(arg1)
-    ccall((:OGR_FD_IsStyleIgnored, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_IsStyleIgnored, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2735,7 +2735,7 @@ Set whether the style can be omitted when fetching features.
 * **bIgnore**: ignore state
 """
 function ogr_fd_setstyleignored(arg1, arg2)
-    ccall((:OGR_FD_SetStyleIgnored, libgdal), Cvoid, (OGRFeatureDefnH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_FD_SetStyleIgnored, libgdal), Cvoid, (OGRFeatureDefnH, Cint), arg1, arg2))
 end
 
 """
@@ -2750,7 +2750,7 @@ Increments the reference count by one.
 the updated reference count.
 """
 function ogr_fd_reference(arg1)
-    ccall((:OGR_FD_Reference, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_Reference, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2765,7 +2765,7 @@ Decrements the reference count by one.
 the updated reference count.
 """
 function ogr_fd_dereference(arg1)
-    ccall((:OGR_FD_Dereference, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_Dereference, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2780,7 +2780,7 @@ Fetch current reference count.
 the current reference count.
 """
 function ogr_fd_getreferencecount(arg1)
-    ccall((:OGR_FD_GetReferenceCount, libgdal), Cint, (OGRFeatureDefnH,), arg1)
+    aftercare(ccall((:OGR_FD_GetReferenceCount, libgdal), Cint, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2795,7 +2795,7 @@ Fetch number of geometry fields on the passed feature definition.
 count of geometry fields.
 """
 function ogr_fd_getgeomfieldcount(hFDefn)
-    ccall((:OGR_FD_GetGeomFieldCount, libgdal), Cint, (OGRFeatureDefnH,), hFDefn)
+    aftercare(ccall((:OGR_FD_GetGeomFieldCount, libgdal), Cint, (OGRFeatureDefnH,), hFDefn))
 end
 
 """
@@ -2812,7 +2812,7 @@ Fetch geometry field definition of the passed feature definition.
 an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
 """
 function ogr_fd_getgeomfielddefn(hFDefn, i)
-    failsafe(ccall((:OGR_FD_GetGeomFieldDefn, libgdal), OGRGeomFieldDefnH, (OGRFeatureDefnH, Cint), hFDefn, i))
+    aftercare(ccall((:OGR_FD_GetGeomFieldDefn, libgdal), OGRGeomFieldDefnH, (OGRFeatureDefnH, Cint), hFDefn, i))
 end
 
 """
@@ -2829,7 +2829,7 @@ Find geometry field by name.
 the geometry field index, or -1 if no match found.
 """
 function ogr_fd_getgeomfieldindex(hFDefn, pszName)
-    ccall((:OGR_FD_GetGeomFieldIndex, libgdal), Cint, (OGRFeatureDefnH, Cstring), hFDefn, pszName)
+    aftercare(ccall((:OGR_FD_GetGeomFieldIndex, libgdal), Cint, (OGRFeatureDefnH, Cstring), hFDefn, pszName))
 end
 
 """
@@ -2843,7 +2843,7 @@ Add a new field definition to the passed feature definition.
 * **hNewGeomField**: handle to the new field definition.
 """
 function ogr_fd_addgeomfielddefn(hFDefn, hGFldDefn)
-    ccall((:OGR_FD_AddGeomFieldDefn, libgdal), Cvoid, (OGRFeatureDefnH, OGRGeomFieldDefnH), hFDefn, hGFldDefn)
+    aftercare(ccall((:OGR_FD_AddGeomFieldDefn, libgdal), Cvoid, (OGRFeatureDefnH, OGRGeomFieldDefnH), hFDefn, hGFldDefn))
 end
 
 """
@@ -2860,7 +2860,7 @@ Delete an existing geometry field definition.
 OGRERR_NONE in case of success.
 """
 function ogr_fd_deletegeomfielddefn(hFDefn, iGeomField)
-    ccall((:OGR_FD_DeleteGeomFieldDefn, libgdal), OGRErr, (OGRFeatureDefnH, Cint), hFDefn, iGeomField)
+    aftercare(ccall((:OGR_FD_DeleteGeomFieldDefn, libgdal), OGRErr, (OGRFeatureDefnH, Cint), hFDefn, iGeomField))
 end
 
 """
@@ -2877,7 +2877,7 @@ Test if the feature definition is identical to the other one.
 TRUE if the feature definition is identical to the other one.
 """
 function ogr_fd_issame(hFDefn, hOtherFDefn)
-    ccall((:OGR_FD_IsSame, libgdal), Cint, (OGRFeatureDefnH, OGRFeatureDefnH), hFDefn, hOtherFDefn)
+    aftercare(ccall((:OGR_FD_IsSame, libgdal), Cint, (OGRFeatureDefnH, OGRFeatureDefnH), hFDefn, hOtherFDefn))
 end
 
 """
@@ -2892,7 +2892,7 @@ Feature factory.
 an handle to the new feature object with null fields and no geometry, or, starting with GDAL 2.1, NULL in case out of memory situation.
 """
 function ogr_f_create(arg1)
-    failsafe(ccall((:OGR_F_Create, libgdal), OGRFeatureH, (OGRFeatureDefnH,), arg1))
+    aftercare(ccall((:OGR_F_Create, libgdal), OGRFeatureH, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -2904,7 +2904,7 @@ Destroy feature.
 * **hFeat**: handle to the feature to destroy.
 """
 function ogr_f_destroy(arg1)
-    ccall((:OGR_F_Destroy, libgdal), Cvoid, (OGRFeatureH,), arg1)
+    aftercare(ccall((:OGR_F_Destroy, libgdal), Cvoid, (OGRFeatureH,), arg1))
 end
 
 """
@@ -2919,7 +2919,7 @@ Fetch feature definition.
 an handle to the feature definition object on which feature depends.
 """
 function ogr_f_getdefnref(arg1)
-    failsafe(ccall((:OGR_F_GetDefnRef, libgdal), OGRFeatureDefnH, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetDefnRef, libgdal), OGRFeatureDefnH, (OGRFeatureH,), arg1))
 end
 
 """
@@ -2936,7 +2936,7 @@ Set feature geometry.
 OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function ogr_f_setgeometrydirectly(arg1, arg2)
-    ccall((:OGR_F_SetGeometryDirectly, libgdal), OGRErr, (OGRFeatureH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetGeometryDirectly, libgdal), OGRErr, (OGRFeatureH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -2953,7 +2953,7 @@ Set feature geometry.
 OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function ogr_f_setgeometry(arg1, arg2)
-    ccall((:OGR_F_SetGeometry, libgdal), OGRErr, (OGRFeatureH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetGeometry, libgdal), OGRErr, (OGRFeatureH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -2968,7 +2968,7 @@ Fetch an handle to feature geometry.
 an handle to internal feature geometry. This object should not be modified.
 """
 function ogr_f_getgeometryref(arg1)
-    failsafe(ccall((:OGR_F_GetGeometryRef, libgdal), OGRGeometryH, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetGeometryRef, libgdal), OGRGeometryH, (OGRFeatureH,), arg1))
 end
 
 """
@@ -2980,7 +2980,7 @@ Take away ownership of geometry.
 the pointer to the geometry.
 """
 function ogr_f_stealgeometry(arg1)
-    failsafe(ccall((:OGR_F_StealGeometry, libgdal), OGRGeometryH, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_StealGeometry, libgdal), OGRGeometryH, (OGRFeatureH,), arg1))
 end
 
 """
@@ -2995,7 +2995,7 @@ Duplicate feature.
 an handle to the new feature, exactly matching this feature.
 """
 function ogr_f_clone(arg1)
-    failsafe(ccall((:OGR_F_Clone, libgdal), OGRFeatureH, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_Clone, libgdal), OGRFeatureH, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3012,7 +3012,7 @@ Test if two features are the same.
 TRUE if they are equal, otherwise FALSE.
 """
 function ogr_f_equal(arg1, arg2)
-    ccall((:OGR_F_Equal, libgdal), Cint, (OGRFeatureH, OGRFeatureH), arg1, arg2)
+    aftercare(ccall((:OGR_F_Equal, libgdal), Cint, (OGRFeatureH, OGRFeatureH), arg1, arg2))
 end
 
 """
@@ -3027,7 +3027,7 @@ Fetch number of fields on this feature This will always be the same as the field
 count of fields.
 """
 function ogr_f_getfieldcount(arg1)
-    ccall((:OGR_F_GetFieldCount, libgdal), Cint, (OGRFeatureH,), arg1)
+    aftercare(ccall((:OGR_F_GetFieldCount, libgdal), Cint, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3044,7 +3044,7 @@ Fetch definition for this field.
 an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
 """
 function ogr_f_getfielddefnref(arg1, arg2)
-    failsafe(ccall((:OGR_F_GetFieldDefnRef, libgdal), OGRFieldDefnH, (OGRFeatureH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_F_GetFieldDefnRef, libgdal), OGRFieldDefnH, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3061,7 +3061,7 @@ Fetch the field index given field name.
 the field index, or -1 if no matching field is found.
 """
 function ogr_f_getfieldindex(arg1, arg2)
-    ccall((:OGR_F_GetFieldIndex, libgdal), Cint, (OGRFeatureH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_F_GetFieldIndex, libgdal), Cint, (OGRFeatureH, Cstring), arg1, arg2))
 end
 
 """
@@ -3078,7 +3078,7 @@ Test if a field has ever been assigned a value or not.
 TRUE if the field has been set, otherwise false.
 """
 function ogr_f_isfieldset(arg1, arg2)
-    ccall((:OGR_F_IsFieldSet, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_IsFieldSet, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3092,7 +3092,7 @@ Clear a field, marking it as unset.
 * **iField**: the field to unset.
 """
 function ogr_f_unsetfield(arg1, arg2)
-    ccall((:OGR_F_UnsetField, libgdal), Cvoid, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_UnsetField, libgdal), Cvoid, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3109,7 +3109,7 @@ Test if a field is null.
 TRUE if the field is null, otherwise false.
 """
 function ogr_f_isfieldnull(arg1, arg2)
-    ccall((:OGR_F_IsFieldNull, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_IsFieldNull, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3126,7 +3126,7 @@ Test if a field is set and not null.
 TRUE if the field is set and not null, otherwise false.
 """
 function ogr_f_isfieldsetandnotnull(arg1, arg2)
-    ccall((:OGR_F_IsFieldSetAndNotNull, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_IsFieldSetAndNotNull, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3140,7 +3140,7 @@ Clear a field, marking it as null.
 * **iField**: the field to set to null.
 """
 function ogr_f_setfieldnull(arg1, arg2)
-    ccall((:OGR_F_SetFieldNull, libgdal), Cvoid, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetFieldNull, libgdal), Cvoid, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3157,7 +3157,7 @@ Fetch an handle to the internal field value given the index.
 the returned handle is to an internal data structure, and should not be freed, or modified.
 """
 function ogr_f_getrawfieldref(arg1, arg2)
-    ccall((:OGR_F_GetRawFieldRef, libgdal), Ptr{OGRField}, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_GetRawFieldRef, libgdal), Ptr{OGRField}, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3169,7 +3169,7 @@ Returns whether a raw field is unset.
 * **puField**: pointer to raw field.
 """
 function ogr_rawfield_isunset(arg1)
-    ccall((:OGR_RawField_IsUnset, libgdal), Cint, (Ptr{OGRField},), arg1)
+    aftercare(ccall((:OGR_RawField_IsUnset, libgdal), Cint, (Ptr{OGRField},), arg1))
 end
 
 """
@@ -3181,7 +3181,7 @@ Returns whether a raw field is null.
 * **puField**: pointer to raw field.
 """
 function ogr_rawfield_isnull(arg1)
-    ccall((:OGR_RawField_IsNull, libgdal), Cint, (Ptr{OGRField},), arg1)
+    aftercare(ccall((:OGR_RawField_IsNull, libgdal), Cint, (Ptr{OGRField},), arg1))
 end
 
 """
@@ -3193,7 +3193,7 @@ Mark a raw field as unset.
 * **puField**: pointer to raw field.
 """
 function ogr_rawfield_setunset(arg1)
-    ccall((:OGR_RawField_SetUnset, libgdal), Cvoid, (Ptr{OGRField},), arg1)
+    aftercare(ccall((:OGR_RawField_SetUnset, libgdal), Cvoid, (Ptr{OGRField},), arg1))
 end
 
 """
@@ -3205,7 +3205,7 @@ Mark a raw field as null.
 * **puField**: pointer to raw field.
 """
 function ogr_rawfield_setnull(arg1)
-    ccall((:OGR_RawField_SetNull, libgdal), Cvoid, (Ptr{OGRField},), arg1)
+    aftercare(ccall((:OGR_RawField_SetNull, libgdal), Cvoid, (Ptr{OGRField},), arg1))
 end
 
 """
@@ -3222,7 +3222,7 @@ Fetch field value as integer.
 the field value.
 """
 function ogr_f_getfieldasinteger(arg1, arg2)
-    ccall((:OGR_F_GetFieldAsInteger, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_GetFieldAsInteger, libgdal), Cint, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3239,7 +3239,7 @@ Fetch field value as integer 64 bit.
 the field value.
 """
 function ogr_f_getfieldasinteger64(arg1, arg2)
-    ccall((:OGR_F_GetFieldAsInteger64, libgdal), GIntBig, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_GetFieldAsInteger64, libgdal), GIntBig, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3256,7 +3256,7 @@ Fetch field value as a double.
 the field value.
 """
 function ogr_f_getfieldasdouble(arg1, arg2)
-    ccall((:OGR_F_GetFieldAsDouble, libgdal), Cdouble, (OGRFeatureH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_F_GetFieldAsDouble, libgdal), Cdouble, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3273,7 +3273,7 @@ Fetch field value as a string.
 the field value. This string is internal, and should not be modified, or freed. Its lifetime may be very brief.
 """
 function ogr_f_getfieldasstring(arg1, arg2)
-    string_or_nothing(ccall((:OGR_F_GetFieldAsString, libgdal), Cstring, (OGRFeatureH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_F_GetFieldAsString, libgdal), Cstring, (OGRFeatureH, Cint), arg1, arg2), false)
 end
 
 """
@@ -3292,7 +3292,7 @@ Fetch field value as a list of integers.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
 """
 function ogr_f_getfieldasintegerlist(arg1, arg2, arg3)
-    ccall((:OGR_F_GetFieldAsIntegerList, libgdal), Ptr{Cint}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_GetFieldAsIntegerList, libgdal), Ptr{Cint}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -3311,7 +3311,7 @@ Fetch field value as a list of 64 bit integers.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
 """
 function ogr_f_getfieldasinteger64list(arg1, arg2, arg3)
-    ccall((:OGR_F_GetFieldAsInteger64List, libgdal), Ptr{GIntBig}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_GetFieldAsInteger64List, libgdal), Ptr{GIntBig}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -3330,7 +3330,7 @@ Fetch field value as a list of doubles.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
 """
 function ogr_f_getfieldasdoublelist(arg1, arg2, arg3)
-    ccall((:OGR_F_GetFieldAsDoubleList, libgdal), Ptr{Cdouble}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_GetFieldAsDoubleList, libgdal), Ptr{Cdouble}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -3347,7 +3347,7 @@ Fetch field value as a list of strings.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
 """
 function ogr_f_getfieldasstringlist(arg1, arg2)
-    unsafe_loadstringlist(ccall((:OGR_F_GetFieldAsStringList, libgdal), Ptr{Cstring}, (OGRFeatureH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_F_GetFieldAsStringList, libgdal), Ptr{Cstring}, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3366,7 +3366,7 @@ Fetch field value as binary.
 the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
 """
 function ogr_f_getfieldasbinary(arg1, arg2, arg3)
-    ccall((:OGR_F_GetFieldAsBinary, libgdal), Ptr{GByte}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_GetFieldAsBinary, libgdal), Ptr{GByte}, (OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3))
 end
 
 """
@@ -3397,7 +3397,7 @@ Fetch field value as date and time.
 TRUE on success or FALSE on failure.
 """
 function ogr_f_getfieldasdatetime(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    ccall((:OGR_F_GetFieldAsDateTime, libgdal), Cint, (OGRFeatureH, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    aftercare(ccall((:OGR_F_GetFieldAsDateTime, libgdal), Cint, (OGRFeatureH, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
 end
 
 """
@@ -3428,7 +3428,7 @@ Fetch field value as date and time.
 TRUE on success or FALSE on failure.
 """
 function ogr_f_getfieldasdatetimeex(hFeat, iField, pnYear, pnMonth, pnDay, pnHour, pnMinute, pfSecond, pnTZFlag)
-    ccall((:OGR_F_GetFieldAsDateTimeEx, libgdal), Cint, (OGRFeatureH, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Ptr{Cint}), hFeat, iField, pnYear, pnMonth, pnDay, pnHour, pnMinute, pfSecond, pnTZFlag)
+    aftercare(ccall((:OGR_F_GetFieldAsDateTimeEx, libgdal), Cint, (OGRFeatureH, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Ptr{Cint}), hFeat, iField, pnYear, pnMonth, pnDay, pnHour, pnMinute, pfSecond, pnTZFlag))
 end
 
 """
@@ -3444,7 +3444,7 @@ Set field to integer value.
 * **nValue**: the value to assign.
 """
 function ogr_f_setfieldinteger(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldInteger, libgdal), Cvoid, (OGRFeatureH, Cint, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldInteger, libgdal), Cvoid, (OGRFeatureH, Cint, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -3460,7 +3460,7 @@ Set field to 64 bit integer value.
 * **nValue**: the value to assign.
 """
 function ogr_f_setfieldinteger64(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldInteger64, libgdal), Cvoid, (OGRFeatureH, Cint, GIntBig), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldInteger64, libgdal), Cvoid, (OGRFeatureH, Cint, GIntBig), arg1, arg2, arg3))
 end
 
 """
@@ -3476,7 +3476,7 @@ Set field to double value.
 * **dfValue**: the value to assign.
 """
 function ogr_f_setfielddouble(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldDouble, libgdal), Cvoid, (OGRFeatureH, Cint, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldDouble, libgdal), Cvoid, (OGRFeatureH, Cint, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -3492,7 +3492,7 @@ Set field to string value.
 * **pszValue**: the value to assign.
 """
 function ogr_f_setfieldstring(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldString, libgdal), Cvoid, (OGRFeatureH, Cint, Cstring), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldString, libgdal), Cvoid, (OGRFeatureH, Cint, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -3510,7 +3510,7 @@ Set field to list of integers value.
 * **panValues**: the values to assign.
 """
 function ogr_f_setfieldintegerlist(arg1, arg2, arg3, arg4)
-    ccall((:OGR_F_SetFieldIntegerList, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_F_SetFieldIntegerList, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3528,7 +3528,7 @@ Set field to list of 64 bit integers value.
 * **panValues**: the values to assign.
 """
 function ogr_f_setfieldinteger64list(arg1, arg2, arg3, arg4)
-    ccall((:OGR_F_SetFieldInteger64List, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{GIntBig}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_F_SetFieldInteger64List, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{GIntBig}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3546,7 +3546,7 @@ Set field to list of doubles value.
 * **padfValues**: the values to assign.
 """
 function ogr_f_setfielddoublelist(arg1, arg2, arg3, arg4)
-    ccall((:OGR_F_SetFieldDoubleList, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cdouble}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_F_SetFieldDoubleList, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cdouble}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3562,7 +3562,7 @@ Set field to list of strings value.
 * **papszValues**: the values to assign. List of NUL-terminated string, ending with a NULL pointer.
 """
 function ogr_f_setfieldstringlist(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldStringList, libgdal), Cvoid, (OGRFeatureH, Cint, CSLConstList), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldStringList, libgdal), Cvoid, (OGRFeatureH, Cint, CSLConstList), arg1, arg2, arg3))
 end
 
 """
@@ -3578,7 +3578,7 @@ Set field.
 * **psValue**: handle on the value to assign.
 """
 function ogr_f_setfieldraw(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFieldRaw, libgdal), Cvoid, (OGRFeatureH, Cint, Ptr{OGRField}), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFieldRaw, libgdal), Cvoid, (OGRFeatureH, Cint, Ptr{OGRField}), arg1, arg2, arg3))
 end
 
 """
@@ -3596,7 +3596,7 @@ Set field to binary data.
 * **pabyData**: the data to apply.
 """
 function ogr_f_setfieldbinary(arg1, arg2, arg3, arg4)
-    ccall((:OGR_F_SetFieldBinary, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_F_SetFieldBinary, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Ptr{Cvoid}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3624,7 +3624,7 @@ Set field to datetime.
 * **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
 """
 function ogr_f_setfielddatetime(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    ccall((:OGR_F_SetFieldDateTime, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    aftercare(ccall((:OGR_F_SetFieldDateTime, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
 end
 
 """
@@ -3652,7 +3652,7 @@ Set field to datetime.
 * **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
 """
 function ogr_f_setfielddatetimeex(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    ccall((:OGR_F_SetFieldDateTimeEx, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Cint, Cint, Cint, Cint, Cfloat, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    aftercare(ccall((:OGR_F_SetFieldDateTimeEx, libgdal), Cvoid, (OGRFeatureH, Cint, Cint, Cint, Cint, Cint, Cint, Cfloat, Cint), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
 end
 
 """
@@ -3667,7 +3667,7 @@ Fetch number of geometry fields on this feature This will always be the same as 
 count of geometry fields.
 """
 function ogr_f_getgeomfieldcount(hFeat)
-    ccall((:OGR_F_GetGeomFieldCount, libgdal), Cint, (OGRFeatureH,), hFeat)
+    aftercare(ccall((:OGR_F_GetGeomFieldCount, libgdal), Cint, (OGRFeatureH,), hFeat))
 end
 
 """
@@ -3684,7 +3684,7 @@ Fetch definition for this geometry field.
 an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
 """
 function ogr_f_getgeomfielddefnref(hFeat, iField)
-    failsafe(ccall((:OGR_F_GetGeomFieldDefnRef, libgdal), OGRGeomFieldDefnH, (OGRFeatureH, Cint), hFeat, iField))
+    aftercare(ccall((:OGR_F_GetGeomFieldDefnRef, libgdal), OGRGeomFieldDefnH, (OGRFeatureH, Cint), hFeat, iField))
 end
 
 """
@@ -3701,7 +3701,7 @@ Fetch the geometry field index given geometry field name.
 the geometry field index, or -1 if no matching geometry field is found.
 """
 function ogr_f_getgeomfieldindex(hFeat, pszName)
-    ccall((:OGR_F_GetGeomFieldIndex, libgdal), Cint, (OGRFeatureH, Cstring), hFeat, pszName)
+    aftercare(ccall((:OGR_F_GetGeomFieldIndex, libgdal), Cint, (OGRFeatureH, Cstring), hFeat, pszName))
 end
 
 """
@@ -3718,7 +3718,7 @@ Fetch an handle to feature geometry.
 an handle to internal feature geometry. This object should not be modified.
 """
 function ogr_f_getgeomfieldref(hFeat, iField)
-    failsafe(ccall((:OGR_F_GetGeomFieldRef, libgdal), OGRGeometryH, (OGRFeatureH, Cint), hFeat, iField))
+    aftercare(ccall((:OGR_F_GetGeomFieldRef, libgdal), OGRGeometryH, (OGRFeatureH, Cint), hFeat, iField))
 end
 
 """
@@ -3737,7 +3737,7 @@ Set feature geometry of a specified geometry field.
 OGRERR_NONE if successful, or OGRERR_FAILURE if the index is invalid, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function ogr_f_setgeomfielddirectly(hFeat, iField, hGeom)
-    ccall((:OGR_F_SetGeomFieldDirectly, libgdal), OGRErr, (OGRFeatureH, Cint, OGRGeometryH), hFeat, iField, hGeom)
+    aftercare(ccall((:OGR_F_SetGeomFieldDirectly, libgdal), OGRErr, (OGRFeatureH, Cint, OGRGeometryH), hFeat, iField, hGeom))
 end
 
 """
@@ -3756,7 +3756,7 @@ Set feature geometry of a specified geometry field.
 OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function ogr_f_setgeomfield(hFeat, iField, hGeom)
-    ccall((:OGR_F_SetGeomField, libgdal), OGRErr, (OGRFeatureH, Cint, OGRGeometryH), hFeat, iField, hGeom)
+    aftercare(ccall((:OGR_F_SetGeomField, libgdal), OGRErr, (OGRFeatureH, Cint, OGRGeometryH), hFeat, iField, hGeom))
 end
 
 """
@@ -3771,7 +3771,7 @@ Get feature identifier.
 feature id or OGRNullFID if none has been assigned.
 """
 function ogr_f_getfid(arg1)
-    ccall((:OGR_F_GetFID, libgdal), GIntBig, (OGRFeatureH,), arg1)
+    aftercare(ccall((:OGR_F_GetFID, libgdal), GIntBig, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3788,7 +3788,7 @@ Set the feature identifier.
 On success OGRERR_NONE, or on failure some other value.
 """
 function ogr_f_setfid(arg1, arg2)
-    ccall((:OGR_F_SetFID, libgdal), OGRErr, (OGRFeatureH, GIntBig), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetFID, libgdal), OGRErr, (OGRFeatureH, GIntBig), arg1, arg2))
 end
 
 """
@@ -3802,7 +3802,7 @@ Dump this feature in a human readable form.
 * **fpOut**: the stream to write to, such as strout.
 """
 function ogr_f_dumpreadable(arg1, arg2)
-    ccall((:OGR_F_DumpReadable, libgdal), Cvoid, (OGRFeatureH, Ptr{Cint}), arg1, arg2)
+    aftercare(ccall((:OGR_F_DumpReadable, libgdal), Cvoid, (OGRFeatureH, Ptr{Cint}), arg1, arg2))
 end
 
 """
@@ -3821,7 +3821,7 @@ Set one feature from another.
 OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
 """
 function ogr_f_setfrom(arg1, arg2, arg3)
-    ccall((:OGR_F_SetFrom, libgdal), OGRErr, (OGRFeatureH, OGRFeatureH, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_F_SetFrom, libgdal), OGRErr, (OGRFeatureH, OGRFeatureH, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -3842,7 +3842,7 @@ Set one feature from another.
 OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
 """
 function ogr_f_setfromwithmap(arg1, arg2, arg3, arg4)
-    ccall((:OGR_F_SetFromWithMap, libgdal), OGRErr, (OGRFeatureH, OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OGR_F_SetFromWithMap, libgdal), OGRErr, (OGRFeatureH, OGRFeatureH, Cint, Ptr{Cint}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -3857,7 +3857,7 @@ Fetch style string for this feature.
 a reference to a representation in string format, or NULL if there isn't one.
 """
 function ogr_f_getstylestring(arg1)
-    string_or_nothing(ccall((:OGR_F_GetStyleString, libgdal), Cstring, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetStyleString, libgdal), Cstring, (OGRFeatureH,), arg1), false)
 end
 
 """
@@ -3871,7 +3871,7 @@ Set feature style string.
 * **pszStyle**: the style string to apply to this feature, cannot be NULL.
 """
 function ogr_f_setstylestring(arg1, arg2)
-    ccall((:OGR_F_SetStyleString, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetStyleString, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2))
 end
 
 """
@@ -3885,7 +3885,7 @@ Set feature style string.
 * **pszStyle**: the style string to apply to this feature, cannot be NULL.
 """
 function ogr_f_setstylestringdirectly(arg1, arg2)
-    ccall((:OGR_F_SetStyleStringDirectly, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetStyleStringDirectly, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2))
 end
 
 """
@@ -3894,7 +3894,7 @@ end
 Return style table.
 """
 function ogr_f_getstyletable(arg1)
-    failsafe(ccall((:OGR_F_GetStyleTable, libgdal), OGRStyleTableH, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetStyleTable, libgdal), OGRStyleTableH, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3904,7 +3904,7 @@ end
 Set style table and take ownership.
 """
 function ogr_f_setstyletabledirectly(arg1, arg2)
-    ccall((:OGR_F_SetStyleTableDirectly, libgdal), Cvoid, (OGRFeatureH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetStyleTableDirectly, libgdal), Cvoid, (OGRFeatureH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -3914,7 +3914,7 @@ end
 Set style table.
 """
 function ogr_f_setstyletable(arg1, arg2)
-    ccall((:OGR_F_SetStyleTable, libgdal), Cvoid, (OGRFeatureH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetStyleTable, libgdal), Cvoid, (OGRFeatureH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -3929,7 +3929,7 @@ Returns the native data for the feature.
 a string with the native data, or NULL if there is none.
 """
 function ogr_f_getnativedata(arg1)
-    string_or_nothing(ccall((:OGR_F_GetNativeData, libgdal), Cstring, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetNativeData, libgdal), Cstring, (OGRFeatureH,), arg1), false)
 end
 
 """
@@ -3943,7 +3943,7 @@ Sets the native data for the feature.
 * **pszNativeData**: a string with the native data, or NULL if there is none.
 """
 function ogr_f_setnativedata(arg1, arg2)
-    ccall((:OGR_F_SetNativeData, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetNativeData, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2))
 end
 
 """
@@ -3958,7 +3958,7 @@ Returns the native media type for the feature.
 a string with the native media type, or NULL if there is none.
 """
 function ogr_f_getnativemediatype(arg1)
-    string_or_nothing(ccall((:OGR_F_GetNativeMediaType, libgdal), Cstring, (OGRFeatureH,), arg1))
+    aftercare(ccall((:OGR_F_GetNativeMediaType, libgdal), Cstring, (OGRFeatureH,), arg1), false)
 end
 
 """
@@ -3972,7 +3972,7 @@ Sets the native media type for the feature.
 * **pszNativeMediaType**: a string with the native media type, or NULL if there is none.
 """
 function ogr_f_setnativemediatype(arg1, arg2)
-    ccall((:OGR_F_SetNativeMediaType, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_F_SetNativeMediaType, libgdal), Cvoid, (OGRFeatureH, Cstring), arg1, arg2))
 end
 
 """
@@ -3988,7 +3988,7 @@ Fill unset fields with default values that might be defined.
 * **papszOptions**: unused currently. Must be set to NULL.
 """
 function ogr_f_fillunsetwithdefault(hFeat, bNotNullableOnly, papszOptions)
-    ccall((:OGR_F_FillUnsetWithDefault, libgdal), Cvoid, (OGRFeatureH, Cint, Ptr{Cstring}), hFeat, bNotNullableOnly, papszOptions)
+    aftercare(ccall((:OGR_F_FillUnsetWithDefault, libgdal), Cvoid, (OGRFeatureH, Cint, Ptr{Cstring}), hFeat, bNotNullableOnly, papszOptions))
 end
 
 """
@@ -4007,7 +4007,7 @@ Validate that a feature meets constraints of its schema.
 TRUE if all enabled validation tests pass.
 """
 function ogr_f_validate(arg1, nValidateFlags, bEmitError)
-    ccall((:OGR_F_Validate, libgdal), Cint, (OGRFeatureH, Cint, Cint), arg1, nValidateFlags, bEmitError)
+    aftercare(ccall((:OGR_F_Validate, libgdal), Cint, (OGRFeatureH, Cint, Cint), arg1, nValidateFlags, bEmitError))
 end
 
 """
@@ -4022,7 +4022,7 @@ Return the layer name.
 the layer name (must not been freed)
 """
 function ogr_l_getname(arg1)
-    string_or_nothing(ccall((:OGR_L_GetName, libgdal), Cstring, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetName, libgdal), Cstring, (OGRLayerH,), arg1), false)
 end
 
 """
@@ -4037,7 +4037,7 @@ Return the layer geometry type.
 the geometry type
 """
 function ogr_l_getgeomtype(arg1)
-    ccall((:OGR_L_GetGeomType, libgdal), OGRwkbGeometryType, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_GetGeomType, libgdal), OGRwkbGeometryType, (OGRLayerH,), arg1))
 end
 
 """
@@ -4052,7 +4052,7 @@ This function returns the current spatial filter for this layer.
 an handle to the spatial filter geometry.
 """
 function ogr_l_getspatialfilter(arg1)
-    failsafe(ccall((:OGR_L_GetSpatialFilter, libgdal), OGRGeometryH, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetSpatialFilter, libgdal), OGRGeometryH, (OGRLayerH,), arg1))
 end
 
 """
@@ -4066,7 +4066,7 @@ Set a new spatial filter.
 * **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
 """
 function ogr_l_setspatialfilter(arg1, arg2)
-    ccall((:OGR_L_SetSpatialFilter, libgdal), Cvoid, (OGRLayerH, OGRGeometryH), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetSpatialFilter, libgdal), Cvoid, (OGRLayerH, OGRGeometryH), arg1, arg2))
 end
 
 """
@@ -4086,7 +4086,7 @@ Set a new rectangular spatial filter.
 * **dfMaxY**: the maximum Y coordinate for the rectangular region.
 """
 function ogr_l_setspatialfilterrect(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OGR_L_SetSpatialFilterRect, libgdal), Cvoid, (OGRLayerH, Cdouble, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OGR_L_SetSpatialFilterRect, libgdal), Cvoid, (OGRLayerH, Cdouble, Cdouble, Cdouble, Cdouble), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -4102,7 +4102,7 @@ Set a new spatial filter.
 * **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
 """
 function ogr_l_setspatialfilterex(arg1, iGeomField, hGeom)
-    ccall((:OGR_L_SetSpatialFilterEx, libgdal), Cvoid, (OGRLayerH, Cint, OGRGeometryH), arg1, iGeomField, hGeom)
+    aftercare(ccall((:OGR_L_SetSpatialFilterEx, libgdal), Cvoid, (OGRLayerH, Cint, OGRGeometryH), arg1, iGeomField, hGeom))
 end
 
 """
@@ -4124,7 +4124,7 @@ Set a new rectangular spatial filter.
 * **dfMaxY**: the maximum Y coordinate for the rectangular region.
 """
 function ogr_l_setspatialfilterrectex(arg1, iGeomField, dfMinX, dfMinY, dfMaxX, dfMaxY)
-    ccall((:OGR_L_SetSpatialFilterRectEx, libgdal), Cvoid, (OGRLayerH, Cint, Cdouble, Cdouble, Cdouble, Cdouble), arg1, iGeomField, dfMinX, dfMinY, dfMaxX, dfMaxY)
+    aftercare(ccall((:OGR_L_SetSpatialFilterRectEx, libgdal), Cvoid, (OGRLayerH, Cint, Cdouble, Cdouble, Cdouble, Cdouble), arg1, iGeomField, dfMinX, dfMinY, dfMaxX, dfMaxY))
 end
 
 """
@@ -4141,7 +4141,7 @@ Set a new attribute query.
 OGRERR_NONE if successfully installed, or an error code if the query expression is in error, or some other failure occurs.
 """
 function ogr_l_setattributefilter(arg1, arg2)
-    ccall((:OGR_L_SetAttributeFilter, libgdal), OGRErr, (OGRLayerH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetAttributeFilter, libgdal), OGRErr, (OGRLayerH, Cstring), arg1, arg2))
 end
 
 """
@@ -4153,7 +4153,7 @@ Reset feature reading to start on the first feature.
 * **hLayer**: handle to the layer on which features are read.
 """
 function ogr_l_resetreading(arg1)
-    ccall((:OGR_L_ResetReading, libgdal), Cvoid, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_ResetReading, libgdal), Cvoid, (OGRLayerH,), arg1))
 end
 
 """
@@ -4168,7 +4168,7 @@ Fetch the next available feature from this layer.
 an handle to a feature, or NULL if no more features are available.
 """
 function ogr_l_getnextfeature(arg1)
-    failsafe(ccall((:OGR_L_GetNextFeature, libgdal), OGRFeatureH, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetNextFeature, libgdal), OGRFeatureH, (OGRLayerH,), arg1))
 end
 
 """
@@ -4185,7 +4185,7 @@ Move read cursor to the nIndex'th feature in the current resultset.
 OGRERR_NONE on success or an error code.
 """
 function ogr_l_setnextbyindex(arg1, arg2)
-    ccall((:OGR_L_SetNextByIndex, libgdal), OGRErr, (OGRLayerH, GIntBig), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetNextByIndex, libgdal), OGRErr, (OGRLayerH, GIntBig), arg1, arg2))
 end
 
 """
@@ -4202,7 +4202,7 @@ Fetch a feature by its identifier.
 an handle to a feature now owned by the caller, or NULL on failure.
 """
 function ogr_l_getfeature(arg1, arg2)
-    failsafe(ccall((:OGR_L_GetFeature, libgdal), OGRFeatureH, (OGRLayerH, GIntBig), arg1, arg2))
+    aftercare(ccall((:OGR_L_GetFeature, libgdal), OGRFeatureH, (OGRLayerH, GIntBig), arg1, arg2))
 end
 
 """
@@ -4219,7 +4219,7 @@ Rewrite an existing feature.
 OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
 """
 function ogr_l_setfeature(arg1, arg2)
-    ccall((:OGR_L_SetFeature, libgdal), OGRErr, (OGRLayerH, OGRFeatureH), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetFeature, libgdal), OGRErr, (OGRLayerH, OGRFeatureH), arg1, arg2))
 end
 
 """
@@ -4236,7 +4236,7 @@ Create and write a new feature within a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_createfeature(arg1, arg2)
-    ccall((:OGR_L_CreateFeature, libgdal), OGRErr, (OGRLayerH, OGRFeatureH), arg1, arg2)
+    aftercare(ccall((:OGR_L_CreateFeature, libgdal), OGRErr, (OGRLayerH, OGRFeatureH), arg1, arg2))
 end
 
 """
@@ -4253,7 +4253,7 @@ Delete feature from layer.
 OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
 """
 function ogr_l_deletefeature(arg1, arg2)
-    ccall((:OGR_L_DeleteFeature, libgdal), OGRErr, (OGRLayerH, GIntBig), arg1, arg2)
+    aftercare(ccall((:OGR_L_DeleteFeature, libgdal), OGRErr, (OGRLayerH, GIntBig), arg1, arg2))
 end
 
 """
@@ -4268,7 +4268,7 @@ Fetch the schema information for this layer.
 an handle to the feature definition.
 """
 function ogr_l_getlayerdefn(arg1)
-    failsafe(ccall((:OGR_L_GetLayerDefn, libgdal), OGRFeatureDefnH, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetLayerDefn, libgdal), OGRFeatureDefnH, (OGRLayerH,), arg1))
 end
 
 """
@@ -4283,7 +4283,7 @@ Fetch the spatial reference system for this layer.
 spatial reference, or NULL if there isn't one.
 """
 function ogr_l_getspatialref(arg1)
-    failsafe(ccall((:OGR_L_GetSpatialRef, libgdal), OGRSpatialReferenceH, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetSpatialRef, libgdal), OGRSpatialReferenceH, (OGRLayerH,), arg1))
 end
 
 """
@@ -4297,7 +4297,7 @@ Find the index of field in a layer.
 field index, or -1 if the field doesn't exist
 """
 function ogr_l_findfieldindex(arg1, arg2, bExactMatch)
-    ccall((:OGR_L_FindFieldIndex, libgdal), Cint, (OGRLayerH, Cstring, Cint), arg1, arg2, bExactMatch)
+    aftercare(ccall((:OGR_L_FindFieldIndex, libgdal), Cint, (OGRLayerH, Cstring, Cint), arg1, arg2, bExactMatch))
 end
 
 """
@@ -4314,7 +4314,7 @@ Fetch the feature count in this layer.
 feature count, -1 if count not known.
 """
 function ogr_l_getfeaturecount(arg1, arg2)
-    ccall((:OGR_L_GetFeatureCount, libgdal), GIntBig, (OGRLayerH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_L_GetFeatureCount, libgdal), GIntBig, (OGRLayerH, Cint), arg1, arg2))
 end
 
 """
@@ -4333,7 +4333,7 @@ Fetch the extent of this layer.
 OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
 """
 function ogr_l_getextent(arg1, arg2, arg3)
-    ccall((:OGR_L_GetExtent, libgdal), OGRErr, (OGRLayerH, Ptr{OGREnvelope}, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_L_GetExtent, libgdal), OGRErr, (OGRLayerH, Ptr{OGREnvelope}, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -4354,7 +4354,7 @@ Fetch the extent of this layer, on the specified geometry field.
 OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
 """
 function ogr_l_getextentex(arg1, iGeomField, psExtent, bForce)
-    ccall((:OGR_L_GetExtentEx, libgdal), OGRErr, (OGRLayerH, Cint, Ptr{OGREnvelope}, Cint), arg1, iGeomField, psExtent, bForce)
+    aftercare(ccall((:OGR_L_GetExtentEx, libgdal), OGRErr, (OGRLayerH, Cint, Ptr{OGREnvelope}, Cint), arg1, iGeomField, psExtent, bForce))
 end
 
 """
@@ -4371,7 +4371,7 @@ Test if this layer supported the named capability.
 TRUE if the layer has the requested capability, or FALSE otherwise. OGRLayers will return FALSE for any unrecognized capabilities.
 """
 function ogr_l_testcapability(arg1, arg2)
-    ccall((:OGR_L_TestCapability, libgdal), Cint, (OGRLayerH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_L_TestCapability, libgdal), Cint, (OGRLayerH, Cstring), arg1, arg2))
 end
 
 """
@@ -4390,7 +4390,7 @@ Create a new field on a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_createfield(arg1, arg2, arg3)
-    ccall((:OGR_L_CreateField, libgdal), OGRErr, (OGRLayerH, OGRFieldDefnH, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OGR_L_CreateField, libgdal), OGRErr, (OGRLayerH, OGRFieldDefnH, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -4409,7 +4409,7 @@ Create a new geometry field on a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_creategeomfield(hLayer, hFieldDefn, bForce)
-    ccall((:OGR_L_CreateGeomField, libgdal), OGRErr, (OGRLayerH, OGRGeomFieldDefnH, Cint), hLayer, hFieldDefn, bForce)
+    aftercare(ccall((:OGR_L_CreateGeomField, libgdal), OGRErr, (OGRLayerH, OGRGeomFieldDefnH, Cint), hLayer, hFieldDefn, bForce))
 end
 
 """
@@ -4426,7 +4426,7 @@ Delete an existing field on a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_deletefield(arg1, iField)
-    ccall((:OGR_L_DeleteField, libgdal), OGRErr, (OGRLayerH, Cint), arg1, iField)
+    aftercare(ccall((:OGR_L_DeleteField, libgdal), OGRErr, (OGRLayerH, Cint), arg1, iField))
 end
 
 """
@@ -4443,7 +4443,7 @@ Reorder all the fields of a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_reorderfields(arg1, panMap)
-    ccall((:OGR_L_ReorderFields, libgdal), OGRErr, (OGRLayerH, Ptr{Cint}), arg1, panMap)
+    aftercare(ccall((:OGR_L_ReorderFields, libgdal), OGRErr, (OGRLayerH, Ptr{Cint}), arg1, panMap))
 end
 
 """
@@ -4462,7 +4462,7 @@ Reorder an existing field on a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_reorderfield(arg1, iOldFieldPos, iNewFieldPos)
-    ccall((:OGR_L_ReorderField, libgdal), OGRErr, (OGRLayerH, Cint, Cint), arg1, iOldFieldPos, iNewFieldPos)
+    aftercare(ccall((:OGR_L_ReorderField, libgdal), OGRErr, (OGRLayerH, Cint, Cint), arg1, iOldFieldPos, iNewFieldPos))
 end
 
 """
@@ -4483,7 +4483,7 @@ Alter the definition of an existing field on a layer.
 OGRERR_NONE on success.
 """
 function ogr_l_alterfielddefn(arg1, iField, hNewFieldDefn, nFlags)
-    ccall((:OGR_L_AlterFieldDefn, libgdal), OGRErr, (OGRLayerH, Cint, OGRFieldDefnH, Cint), arg1, iField, hNewFieldDefn, nFlags)
+    aftercare(ccall((:OGR_L_AlterFieldDefn, libgdal), OGRErr, (OGRLayerH, Cint, OGRFieldDefnH, Cint), arg1, iField, hNewFieldDefn, nFlags))
 end
 
 """
@@ -4498,7 +4498,7 @@ For datasources which support transactions, StartTransaction creates a transacti
 OGRERR_NONE on success.
 """
 function ogr_l_starttransaction(arg1)
-    ccall((:OGR_L_StartTransaction, libgdal), OGRErr, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_StartTransaction, libgdal), OGRErr, (OGRLayerH,), arg1))
 end
 
 """
@@ -4513,7 +4513,7 @@ For datasources which support transactions, CommitTransaction commits a transact
 OGRERR_NONE on success.
 """
 function ogr_l_committransaction(arg1)
-    ccall((:OGR_L_CommitTransaction, libgdal), OGRErr, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_CommitTransaction, libgdal), OGRErr, (OGRLayerH,), arg1))
 end
 
 """
@@ -4528,28 +4528,28 @@ For datasources which support transactions, RollbackTransaction will roll back a
 OGRERR_NONE on success.
 """
 function ogr_l_rollbacktransaction(arg1)
-    ccall((:OGR_L_RollbackTransaction, libgdal), OGRErr, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_RollbackTransaction, libgdal), OGRErr, (OGRLayerH,), arg1))
 end
 
 """
     OGR_L_Reference(OGRLayerH hLayer) -> int
 """
 function ogr_l_reference(arg1)
-    ccall((:OGR_L_Reference, libgdal), Cint, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_Reference, libgdal), Cint, (OGRLayerH,), arg1))
 end
 
 """
     OGR_L_Dereference(OGRLayerH hLayer) -> int
 """
 function ogr_l_dereference(arg1)
-    ccall((:OGR_L_Dereference, libgdal), Cint, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_Dereference, libgdal), Cint, (OGRLayerH,), arg1))
 end
 
 """
     OGR_L_GetRefCount(OGRLayerH hLayer) -> int
 """
 function ogr_l_getrefcount(arg1)
-    ccall((:OGR_L_GetRefCount, libgdal), Cint, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_GetRefCount, libgdal), Cint, (OGRLayerH,), arg1))
 end
 
 """
@@ -4564,14 +4564,14 @@ Flush pending changes to disk.
 OGRERR_NONE if no error occurs (even if nothing is done) or an error code.
 """
 function ogr_l_synctodisk(arg1)
-    ccall((:OGR_L_SyncToDisk, libgdal), OGRErr, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_SyncToDisk, libgdal), OGRErr, (OGRLayerH,), arg1))
 end
 
 """
     OGR_L_GetFeaturesRead(OGRLayerH hLayer) -> GIntBig
 """
 function ogr_l_getfeaturesread(arg1)
-    ccall((:OGR_L_GetFeaturesRead, libgdal), GIntBig, (OGRLayerH,), arg1)
+    aftercare(ccall((:OGR_L_GetFeaturesRead, libgdal), GIntBig, (OGRLayerH,), arg1))
 end
 
 """
@@ -4586,7 +4586,7 @@ This method returns the name of the underlying database column being used as the
 fid column name.
 """
 function ogr_l_getfidcolumn(arg1)
-    string_or_nothing(ccall((:OGR_L_GetFIDColumn, libgdal), Cstring, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetFIDColumn, libgdal), Cstring, (OGRLayerH,), arg1), false)
 end
 
 """
@@ -4601,7 +4601,7 @@ This method returns the name of the underlying database column being used as the
 geometry column name.
 """
 function ogr_l_getgeometrycolumn(arg1)
-    string_or_nothing(ccall((:OGR_L_GetGeometryColumn, libgdal), Cstring, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetGeometryColumn, libgdal), Cstring, (OGRLayerH,), arg1), false)
 end
 
 """
@@ -4610,7 +4610,7 @@ end
 Get style table.
 """
 function ogr_l_getstyletable(arg1)
-    failsafe(ccall((:OGR_L_GetStyleTable, libgdal), OGRStyleTableH, (OGRLayerH,), arg1))
+    aftercare(ccall((:OGR_L_GetStyleTable, libgdal), OGRStyleTableH, (OGRLayerH,), arg1))
 end
 
 """
@@ -4620,7 +4620,7 @@ end
 Set style table (and take ownership)
 """
 function ogr_l_setstyletabledirectly(arg1, arg2)
-    ccall((:OGR_L_SetStyleTableDirectly, libgdal), Cvoid, (OGRLayerH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetStyleTableDirectly, libgdal), Cvoid, (OGRLayerH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -4630,7 +4630,7 @@ end
 Set style table.
 """
 function ogr_l_setstyletable(arg1, arg2)
-    ccall((:OGR_L_SetStyleTable, libgdal), Cvoid, (OGRLayerH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetStyleTable, libgdal), Cvoid, (OGRLayerH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -4646,7 +4646,7 @@ Set which fields can be omitted when retrieving features from the layer.
 OGRERR_NONE if all field names have been resolved (even if the driver does not support this method)
 """
 function ogr_l_setignoredfields(arg1, arg2)
-    ccall((:OGR_L_SetIgnoredFields, libgdal), OGRErr, (OGRLayerH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OGR_L_SetIgnoredFields, libgdal), OGRErr, (OGRLayerH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -4671,7 +4671,7 @@ Intersection of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_intersection(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Intersection, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Intersection, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4696,7 +4696,7 @@ Union of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_union(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Union, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Union, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4721,7 +4721,7 @@ Symmetrical difference of two layers.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_symdifference(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_SymDifference, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_SymDifference, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4746,7 +4746,7 @@ Identify the features of this layer with the ones from the identity layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_identity(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Identity, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Identity, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4771,7 +4771,7 @@ Update this layer with features from the update layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_update(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Update, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Update, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4796,7 +4796,7 @@ Clip off areas that are not covered by the method layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_clip(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Clip, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Clip, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4821,7 +4821,7 @@ Remove areas that are covered by the method layer.
 an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
 """
 function ogr_l_erase(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OGR_L_Erase, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OGR_L_Erase, libgdal), OGRErr, (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -4833,7 +4833,7 @@ Closes opened datasource and releases allocated resources.
 * **hDataSource**: handle to allocated datasource object.
 """
 function ogr_ds_destroy(arg1)
-    ccall((:OGR_DS_Destroy, libgdal), Cvoid, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_Destroy, libgdal), Cvoid, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -4848,7 +4848,7 @@ Returns the name of the data source.
 pointer to an internal name string which should not be modified or freed by the caller.
 """
 function ogr_ds_getname(arg1)
-    string_or_nothing(ccall((:OGR_DS_GetName, libgdal), Cstring, (OGRDataSourceH,), arg1))
+    aftercare(ccall((:OGR_DS_GetName, libgdal), Cstring, (OGRDataSourceH,), arg1), false)
 end
 
 """
@@ -4863,7 +4863,7 @@ Get the number of layers in this data source.
 layer count.
 """
 function ogr_ds_getlayercount(arg1)
-    ccall((:OGR_DS_GetLayerCount, libgdal), Cint, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_GetLayerCount, libgdal), Cint, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -4880,7 +4880,7 @@ Fetch a layer by index.
 an handle to the layer, or NULL if iLayer is out of range or an error occurs.
 """
 function ogr_ds_getlayer(arg1, arg2)
-    failsafe(ccall((:OGR_DS_GetLayer, libgdal), OGRLayerH, (OGRDataSourceH, Cint), arg1, arg2))
+    aftercare(ccall((:OGR_DS_GetLayer, libgdal), OGRLayerH, (OGRDataSourceH, Cint), arg1, arg2))
 end
 
 """
@@ -4897,7 +4897,7 @@ Fetch a layer by name.
 an handle to the layer, or NULL if the layer is not found or an error occurs.
 """
 function ogr_ds_getlayerbyname(arg1, arg2)
-    failsafe(ccall((:OGR_DS_GetLayerByName, libgdal), OGRLayerH, (OGRDataSourceH, Cstring), arg1, arg2))
+    aftercare(ccall((:OGR_DS_GetLayerByName, libgdal), OGRLayerH, (OGRDataSourceH, Cstring), arg1, arg2))
 end
 
 """
@@ -4914,7 +4914,7 @@ Delete the indicated layer from the datasource.
 OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
 """
 function ogr_ds_deletelayer(arg1, arg2)
-    ccall((:OGR_DS_DeleteLayer, libgdal), OGRErr, (OGRDataSourceH, Cint), arg1, arg2)
+    aftercare(ccall((:OGR_DS_DeleteLayer, libgdal), OGRErr, (OGRDataSourceH, Cint), arg1, arg2))
 end
 
 """
@@ -4929,7 +4929,7 @@ Returns the driver that the dataset was opened with.
 NULL if driver info is not available, or pointer to a driver owned by the OGRSFDriverManager.
 """
 function ogr_ds_getdriver(arg1)
-    failsafe(ccall((:OGR_DS_GetDriver, libgdal), OGRSFDriverH, (OGRDataSourceH,), arg1))
+    aftercare(ccall((:OGR_DS_GetDriver, libgdal), OGRSFDriverH, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -4952,7 +4952,7 @@ This function attempts to create a new layer on the data source with the indicat
 NULL is returned on failure, or a new OGRLayer handle on success.
 """
 function ogr_ds_createlayer(arg1, arg2, arg3, arg4, arg5)
-    failsafe(ccall((:OGR_DS_CreateLayer, libgdal), OGRLayerH, (OGRDataSourceH, Cstring, OGRSpatialReferenceH, OGRwkbGeometryType, Ptr{Cstring}), arg1, arg2, arg3, arg4, arg5))
+    aftercare(ccall((:OGR_DS_CreateLayer, libgdal), OGRLayerH, (OGRDataSourceH, Cstring, OGRSpatialReferenceH, OGRwkbGeometryType, Ptr{Cstring}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -4973,7 +4973,7 @@ Duplicate an existing layer.
 an handle to the layer, or NULL if an error occurs.
 """
 function ogr_ds_copylayer(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:OGR_DS_CopyLayer, libgdal), OGRLayerH, (OGRDataSourceH, OGRLayerH, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:OGR_DS_CopyLayer, libgdal), OGRLayerH, (OGRDataSourceH, OGRLayerH, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -4990,7 +4990,7 @@ Test if capability is available.
 TRUE if capability available otherwise FALSE.
 """
 function ogr_ds_testcapability(arg1, arg2)
-    ccall((:OGR_DS_TestCapability, libgdal), Cint, (OGRDataSourceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_DS_TestCapability, libgdal), Cint, (OGRDataSourceH, Cstring), arg1, arg2))
 end
 
 """
@@ -5011,7 +5011,7 @@ Execute an SQL statement against the data store.
 an handle to a OGRLayer containing the results of the query. Deallocate with OGR_DS_ReleaseResultSet().
 """
 function ogr_ds_executesql(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:OGR_DS_ExecuteSQL, libgdal), OGRLayerH, (OGRDataSourceH, Cstring, OGRGeometryH, Cstring), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:OGR_DS_ExecuteSQL, libgdal), OGRLayerH, (OGRDataSourceH, Cstring, OGRGeometryH, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -5025,35 +5025,35 @@ Release results of OGR_DS_ExecuteSQL().
 * **hLayer**: handle to the result of a previous OGR_DS_ExecuteSQL() call.
 """
 function ogr_ds_releaseresultset(arg1, arg2)
-    ccall((:OGR_DS_ReleaseResultSet, libgdal), Cvoid, (OGRDataSourceH, OGRLayerH), arg1, arg2)
+    aftercare(ccall((:OGR_DS_ReleaseResultSet, libgdal), Cvoid, (OGRDataSourceH, OGRLayerH), arg1, arg2))
 end
 
 """
     OGR_DS_Reference(OGRDataSourceH hDataSource) -> int
 """
 function ogr_ds_reference(arg1)
-    ccall((:OGR_DS_Reference, libgdal), Cint, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_Reference, libgdal), Cint, (OGRDataSourceH,), arg1))
 end
 
 """
     OGR_DS_Dereference(OGRDataSourceH hDataSource) -> int
 """
 function ogr_ds_dereference(arg1)
-    ccall((:OGR_DS_Dereference, libgdal), Cint, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_Dereference, libgdal), Cint, (OGRDataSourceH,), arg1))
 end
 
 """
     OGR_DS_GetRefCount(OGRDataSourceH hDataSource) -> int
 """
 function ogr_ds_getrefcount(arg1)
-    ccall((:OGR_DS_GetRefCount, libgdal), Cint, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_GetRefCount, libgdal), Cint, (OGRDataSourceH,), arg1))
 end
 
 """
     OGR_DS_GetSummaryRefCount(OGRDataSourceH hDataSource) -> int
 """
 function ogr_ds_getsummaryrefcount(arg1)
-    ccall((:OGR_DS_GetSummaryRefCount, libgdal), Cint, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_GetSummaryRefCount, libgdal), Cint, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -5062,7 +5062,7 @@ end
 Flush pending changes to disk.
 """
 function ogr_ds_synctodisk(arg1)
-    ccall((:OGR_DS_SyncToDisk, libgdal), OGRErr, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGR_DS_SyncToDisk, libgdal), OGRErr, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -5071,7 +5071,7 @@ end
 Get style table.
 """
 function ogr_ds_getstyletable(arg1)
-    failsafe(ccall((:OGR_DS_GetStyleTable, libgdal), OGRStyleTableH, (OGRDataSourceH,), arg1))
+    aftercare(ccall((:OGR_DS_GetStyleTable, libgdal), OGRStyleTableH, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -5081,7 +5081,7 @@ end
 Set style table (and take ownership)
 """
 function ogr_ds_setstyletabledirectly(arg1, arg2)
-    ccall((:OGR_DS_SetStyleTableDirectly, libgdal), Cvoid, (OGRDataSourceH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_DS_SetStyleTableDirectly, libgdal), Cvoid, (OGRDataSourceH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -5091,7 +5091,7 @@ end
 Set style table.
 """
 function ogr_ds_setstyletable(arg1, arg2)
-    ccall((:OGR_DS_SetStyleTable, libgdal), Cvoid, (OGRDataSourceH, OGRStyleTableH), arg1, arg2)
+    aftercare(ccall((:OGR_DS_SetStyleTable, libgdal), Cvoid, (OGRDataSourceH, OGRStyleTableH), arg1, arg2))
 end
 
 """
@@ -5106,7 +5106,7 @@ Fetch name of driver (file format).
 driver name. This is an internal string and should not be modified or freed.
 """
 function ogr_dr_getname(arg1)
-    string_or_nothing(ccall((:OGR_Dr_GetName, libgdal), Cstring, (OGRSFDriverH,), arg1))
+    aftercare(ccall((:OGR_Dr_GetName, libgdal), Cstring, (OGRSFDriverH,), arg1), false)
 end
 
 """
@@ -5125,7 +5125,7 @@ Attempt to open file with this driver.
 NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
 """
 function ogr_dr_open(arg1, arg2, arg3)
-    failsafe(ccall((:OGR_Dr_Open, libgdal), OGRDataSourceH, (OGRSFDriverH, Cstring, Cint), arg1, arg2, arg3))
+    aftercare(ccall((:OGR_Dr_Open, libgdal), OGRDataSourceH, (OGRSFDriverH, Cstring, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -5142,7 +5142,7 @@ Test if capability is available.
 TRUE if capability available otherwise FALSE.
 """
 function ogr_dr_testcapability(arg1, arg2)
-    ccall((:OGR_Dr_TestCapability, libgdal), Cint, (OGRSFDriverH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_Dr_TestCapability, libgdal), Cint, (OGRSFDriverH, Cstring), arg1, arg2))
 end
 
 """
@@ -5161,7 +5161,7 @@ This function attempts to create a new data source based on the passed driver.
 NULL is returned on failure, or a new OGRDataSource handle on success.
 """
 function ogr_dr_createdatasource(arg1, arg2, arg3)
-    failsafe(ccall((:OGR_Dr_CreateDataSource, libgdal), OGRDataSourceH, (OGRSFDriverH, Cstring, Ptr{Cstring}), arg1, arg2, arg3))
+    aftercare(ccall((:OGR_Dr_CreateDataSource, libgdal), OGRDataSourceH, (OGRSFDriverH, Cstring, Ptr{Cstring}), arg1, arg2, arg3))
 end
 
 """
@@ -5182,7 +5182,7 @@ This function creates a new datasource by copying all the layers from the source
 NULL is returned on failure, or a new OGRDataSource handle on success.
 """
 function ogr_dr_copydatasource(arg1, arg2, arg3, arg4)
-    failsafe(ccall((:OGR_Dr_CopyDataSource, libgdal), OGRDataSourceH, (OGRSFDriverH, OGRDataSourceH, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
+    aftercare(ccall((:OGR_Dr_CopyDataSource, libgdal), OGRDataSourceH, (OGRSFDriverH, OGRDataSourceH, Cstring, Ptr{Cstring}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -5199,7 +5199,7 @@ Delete a datasource.
 OGRERR_NONE on success, and OGRERR_UNSUPPORTED_OPERATION if this is not supported by this driver.
 """
 function ogr_dr_deletedatasource(arg1, arg2)
-    ccall((:OGR_Dr_DeleteDataSource, libgdal), OGRErr, (OGRSFDriverH, Cstring), arg1, arg2)
+    aftercare(ccall((:OGR_Dr_DeleteDataSource, libgdal), OGRErr, (OGRSFDriverH, Cstring), arg1, arg2))
 end
 
 """
@@ -5218,7 +5218,7 @@ Open a file / data source with one of the registered drivers.
 NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
 """
 function ogropen(arg1, arg2, arg3)
-    failsafe(ccall((:OGROpen, libgdal), OGRDataSourceH, (Cstring, Cint, Ptr{OGRSFDriverH}), arg1, arg2, arg3))
+    aftercare(ccall((:OGROpen, libgdal), OGRDataSourceH, (Cstring, Cint, Ptr{OGRSFDriverH}), arg1, arg2, arg3))
 end
 
 """
@@ -5237,7 +5237,7 @@ Open a file / data source with one of the registered drivers if not already open
 NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
 """
 function ogropenshared(arg1, arg2, arg3)
-    failsafe(ccall((:OGROpenShared, libgdal), OGRDataSourceH, (Cstring, Cint, Ptr{OGRSFDriverH}), arg1, arg2, arg3))
+    aftercare(ccall((:OGROpenShared, libgdal), OGRDataSourceH, (Cstring, Cint, Ptr{OGRSFDriverH}), arg1, arg2, arg3))
 end
 
 """
@@ -5252,15 +5252,15 @@ Drop a reference to this datasource, and if the reference count drops to zero cl
 OGRERR_NONE on success or an error code.
 """
 function ogrreleasedatasource(arg1)
-    ccall((:OGRReleaseDataSource, libgdal), OGRErr, (OGRDataSourceH,), arg1)
+    aftercare(ccall((:OGRReleaseDataSource, libgdal), OGRErr, (OGRDataSourceH,), arg1))
 end
 
 function ogrregisterdriver(arg1)
-    ccall((:OGRRegisterDriver, libgdal), Cvoid, (OGRSFDriverH,), arg1)
+    aftercare(ccall((:OGRRegisterDriver, libgdal), Cvoid, (OGRSFDriverH,), arg1))
 end
 
 function ogrderegisterdriver(arg1)
-    ccall((:OGRDeregisterDriver, libgdal), Cvoid, (OGRSFDriverH,), arg1)
+    aftercare(ccall((:OGRDeregisterDriver, libgdal), Cvoid, (OGRSFDriverH,), arg1))
 end
 
 """
@@ -5272,7 +5272,7 @@ Fetch the number of registered drivers.
 the drivers count.
 """
 function ogrgetdrivercount()
-    ccall((:OGRGetDriverCount, libgdal), Cint, ())
+    aftercare(ccall((:OGRGetDriverCount, libgdal), Cint, ()))
 end
 
 """
@@ -5287,7 +5287,7 @@ Fetch the indicated driver.
 handle to the driver, or NULL if iDriver is out of range.
 """
 function ogrgetdriver(arg1)
-    failsafe(ccall((:OGRGetDriver, libgdal), OGRSFDriverH, (Cint,), arg1))
+    aftercare(ccall((:OGRGetDriver, libgdal), OGRSFDriverH, (Cint,), arg1))
 end
 
 """
@@ -5302,15 +5302,15 @@ Fetch the indicated driver.
 the driver, or NULL if no driver with that name is found
 """
 function ogrgetdriverbyname(arg1)
-    failsafe(ccall((:OGRGetDriverByName, libgdal), OGRSFDriverH, (Cstring,), arg1))
+    aftercare(ccall((:OGRGetDriverByName, libgdal), OGRSFDriverH, (Cstring,), arg1))
 end
 
 function ogrgetopendscount()
-    ccall((:OGRGetOpenDSCount, libgdal), Cint, ())
+    aftercare(ccall((:OGRGetOpenDSCount, libgdal), Cint, ()))
 end
 
 function ogrgetopends(iDS)
-    failsafe(ccall((:OGRGetOpenDS, libgdal), OGRDataSourceH, (Cint,), iDS))
+    aftercare(ccall((:OGRGetOpenDS, libgdal), OGRDataSourceH, (Cint,), iDS))
 end
 
 """
@@ -5319,7 +5319,7 @@ end
 Register all drivers.
 """
 function ogrregisterall()
-    ccall((:OGRRegisterAll, libgdal), Cvoid, ())
+    aftercare(ccall((:OGRRegisterAll, libgdal), Cvoid, ()))
 end
 
 """
@@ -5328,7 +5328,7 @@ end
 Clean-up all drivers (including raster ones starting with GDAL 2.0.
 """
 function ogrcleanupall()
-    ccall((:OGRCleanupAll, libgdal), Cvoid, ())
+    aftercare(ccall((:OGRCleanupAll, libgdal), Cvoid, ()))
 end
 
 """
@@ -5343,7 +5343,7 @@ OGRStyleMgr factory.
 an handle to the new style manager object.
 """
 function ogr_sm_create(hStyleTable)
-    failsafe(ccall((:OGR_SM_Create, libgdal), OGRStyleMgrH, (OGRStyleTableH,), hStyleTable))
+    aftercare(ccall((:OGR_SM_Create, libgdal), OGRStyleMgrH, (OGRStyleTableH,), hStyleTable))
 end
 
 """
@@ -5355,7 +5355,7 @@ Destroy Style Manager.
 * **hSM**: handle to the style manager to destroy.
 """
 function ogr_sm_destroy(hSM)
-    ccall((:OGR_SM_Destroy, libgdal), Cvoid, (OGRStyleMgrH,), hSM)
+    aftercare(ccall((:OGR_SM_Destroy, libgdal), Cvoid, (OGRStyleMgrH,), hSM))
 end
 
 """
@@ -5372,7 +5372,7 @@ Initialize style manager from the style string of a feature.
 a reference to the style string read from the feature, or NULL in case of error.
 """
 function ogr_sm_initfromfeature(hSM, hFeat)
-    string_or_nothing(ccall((:OGR_SM_InitFromFeature, libgdal), Cstring, (OGRStyleMgrH, OGRFeatureH), hSM, hFeat))
+    aftercare(ccall((:OGR_SM_InitFromFeature, libgdal), Cstring, (OGRStyleMgrH, OGRFeatureH), hSM, hFeat), false)
 end
 
 """
@@ -5389,7 +5389,7 @@ Initialize style manager from the style string.
 TRUE on success, FALSE on errors.
 """
 function ogr_sm_initstylestring(hSM, pszStyleString)
-    ccall((:OGR_SM_InitStyleString, libgdal), Cint, (OGRStyleMgrH, Cstring), hSM, pszStyleString)
+    aftercare(ccall((:OGR_SM_InitStyleString, libgdal), Cint, (OGRStyleMgrH, Cstring), hSM, pszStyleString))
 end
 
 """
@@ -5406,7 +5406,7 @@ Get the number of parts in a style.
 the number of parts (style tools) in the style.
 """
 function ogr_sm_getpartcount(hSM, pszStyleString)
-    ccall((:OGR_SM_GetPartCount, libgdal), Cint, (OGRStyleMgrH, Cstring), hSM, pszStyleString)
+    aftercare(ccall((:OGR_SM_GetPartCount, libgdal), Cint, (OGRStyleMgrH, Cstring), hSM, pszStyleString))
 end
 
 """
@@ -5425,7 +5425,7 @@ Fetch a part (style tool) from the current style.
 OGRStyleToolH of the requested part (style tools) or NULL on error.
 """
 function ogr_sm_getpart(hSM, nPartId, pszStyleString)
-    failsafe(ccall((:OGR_SM_GetPart, libgdal), OGRStyleToolH, (OGRStyleMgrH, Cint, Cstring), hSM, nPartId, pszStyleString))
+    aftercare(ccall((:OGR_SM_GetPart, libgdal), OGRStyleToolH, (OGRStyleMgrH, Cint, Cstring), hSM, nPartId, pszStyleString))
 end
 
 """
@@ -5442,7 +5442,7 @@ Add a part (style tool) to the current style.
 TRUE on success, FALSE on errors.
 """
 function ogr_sm_addpart(hSM, hST)
-    ccall((:OGR_SM_AddPart, libgdal), Cint, (OGRStyleMgrH, OGRStyleToolH), hSM, hST)
+    aftercare(ccall((:OGR_SM_AddPart, libgdal), Cint, (OGRStyleMgrH, OGRStyleToolH), hSM, hST))
 end
 
 """
@@ -5461,7 +5461,7 @@ Add a style to the current style table.
 TRUE on success, FALSE on errors.
 """
 function ogr_sm_addstyle(hSM, pszStyleName, pszStyleString)
-    ccall((:OGR_SM_AddStyle, libgdal), Cint, (OGRStyleMgrH, Cstring, Cstring), hSM, pszStyleName, pszStyleString)
+    aftercare(ccall((:OGR_SM_AddStyle, libgdal), Cint, (OGRStyleMgrH, Cstring, Cstring), hSM, pszStyleName, pszStyleString))
 end
 
 """
@@ -5476,7 +5476,7 @@ OGRStyleTool factory.
 an handle to the new style tool object or NULL if the creation failed.
 """
 function ogr_st_create(eClassId)
-    failsafe(ccall((:OGR_ST_Create, libgdal), OGRStyleToolH, (OGRSTClassId,), eClassId))
+    aftercare(ccall((:OGR_ST_Create, libgdal), OGRStyleToolH, (OGRSTClassId,), eClassId))
 end
 
 """
@@ -5488,7 +5488,7 @@ Destroy Style Tool.
 * **hST**: handle to the style tool to destroy.
 """
 function ogr_st_destroy(hST)
-    ccall((:OGR_ST_Destroy, libgdal), Cvoid, (OGRStyleToolH,), hST)
+    aftercare(ccall((:OGR_ST_Destroy, libgdal), Cvoid, (OGRStyleToolH,), hST))
 end
 
 """
@@ -5503,7 +5503,7 @@ Determine type of Style Tool.
 the style tool type, one of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
 """
 function ogr_st_gettype(hST)
-    ccall((:OGR_ST_GetType, libgdal), OGRSTClassId, (OGRStyleToolH,), hST)
+    aftercare(ccall((:OGR_ST_GetType, libgdal), OGRSTClassId, (OGRStyleToolH,), hST))
 end
 
 """
@@ -5518,7 +5518,7 @@ Get Style Tool units.
 the style tool units.
 """
 function ogr_st_getunit(hST)
-    ccall((:OGR_ST_GetUnit, libgdal), OGRSTUnitId, (OGRStyleToolH,), hST)
+    aftercare(ccall((:OGR_ST_GetUnit, libgdal), OGRSTUnitId, (OGRStyleToolH,), hST))
 end
 
 """
@@ -5534,7 +5534,7 @@ Set Style Tool units.
 * **dfGroundPaperScale**: ground to paper scale factor.
 """
 function ogr_st_setunit(hST, eUnit, dfGroundPaperScale)
-    ccall((:OGR_ST_SetUnit, libgdal), Cvoid, (OGRStyleToolH, OGRSTUnitId, Cdouble), hST, eUnit, dfGroundPaperScale)
+    aftercare(ccall((:OGR_ST_SetUnit, libgdal), Cvoid, (OGRStyleToolH, OGRSTUnitId, Cdouble), hST, eUnit, dfGroundPaperScale))
 end
 
 """
@@ -5553,7 +5553,7 @@ Get Style Tool parameter value as string.
 the parameter value as string and sets bValueIsNull.
 """
 function ogr_st_getparamstr(hST, eParam, bValueIsNull)
-    string_or_nothing(ccall((:OGR_ST_GetParamStr, libgdal), Cstring, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull))
+    aftercare(ccall((:OGR_ST_GetParamStr, libgdal), Cstring, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull), false)
 end
 
 """
@@ -5572,7 +5572,7 @@ Get Style Tool parameter value as an integer.
 the parameter value as integer and sets bValueIsNull.
 """
 function ogr_st_getparamnum(hST, eParam, bValueIsNull)
-    ccall((:OGR_ST_GetParamNum, libgdal), Cint, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull)
+    aftercare(ccall((:OGR_ST_GetParamNum, libgdal), Cint, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull))
 end
 
 """
@@ -5591,7 +5591,7 @@ Get Style Tool parameter value as a double.
 the parameter value as double and sets bValueIsNull.
 """
 function ogr_st_getparamdbl(hST, eParam, bValueIsNull)
-    ccall((:OGR_ST_GetParamDbl, libgdal), Cdouble, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull)
+    aftercare(ccall((:OGR_ST_GetParamDbl, libgdal), Cdouble, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull))
 end
 
 """
@@ -5607,7 +5607,7 @@ Set Style Tool parameter value from a string.
 * **pszValue**: the new parameter value
 """
 function ogr_st_setparamstr(hST, eParam, pszValue)
-    ccall((:OGR_ST_SetParamStr, libgdal), Cvoid, (OGRStyleToolH, Cint, Cstring), hST, eParam, pszValue)
+    aftercare(ccall((:OGR_ST_SetParamStr, libgdal), Cvoid, (OGRStyleToolH, Cint, Cstring), hST, eParam, pszValue))
 end
 
 """
@@ -5623,7 +5623,7 @@ Set Style Tool parameter value from an integer.
 * **nValue**: the new parameter value
 """
 function ogr_st_setparamnum(hST, eParam, nValue)
-    ccall((:OGR_ST_SetParamNum, libgdal), Cvoid, (OGRStyleToolH, Cint, Cint), hST, eParam, nValue)
+    aftercare(ccall((:OGR_ST_SetParamNum, libgdal), Cvoid, (OGRStyleToolH, Cint, Cint), hST, eParam, nValue))
 end
 
 """
@@ -5639,7 +5639,7 @@ Set Style Tool parameter value from a double.
 * **dfValue**: the new parameter value
 """
 function ogr_st_setparamdbl(hST, eParam, dfValue)
-    ccall((:OGR_ST_SetParamDbl, libgdal), Cvoid, (OGRStyleToolH, Cint, Cdouble), hST, eParam, dfValue)
+    aftercare(ccall((:OGR_ST_SetParamDbl, libgdal), Cvoid, (OGRStyleToolH, Cint, Cdouble), hST, eParam, dfValue))
 end
 
 """
@@ -5654,7 +5654,7 @@ Get the style string for this Style Tool.
 the style string for this style tool or "" if the hST is invalid.
 """
 function ogr_st_getstylestring(hST)
-    string_or_nothing(ccall((:OGR_ST_GetStyleString, libgdal), Cstring, (OGRStyleToolH,), hST))
+    aftercare(ccall((:OGR_ST_GetStyleString, libgdal), Cstring, (OGRStyleToolH,), hST), false)
 end
 
 """
@@ -5679,7 +5679,7 @@ Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
 TRUE if the color could be successfully parsed, or FALSE in case of errors.
 """
 function ogr_st_getrgbfromstring(hST, pszColor, pnRed, pnGreen, pnBlue, pnAlpha)
-    ccall((:OGR_ST_GetRGBFromString, libgdal), Cint, (OGRStyleToolH, Cstring, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), hST, pszColor, pnRed, pnGreen, pnBlue, pnAlpha)
+    aftercare(ccall((:OGR_ST_GetRGBFromString, libgdal), Cint, (OGRStyleToolH, Cstring, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), hST, pszColor, pnRed, pnGreen, pnBlue, pnAlpha))
 end
 
 """
@@ -5691,7 +5691,7 @@ OGRStyleTable factory.
 an handle to the new style table object.
 """
 function ogr_stbl_create()
-    failsafe(ccall((:OGR_STBL_Create, libgdal), OGRStyleTableH, ()))
+    aftercare(ccall((:OGR_STBL_Create, libgdal), OGRStyleTableH, ()))
 end
 
 """
@@ -5703,7 +5703,7 @@ Destroy Style Table.
 * **hSTBL**: handle to the style table to destroy.
 """
 function ogr_stbl_destroy(hSTBL)
-    ccall((:OGR_STBL_Destroy, libgdal), Cvoid, (OGRStyleTableH,), hSTBL)
+    aftercare(ccall((:OGR_STBL_Destroy, libgdal), Cvoid, (OGRStyleTableH,), hSTBL))
 end
 
 """
@@ -5722,7 +5722,7 @@ Add a new style in the table.
 TRUE on success, FALSE on error
 """
 function ogr_stbl_addstyle(hStyleTable, pszName, pszStyleString)
-    ccall((:OGR_STBL_AddStyle, libgdal), Cint, (OGRStyleTableH, Cstring, Cstring), hStyleTable, pszName, pszStyleString)
+    aftercare(ccall((:OGR_STBL_AddStyle, libgdal), Cint, (OGRStyleTableH, Cstring, Cstring), hStyleTable, pszName, pszStyleString))
 end
 
 """
@@ -5739,7 +5739,7 @@ Save a style table to a file.
 TRUE on success, FALSE on error
 """
 function ogr_stbl_savestyletable(hStyleTable, pszFilename)
-    ccall((:OGR_STBL_SaveStyleTable, libgdal), Cint, (OGRStyleTableH, Cstring), hStyleTable, pszFilename)
+    aftercare(ccall((:OGR_STBL_SaveStyleTable, libgdal), Cint, (OGRStyleTableH, Cstring), hStyleTable, pszFilename))
 end
 
 """
@@ -5756,7 +5756,7 @@ Load a style table from a file.
 TRUE on success, FALSE on error
 """
 function ogr_stbl_loadstyletable(hStyleTable, pszFilename)
-    ccall((:OGR_STBL_LoadStyleTable, libgdal), Cint, (OGRStyleTableH, Cstring), hStyleTable, pszFilename)
+    aftercare(ccall((:OGR_STBL_LoadStyleTable, libgdal), Cint, (OGRStyleTableH, Cstring), hStyleTable, pszFilename))
 end
 
 """
@@ -5773,7 +5773,7 @@ Get a style string by name.
 the style string matching the name or NULL if not found or error.
 """
 function ogr_stbl_find(hStyleTable, pszName)
-    string_or_nothing(ccall((:OGR_STBL_Find, libgdal), Cstring, (OGRStyleTableH, Cstring), hStyleTable, pszName))
+    aftercare(ccall((:OGR_STBL_Find, libgdal), Cstring, (OGRStyleTableH, Cstring), hStyleTable, pszName), false)
 end
 
 """
@@ -5785,7 +5785,7 @@ Reset the next style pointer to 0.
 * **hStyleTable**: handle to the style table.
 """
 function ogr_stbl_resetstylestringreading(hStyleTable)
-    ccall((:OGR_STBL_ResetStyleStringReading, libgdal), Cvoid, (OGRStyleTableH,), hStyleTable)
+    aftercare(ccall((:OGR_STBL_ResetStyleStringReading, libgdal), Cvoid, (OGRStyleTableH,), hStyleTable))
 end
 
 """
@@ -5800,7 +5800,7 @@ Get the next style string from the table.
 the next style string or NULL on error.
 """
 function ogr_stbl_getnextstyle(hStyleTable)
-    string_or_nothing(ccall((:OGR_STBL_GetNextStyle, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
+    aftercare(ccall((:OGR_STBL_GetNextStyle, libgdal), Cstring, (OGRStyleTableH,), hStyleTable), false)
 end
 
 """
@@ -5815,5 +5815,5 @@ Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
 the Name of the last style string or NULL on error.
 """
 function ogr_stbl_getlaststylename(hStyleTable)
-    string_or_nothing(ccall((:OGR_STBL_GetLastStyleName, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
+    aftercare(ccall((:OGR_STBL_GetLastStyleName, libgdal), Cstring, (OGRStyleTableH,), hStyleTable), false)
 end

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -517,7 +517,7 @@ Fetch WKT name for geometry type.
 name used for this geometry type in well known text format.
 """
 function ogr_g_getgeometryname(arg1)
-    unsafe_string(ccall((:OGR_G_GetGeometryName, libgdal), Cstring, (OGRGeometryH,), arg1))
+    string_or_nothing(ccall((:OGR_G_GetGeometryName, libgdal), Cstring, (OGRGeometryH,), arg1))
 end
 
 """
@@ -587,7 +587,7 @@ Convert a geometry into GML format.
 A GML fragment or NULL in case of error.
 """
 function ogr_g_exporttogml(arg1)
-    unsafe_string(ccall((:OGR_G_ExportToGML, libgdal), Cstring, (OGRGeometryH,), arg1))
+    string_or_nothing(ccall((:OGR_G_ExportToGML, libgdal), Cstring, (OGRGeometryH,), arg1))
 end
 
 """
@@ -604,7 +604,7 @@ Convert a geometry into GML format.
 A GML fragment or NULL in case of error.
 """
 function ogr_g_exporttogmlex(arg1, papszOptions)
-    unsafe_string(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
+    string_or_nothing(ccall((:OGR_G_ExportToGMLEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
 end
 
 """
@@ -648,7 +648,7 @@ Convert a geometry into KML format.
 A KML fragment or NULL in case of error.
 """
 function ogr_g_exporttokml(arg1, pszAltitudeMode)
-    unsafe_string(ccall((:OGR_G_ExportToKML, libgdal), Cstring, (OGRGeometryH, Cstring), arg1, pszAltitudeMode))
+    string_or_nothing(ccall((:OGR_G_ExportToKML, libgdal), Cstring, (OGRGeometryH, Cstring), arg1, pszAltitudeMode))
 end
 
 """
@@ -663,7 +663,7 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 function ogr_g_exporttojson(arg1)
-    unsafe_string(ccall((:OGR_G_ExportToJson, libgdal), Cstring, (OGRGeometryH,), arg1))
+    string_or_nothing(ccall((:OGR_G_ExportToJson, libgdal), Cstring, (OGRGeometryH,), arg1))
 end
 
 """
@@ -680,7 +680,7 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 function ogr_g_exporttojsonex(arg1, papszOptions)
-    unsafe_string(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
+    string_or_nothing(ccall((:OGR_G_ExportToJsonEx, libgdal), Cstring, (OGRGeometryH, Ptr{Cstring}), arg1, papszOptions))
 end
 
 """
@@ -2007,7 +2007,7 @@ Fetch name of this field.
 the name of the field definition.
 """
 function ogr_fld_getnameref(arg1)
-    unsafe_string(ccall((:OGR_Fld_GetNameRef, libgdal), Cstring, (OGRFieldDefnH,), arg1))
+    string_or_nothing(ccall((:OGR_Fld_GetNameRef, libgdal), Cstring, (OGRFieldDefnH,), arg1))
 end
 
 """
@@ -2247,7 +2247,7 @@ Get default field value.
 default field value or NULL.
 """
 function ogr_fld_getdefault(hDefn)
-    unsafe_string(ccall((:OGR_Fld_GetDefault, libgdal), Cstring, (OGRFieldDefnH,), hDefn))
+    string_or_nothing(ccall((:OGR_Fld_GetDefault, libgdal), Cstring, (OGRFieldDefnH,), hDefn))
 end
 
 """
@@ -2291,7 +2291,7 @@ Fetch human readable name for a field type.
 the name.
 """
 function ogr_getfieldtypename(arg1)
-    unsafe_string(ccall((:OGR_GetFieldTypeName, libgdal), Cstring, (OGRFieldType,), arg1))
+    string_or_nothing(ccall((:OGR_GetFieldTypeName, libgdal), Cstring, (OGRFieldType,), arg1))
 end
 
 """
@@ -2306,7 +2306,7 @@ Fetch human readable name for a field subtype.
 the name.
 """
 function ogr_getfieldsubtypename(arg1)
-    unsafe_string(ccall((:OGR_GetFieldSubTypeName, libgdal), Cstring, (OGRFieldSubType,), arg1))
+    string_or_nothing(ccall((:OGR_GetFieldSubTypeName, libgdal), Cstring, (OGRFieldSubType,), arg1))
 end
 
 """
@@ -2381,7 +2381,7 @@ Fetch name of this field.
 the name of the geometry field definition.
 """
 function ogr_gfld_getnameref(arg1)
-    unsafe_string(ccall((:OGR_GFld_GetNameRef, libgdal), Cstring, (OGRGeomFieldDefnH,), arg1))
+    string_or_nothing(ccall((:OGR_GFld_GetNameRef, libgdal), Cstring, (OGRGeomFieldDefnH,), arg1))
 end
 
 """
@@ -2551,7 +2551,7 @@ Get name of the OGRFeatureDefn passed as an argument.
 the name. This name is internal and should not be modified, or freed.
 """
 function ogr_fd_getname(arg1)
-    unsafe_string(ccall((:OGR_FD_GetName, libgdal), Cstring, (OGRFeatureDefnH,), arg1))
+    string_or_nothing(ccall((:OGR_FD_GetName, libgdal), Cstring, (OGRFeatureDefnH,), arg1))
 end
 
 """
@@ -3273,7 +3273,7 @@ Fetch field value as a string.
 the field value. This string is internal, and should not be modified, or freed. Its lifetime may be very brief.
 """
 function ogr_f_getfieldasstring(arg1, arg2)
-    unsafe_string(ccall((:OGR_F_GetFieldAsString, libgdal), Cstring, (OGRFeatureH, Cint), arg1, arg2))
+    string_or_nothing(ccall((:OGR_F_GetFieldAsString, libgdal), Cstring, (OGRFeatureH, Cint), arg1, arg2))
 end
 
 """
@@ -3857,7 +3857,7 @@ Fetch style string for this feature.
 a reference to a representation in string format, or NULL if there isn't one.
 """
 function ogr_f_getstylestring(arg1)
-    unsafe_string(ccall((:OGR_F_GetStyleString, libgdal), Cstring, (OGRFeatureH,), arg1))
+    string_or_nothing(ccall((:OGR_F_GetStyleString, libgdal), Cstring, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3929,7 +3929,7 @@ Returns the native data for the feature.
 a string with the native data, or NULL if there is none.
 """
 function ogr_f_getnativedata(arg1)
-    unsafe_string(ccall((:OGR_F_GetNativeData, libgdal), Cstring, (OGRFeatureH,), arg1))
+    string_or_nothing(ccall((:OGR_F_GetNativeData, libgdal), Cstring, (OGRFeatureH,), arg1))
 end
 
 """
@@ -3958,7 +3958,7 @@ Returns the native media type for the feature.
 a string with the native media type, or NULL if there is none.
 """
 function ogr_f_getnativemediatype(arg1)
-    unsafe_string(ccall((:OGR_F_GetNativeMediaType, libgdal), Cstring, (OGRFeatureH,), arg1))
+    string_or_nothing(ccall((:OGR_F_GetNativeMediaType, libgdal), Cstring, (OGRFeatureH,), arg1))
 end
 
 """
@@ -4022,7 +4022,7 @@ Return the layer name.
 the layer name (must not been freed)
 """
 function ogr_l_getname(arg1)
-    unsafe_string(ccall((:OGR_L_GetName, libgdal), Cstring, (OGRLayerH,), arg1))
+    string_or_nothing(ccall((:OGR_L_GetName, libgdal), Cstring, (OGRLayerH,), arg1))
 end
 
 """
@@ -4586,7 +4586,7 @@ This method returns the name of the underlying database column being used as the
 fid column name.
 """
 function ogr_l_getfidcolumn(arg1)
-    unsafe_string(ccall((:OGR_L_GetFIDColumn, libgdal), Cstring, (OGRLayerH,), arg1))
+    string_or_nothing(ccall((:OGR_L_GetFIDColumn, libgdal), Cstring, (OGRLayerH,), arg1))
 end
 
 """
@@ -4601,7 +4601,7 @@ This method returns the name of the underlying database column being used as the
 geometry column name.
 """
 function ogr_l_getgeometrycolumn(arg1)
-    unsafe_string(ccall((:OGR_L_GetGeometryColumn, libgdal), Cstring, (OGRLayerH,), arg1))
+    string_or_nothing(ccall((:OGR_L_GetGeometryColumn, libgdal), Cstring, (OGRLayerH,), arg1))
 end
 
 """
@@ -4848,7 +4848,7 @@ Returns the name of the data source.
 pointer to an internal name string which should not be modified or freed by the caller.
 """
 function ogr_ds_getname(arg1)
-    unsafe_string(ccall((:OGR_DS_GetName, libgdal), Cstring, (OGRDataSourceH,), arg1))
+    string_or_nothing(ccall((:OGR_DS_GetName, libgdal), Cstring, (OGRDataSourceH,), arg1))
 end
 
 """
@@ -5106,7 +5106,7 @@ Fetch name of driver (file format).
 driver name. This is an internal string and should not be modified or freed.
 """
 function ogr_dr_getname(arg1)
-    unsafe_string(ccall((:OGR_Dr_GetName, libgdal), Cstring, (OGRSFDriverH,), arg1))
+    string_or_nothing(ccall((:OGR_Dr_GetName, libgdal), Cstring, (OGRSFDriverH,), arg1))
 end
 
 """
@@ -5372,7 +5372,7 @@ Initialize style manager from the style string of a feature.
 a reference to the style string read from the feature, or NULL in case of error.
 """
 function ogr_sm_initfromfeature(hSM, hFeat)
-    unsafe_string(ccall((:OGR_SM_InitFromFeature, libgdal), Cstring, (OGRStyleMgrH, OGRFeatureH), hSM, hFeat))
+    string_or_nothing(ccall((:OGR_SM_InitFromFeature, libgdal), Cstring, (OGRStyleMgrH, OGRFeatureH), hSM, hFeat))
 end
 
 """
@@ -5553,7 +5553,7 @@ Get Style Tool parameter value as string.
 the parameter value as string and sets bValueIsNull.
 """
 function ogr_st_getparamstr(hST, eParam, bValueIsNull)
-    unsafe_string(ccall((:OGR_ST_GetParamStr, libgdal), Cstring, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull))
+    string_or_nothing(ccall((:OGR_ST_GetParamStr, libgdal), Cstring, (OGRStyleToolH, Cint, Ptr{Cint}), hST, eParam, bValueIsNull))
 end
 
 """
@@ -5654,7 +5654,7 @@ Get the style string for this Style Tool.
 the style string for this style tool or "" if the hST is invalid.
 """
 function ogr_st_getstylestring(hST)
-    unsafe_string(ccall((:OGR_ST_GetStyleString, libgdal), Cstring, (OGRStyleToolH,), hST))
+    string_or_nothing(ccall((:OGR_ST_GetStyleString, libgdal), Cstring, (OGRStyleToolH,), hST))
 end
 
 """
@@ -5773,7 +5773,7 @@ Get a style string by name.
 the style string matching the name or NULL if not found or error.
 """
 function ogr_stbl_find(hStyleTable, pszName)
-    unsafe_string(ccall((:OGR_STBL_Find, libgdal), Cstring, (OGRStyleTableH, Cstring), hStyleTable, pszName))
+    string_or_nothing(ccall((:OGR_STBL_Find, libgdal), Cstring, (OGRStyleTableH, Cstring), hStyleTable, pszName))
 end
 
 """
@@ -5800,7 +5800,7 @@ Get the next style string from the table.
 the next style string or NULL on error.
 """
 function ogr_stbl_getnextstyle(hStyleTable)
-    unsafe_string(ccall((:OGR_STBL_GetNextStyle, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
+    string_or_nothing(ccall((:OGR_STBL_GetNextStyle, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
 end
 
 """
@@ -5815,5 +5815,5 @@ Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
 the Name of the last style string or NULL on error.
 """
 function ogr_stbl_getlaststylename(hStyleTable)
-    unsafe_string(ccall((:OGR_STBL_GetLastStyleName, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
+    string_or_nothing(ccall((:OGR_STBL_GetLastStyleName, libgdal), Cstring, (OGRStyleTableH,), hStyleTable))
 end

--- a/src/ogr_core.jl
+++ b/src/ogr_core.jl
@@ -26,7 +26,7 @@ function ogrrealloc(arg1, size_t)
 end
 
 function ogrstrdup(arg1)
-    unsafe_string(ccall((:OGRStrdup, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:OGRStrdup, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """
@@ -48,7 +48,7 @@ Fetch a human readable name corresponding to an OGRwkbGeometryType value.
 internal human readable string, or NULL on failure.
 """
 function ogrgeometrytypetoname(eType)
-    unsafe_string(ccall((:OGRGeometryTypeToName, libgdal), Cstring, (OGRwkbGeometryType,), eType))
+    string_or_nothing(ccall((:OGRGeometryTypeToName, libgdal), Cstring, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -319,7 +319,7 @@ Get runtime version information.
 an internal string containing the requested information.
 """
 function gdalversioninfo(arg1)
-    unsafe_string(ccall((:GDALVersionInfo, libgdal), Cstring, (Cstring,), arg1))
+    string_or_nothing(ccall((:GDALVersionInfo, libgdal), Cstring, (Cstring,), arg1))
 end
 
 """

--- a/src/ogr_core.jl
+++ b/src/ogr_core.jl
@@ -6,7 +6,7 @@
     OGRMalloc(size_t size) -> void *
 """
 function ogrmalloc()
-    failsafe(ccall((:OGRMalloc, libgdal), Ptr{Cvoid}, ()))
+    aftercare(ccall((:OGRMalloc, libgdal), Ptr{Cvoid}, ()))
 end
 
 """
@@ -14,7 +14,7 @@ end
               size_t size) -> void *
 """
 function ogrcalloc()
-    failsafe(ccall((:OGRCalloc, libgdal), Ptr{Cvoid}, ()))
+    aftercare(ccall((:OGRCalloc, libgdal), Ptr{Cvoid}, ()))
 end
 
 """
@@ -22,18 +22,18 @@ end
                size_t size) -> void *
 """
 function ogrrealloc(arg1, size_t)
-    failsafe(ccall((:OGRRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), arg1, size_t))
+    aftercare(ccall((:OGRRealloc, libgdal), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), arg1, size_t))
 end
 
 function ogrstrdup(arg1)
-    string_or_nothing(ccall((:OGRStrdup, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:OGRStrdup, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
     OGRFree(void * pMemory) -> void
 """
 function ogrfree(arg1)
-    ccall((:OGRFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1)
+    aftercare(ccall((:OGRFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
 end
 
 """
@@ -48,7 +48,7 @@ Fetch a human readable name corresponding to an OGRwkbGeometryType value.
 internal human readable string, or NULL on failure.
 """
 function ogrgeometrytypetoname(eType)
-    string_or_nothing(ccall((:OGRGeometryTypeToName, libgdal), Cstring, (OGRwkbGeometryType,), eType))
+    aftercare(ccall((:OGRGeometryTypeToName, libgdal), Cstring, (OGRwkbGeometryType,), eType), false)
 end
 
 """
@@ -65,7 +65,7 @@ Find common geometry type.
 the merged geometry type.
 """
 function ogrmergegeometrytypes(eMain, eExtra)
-    ccall((:OGRMergeGeometryTypes, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, OGRwkbGeometryType), eMain, eExtra)
+    aftercare(ccall((:OGRMergeGeometryTypes, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, OGRwkbGeometryType), eMain, eExtra))
 end
 
 """
@@ -84,7 +84,7 @@ Find common geometry type.
 the merged geometry type.
 """
 function ogrmergegeometrytypesex(eMain, eExtra, bAllowPromotingToCurves)
-    ccall((:OGRMergeGeometryTypesEx, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, OGRwkbGeometryType, Cint), eMain, eExtra, bAllowPromotingToCurves)
+    aftercare(ccall((:OGRMergeGeometryTypesEx, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, OGRwkbGeometryType, Cint), eMain, eExtra, bAllowPromotingToCurves))
 end
 
 """
@@ -99,7 +99,7 @@ Returns the 2D geometry type corresponding to the passed geometry type.
 2D geometry type corresponding to the passed geometry type.
 """
 function ogr_gt_flatten(eType)
-    ccall((:OGR_GT_Flatten, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_Flatten, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -114,7 +114,7 @@ Returns the 3D geometry type corresponding to the passed geometry type.
 3D geometry type corresponding to the passed geometry type.
 """
 function ogr_gt_setz(eType)
-    ccall((:OGR_GT_SetZ, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_SetZ, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -129,7 +129,7 @@ Returns the measured geometry type corresponding to the passed geometry type.
 measured geometry type corresponding to the passed geometry type.
 """
 function ogr_gt_setm(eType)
-    ccall((:OGR_GT_SetM, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_SetM, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -148,7 +148,7 @@ Returns a XY, XYZ, XYM or XYZM geometry type depending on parameter.
 Output geometry type.
 """
 function ogr_gt_setmodifier(eType, bSetZ, bSetM)
-    ccall((:OGR_GT_SetModifier, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, Cint, Cint), eType, bSetZ, bSetM)
+    aftercare(ccall((:OGR_GT_SetModifier, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType, Cint, Cint), eType, bSetZ, bSetM))
 end
 
 """
@@ -163,7 +163,7 @@ Return if the geometry type is a 3D geometry type.
 TRUE if the geometry type is a 3D geometry type.
 """
 function ogr_gt_hasz(eType)
-    ccall((:OGR_GT_HasZ, libgdal), Cint, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_HasZ, libgdal), Cint, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -178,7 +178,7 @@ Return if the geometry type is a measured type.
 TRUE if the geometry type is a measured type.
 """
 function ogr_gt_hasm(eType)
-    ccall((:OGR_GT_HasM, libgdal), Cint, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_HasM, libgdal), Cint, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -195,7 +195,7 @@ Returns if a type is a subclass of another one.
 TRUE if eType is a subclass of eSuperType.
 """
 function ogr_gt_issubclassof(eType, eSuperType)
-    ccall((:OGR_GT_IsSubClassOf, libgdal), Cint, (OGRwkbGeometryType, OGRwkbGeometryType), eType, eSuperType)
+    aftercare(ccall((:OGR_GT_IsSubClassOf, libgdal), Cint, (OGRwkbGeometryType, OGRwkbGeometryType), eType, eSuperType))
 end
 
 """
@@ -210,7 +210,7 @@ Return if a geometry type is an instance of Curve.
 TRUE if the geometry type is an instance of Curve
 """
 function ogr_gt_iscurve(arg1)
-    ccall((:OGR_GT_IsCurve, libgdal), Cint, (OGRwkbGeometryType,), arg1)
+    aftercare(ccall((:OGR_GT_IsCurve, libgdal), Cint, (OGRwkbGeometryType,), arg1))
 end
 
 """
@@ -225,7 +225,7 @@ Return if a geometry type is an instance of Surface.
 TRUE if the geometry type is an instance of Surface
 """
 function ogr_gt_issurface(arg1)
-    ccall((:OGR_GT_IsSurface, libgdal), Cint, (OGRwkbGeometryType,), arg1)
+    aftercare(ccall((:OGR_GT_IsSurface, libgdal), Cint, (OGRwkbGeometryType,), arg1))
 end
 
 """
@@ -240,7 +240,7 @@ Return if a geometry type is a non-linear geometry type.
 TRUE if the geometry type is a non-linear geometry type.
 """
 function ogr_gt_isnonlinear(arg1)
-    ccall((:OGR_GT_IsNonLinear, libgdal), Cint, (OGRwkbGeometryType,), arg1)
+    aftercare(ccall((:OGR_GT_IsNonLinear, libgdal), Cint, (OGRwkbGeometryType,), arg1))
 end
 
 """
@@ -255,7 +255,7 @@ Returns the collection type that can contain the passed geometry type.
 the collection type that can contain the passed geometry type or wkbUnknown
 """
 function ogr_gt_getcollection(eType)
-    ccall((:OGR_GT_GetCollection, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_GetCollection, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -270,7 +270,7 @@ Returns the curve geometry type that can contain the passed geometry type.
 the curve type that can contain the passed geometry type
 """
 function ogr_gt_getcurve(eType)
-    ccall((:OGR_GT_GetCurve, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_GetCurve, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -285,7 +285,7 @@ Returns the non-curve geometry type that can contain the passed geometry type.
 the non-curve type that can contain the passed geometry type
 """
 function ogr_gt_getlinear(eType)
-    ccall((:OGR_GT_GetLinear, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType)
+    aftercare(ccall((:OGR_GT_GetLinear, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -304,7 +304,7 @@ Parse date string.
 TRUE if apparently successful or FALSE on failure.
 """
 function ogrparsedate(pszInput, psOutput, nOptions)
-    ccall((:OGRParseDate, libgdal), Cint, (Cstring, Ptr{OGRField}, Cint), pszInput, psOutput, nOptions)
+    aftercare(ccall((:OGRParseDate, libgdal), Cint, (Cstring, Ptr{OGRField}, Cint), pszInput, psOutput, nOptions))
 end
 
 """
@@ -319,7 +319,7 @@ Get runtime version information.
 an internal string containing the requested information.
 """
 function gdalversioninfo(arg1)
-    string_or_nothing(ccall((:GDALVersionInfo, libgdal), Cstring, (Cstring,), arg1))
+    aftercare(ccall((:GDALVersionInfo, libgdal), Cstring, (Cstring,), arg1), false)
 end
 
 """
@@ -338,5 +338,5 @@ Return TRUE if GDAL library version at runtime matches nVersionMajor.nVersionMin
 TRUE if GDAL library version at runtime matches nVersionMajor.nVersionMinor, FALSE otherwise.
 """
 function gdalcheckversion(nVersionMajor, nVersionMinor, pszCallingComponentName)
-    ccall((:GDALCheckVersion, libgdal), Cint, (Cint, Cint, Cstring), nVersionMajor, nVersionMinor, pszCallingComponentName)
+    aftercare(ccall((:GDALCheckVersion, libgdal), Cint, (Cint, Cint, Cstring), nVersionMajor, nVersionMinor, pszCallingComponentName))
 end

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -11,7 +11,7 @@ Return the string representation for the OGRAxisOrientation enumeration.
 an internal string
 """
 function osraxisenumtoname(eOrientation)
-    string_or_nothing(ccall((:OSRAxisEnumToName, libgdal), Cstring, (OGRAxisOrientation,), eOrientation))
+    aftercare(ccall((:OSRAxisEnumToName, libgdal), Cstring, (OGRAxisOrientation,), eOrientation), false)
 end
 
 """
@@ -23,7 +23,7 @@ Set the search path(s) for PROJ resource files.
 * **papszPaths**: NULL terminated list of directory paths.
 """
 function osrsetprojsearchpaths(papszPaths)
-    ccall((:OSRSetPROJSearchPaths, libgdal), Cvoid, (Ptr{Cstring},), papszPaths)
+    aftercare(ccall((:OSRSetPROJSearchPaths, libgdal), Cvoid, (Ptr{Cstring},), papszPaths))
 end
 
 """
@@ -32,7 +32,7 @@ end
 Constructor.
 """
 function osrnewspatialreference(arg1)
-    failsafe(ccall((:OSRNewSpatialReference, libgdal), OGRSpatialReferenceH, (Cstring,), arg1))
+    aftercare(ccall((:OSRNewSpatialReference, libgdal), OGRSpatialReferenceH, (Cstring,), arg1))
 end
 
 """
@@ -41,7 +41,7 @@ end
 Make a duplicate of the GEOGCS node of this OGRSpatialReference object.
 """
 function osrclonegeogcs(arg1)
-    failsafe(ccall((:OSRCloneGeogCS, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH,), arg1))
+    aftercare(ccall((:OSRCloneGeogCS, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -50,7 +50,7 @@ end
 Make a duplicate of this OGRSpatialReference.
 """
 function osrclone(arg1)
-    failsafe(ccall((:OSRClone, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH,), arg1))
+    aftercare(ccall((:OSRClone, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -62,7 +62,7 @@ OGRSpatialReference destructor.
 * **hSRS**: the object to delete
 """
 function osrdestroyspatialreference(arg1)
-    ccall((:OSRDestroySpatialReference, libgdal), Cvoid, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRDestroySpatialReference, libgdal), Cvoid, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -71,7 +71,7 @@ end
 Increments the reference count by one.
 """
 function osrreference(arg1)
-    ccall((:OSRReference, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRReference, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -80,7 +80,7 @@ end
 Decrements the reference count by one.
 """
 function osrdereference(arg1)
-    ccall((:OSRDereference, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRDereference, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -89,7 +89,7 @@ end
 Decrements the reference count by one, and destroy if zero.
 """
 function osrrelease(arg1)
-    ccall((:OSRRelease, libgdal), Cvoid, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRRelease, libgdal), Cvoid, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -98,7 +98,7 @@ end
 Validate SRS tokens.
 """
 function osrvalidate(arg1)
-    ccall((:OSRValidate, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRValidate, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -108,7 +108,7 @@ end
 Initialize SRS based on EPSG GCS or PCS code.
 """
 function osrimportfromepsg(arg1, arg2)
-    ccall((:OSRImportFromEPSG, libgdal), OGRErr, (OGRSpatialReferenceH, Cint), arg1, arg2)
+    aftercare(ccall((:OSRImportFromEPSG, libgdal), OGRErr, (OGRSpatialReferenceH, Cint), arg1, arg2))
 end
 
 """
@@ -118,7 +118,7 @@ end
 Initialize SRS based on EPSG CRS code.
 """
 function osrimportfromepsga(arg1, arg2)
-    ccall((:OSRImportFromEPSGA, libgdal), OGRErr, (OGRSpatialReferenceH, Cint), arg1, arg2)
+    aftercare(ccall((:OSRImportFromEPSGA, libgdal), OGRErr, (OGRSpatialReferenceH, Cint), arg1, arg2))
 end
 
 """
@@ -128,7 +128,7 @@ end
 Import from WKT string.
 """
 function osrimportfromwkt(arg1, arg2)
-    ccall((:OSRImportFromWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRImportFromWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -138,7 +138,7 @@ end
 Import PROJ coordinate string.
 """
 function osrimportfromproj4(arg1, arg2)
-    ccall((:OSRImportFromProj4, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OSRImportFromProj4, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2))
 end
 
 """
@@ -148,7 +148,7 @@ end
 Import coordinate system from ESRI .prj format(s).
 """
 function osrimportfromesri(arg1, arg2)
-    ccall((:OSRImportFromESRI, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRImportFromESRI, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -160,7 +160,7 @@ end
 Import coordinate system from PCI projection definition.
 """
 function osrimportfrompci(hSRS, arg1, arg2, arg3)
-    ccall((:OSRImportFromPCI, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Ptr{Cdouble}), hSRS, arg1, arg2, arg3)
+    aftercare(ccall((:OSRImportFromPCI, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Ptr{Cdouble}), hSRS, arg1, arg2, arg3))
 end
 
 """
@@ -173,7 +173,7 @@ end
 Import coordinate system from USGS projection definition.
 """
 function osrimportfromusgs(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OSRImportFromUSGS, libgdal), OGRErr, (OGRSpatialReferenceH, Clong, Clong, Ptr{Cdouble}, Clong), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OSRImportFromUSGS, libgdal), OGRErr, (OGRSpatialReferenceH, Clong, Clong, Ptr{Cdouble}, Clong), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -183,7 +183,7 @@ end
 Import coordinate system from XML format (GML only currently).
 """
 function osrimportfromxml(arg1, arg2)
-    ccall((:OSRImportFromXML, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OSRImportFromXML, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2))
 end
 
 """
@@ -202,7 +202,7 @@ Read SRS from WKT dictionary.
 OGRERR_NONE on success, or OGRERR_SRS_UNSUPPORTED if the code isn't found, and OGRERR_SRS_FAILURE if something more dramatic goes wrong.
 """
 function osrimportfromdict(arg1, arg2, arg3)
-    ccall((:OSRImportFromDict, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring), arg1, arg2, arg3)
+    aftercare(ccall((:OSRImportFromDict, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -215,7 +215,7 @@ end
 Import coordinate system from "Panorama" GIS projection definition.
 """
 function osrimportfrompanorama(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OSRImportFromPanorama, libgdal), OGRErr, (OGRSpatialReferenceH, Clong, Clong, Clong, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OSRImportFromPanorama, libgdal), OGRErr, (OGRSpatialReferenceH, Clong, Clong, Clong, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -232,7 +232,7 @@ Import coordinate system from OziExplorer projection definition.
 OGRERR_NONE on success or an error code in case of failure.
 """
 function osrimportfromozi(arg1, arg2)
-    ccall((:OSRImportFromOzi, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRImportFromOzi, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -242,7 +242,7 @@ end
 Import Mapinfo style CoordSys definition.
 """
 function osrimportfrommicoordsys(arg1, arg2)
-    ccall((:OSRImportFromMICoordSys, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OSRImportFromMICoordSys, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2))
 end
 
 """
@@ -254,7 +254,7 @@ end
 Create OGR WKT from ERMapper projection definitions.
 """
 function osrimportfromerm(arg1, arg2, arg3, arg4)
-    ccall((:OSRImportFromERM, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OSRImportFromERM, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -264,7 +264,7 @@ end
 Set spatial reference from a URL.
 """
 function osrimportfromurl(arg1, arg2)
-    ccall((:OSRImportFromUrl, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OSRImportFromUrl, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2))
 end
 
 """
@@ -274,7 +274,7 @@ end
 Convert this SRS into WKT 1 format.
 """
 function osrexporttowkt(arg1, arg2)
-    ccall((:OSRExportToWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRExportToWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -285,7 +285,7 @@ end
 Convert this SRS into WKT format.
 """
 function osrexporttowktex(arg1, ppszResult, papszOptions)
-    ccall((:OSRExportToWktEx, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cstring}), arg1, ppszResult, papszOptions)
+    aftercare(ccall((:OSRExportToWktEx, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cstring}), arg1, ppszResult, papszOptions))
 end
 
 """
@@ -296,7 +296,7 @@ end
 Convert this SRS into a nicely formatted WKT 1 string for display to a person.
 """
 function osrexporttoprettywkt(arg1, arg2, arg3)
-    ccall((:OSRExportToPrettyWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Cint), arg1, arg2, arg3)
+    aftercare(ccall((:OSRExportToPrettyWkt, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Cint), arg1, arg2, arg3))
 end
 
 """
@@ -306,7 +306,7 @@ end
 Export coordinate system in PROJ format.
 """
 function osrexporttoproj4(arg1, arg2)
-    ccall((:OSRExportToProj4, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRExportToProj4, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -318,7 +318,7 @@ end
 Export coordinate system in PCI projection definition.
 """
 function osrexporttopci(arg1, arg2, arg3, arg4)
-    ccall((:OSRExportToPCI, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cstring}, Ptr{Ptr{Cdouble}}), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OSRExportToPCI, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cstring}, Ptr{Ptr{Cdouble}}), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -331,7 +331,7 @@ end
 Export coordinate system in USGS GCTP projection definition.
 """
 function osrexporttousgs(arg1, arg2, arg3, arg4, arg5)
-    ccall((:OSRExportToUSGS, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Clong}, Ptr{Clong}, Ptr{Ptr{Cdouble}}, Ptr{Clong}), arg1, arg2, arg3, arg4, arg5)
+    aftercare(ccall((:OSRExportToUSGS, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Clong}, Ptr{Clong}, Ptr{Ptr{Cdouble}}, Ptr{Clong}), arg1, arg2, arg3, arg4, arg5))
 end
 
 """
@@ -342,7 +342,7 @@ end
 Export coordinate system in XML format.
 """
 function osrexporttoxml(arg1, arg2, arg3)
-    ccall((:OSRExportToXML, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Cstring), arg1, arg2, arg3)
+    aftercare(ccall((:OSRExportToXML, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}, Cstring), arg1, arg2, arg3))
 end
 
 """
@@ -356,7 +356,7 @@ end
 Export coordinate system in "Panorama" GIS projection definition.
 """
 function osrexporttopanorama(arg1, arg2, arg3, arg4, arg5, arg6)
-    ccall((:OSRExportToPanorama, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5, arg6)
+    aftercare(ccall((:OSRExportToPanorama, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cdouble}), arg1, arg2, arg3, arg4, arg5, arg6))
 end
 
 """
@@ -366,7 +366,7 @@ end
 Export coordinate system in Mapinfo style CoordSys format.
 """
 function osrexporttomicoordsys(arg1, arg2)
-    ccall((:OSRExportToMICoordSys, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRExportToMICoordSys, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -378,7 +378,7 @@ end
 Convert coordinate system to ERMapper format.
 """
 function osrexporttoerm(arg1, arg2, arg3, arg4)
-    ccall((:OSRExportToERM, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OSRExportToERM, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -387,7 +387,7 @@ end
 Convert in place to ESRI WKT format.
 """
 function osrmorphtoesri(arg1)
-    ccall((:OSRMorphToESRI, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRMorphToESRI, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -396,7 +396,7 @@ end
 Convert in place from ESRI WKT format.
 """
 function osrmorphfromesri(arg1)
-    ccall((:OSRMorphFromESRI, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRMorphFromESRI, libgdal), OGRErr, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -415,7 +415,7 @@ Convert to another equivalent projection.
 a new SRS, or NULL in case of error.
 """
 function osrconverttootherprojection(hSRS, pszTargetProjection, papszOptions)
-    failsafe(ccall((:OSRConvertToOtherProjection, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH, Cstring, Ptr{Cstring}), hSRS, pszTargetProjection, papszOptions))
+    aftercare(ccall((:OSRConvertToOtherProjection, libgdal), OGRSpatialReferenceH, (OGRSpatialReferenceH, Cstring, Ptr{Cstring}), hSRS, pszTargetProjection, papszOptions))
 end
 
 """
@@ -424,7 +424,7 @@ end
 Return the CRS name.
 """
 function osrgetname(hSRS)
-    string_or_nothing(ccall((:OSRGetName, libgdal), Cstring, (OGRSpatialReferenceH,), hSRS))
+    aftercare(ccall((:OSRGetName, libgdal), Cstring, (OGRSpatialReferenceH,), hSRS), false)
 end
 
 """
@@ -435,7 +435,7 @@ end
 Set attribute value in spatial reference.
 """
 function osrsetattrvalue(hSRS, pszNodePath, pszNewNodeValue)
-    ccall((:OSRSetAttrValue, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring), hSRS, pszNodePath, pszNewNodeValue)
+    aftercare(ccall((:OSRSetAttrValue, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring), hSRS, pszNodePath, pszNewNodeValue))
 end
 
 """
@@ -446,7 +446,7 @@ end
 Fetch indicated attribute of named node.
 """
 function osrgetattrvalue(hSRS, pszName, iChild)
-    string_or_nothing(ccall((:OSRGetAttrValue, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint), hSRS, pszName, iChild))
+    aftercare(ccall((:OSRGetAttrValue, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint), hSRS, pszName, iChild), false)
 end
 
 """
@@ -457,7 +457,7 @@ end
 Set the angular units for the geographic coordinate system.
 """
 function osrsetangularunits(arg1, arg2, arg3)
-    ccall((:OSRSetAngularUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OSRSetAngularUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -467,7 +467,7 @@ end
 Fetch angular geographic coordinate system units.
 """
 function osrgetangularunits(arg1, arg2)
-    ccall((:OSRGetAngularUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRGetAngularUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -478,7 +478,7 @@ end
 Set the linear units for the projection.
 """
 function osrsetlinearunits(arg1, arg2, arg3)
-    ccall((:OSRSetLinearUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OSRSetLinearUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -490,7 +490,7 @@ end
 Set the linear units for the target node.
 """
 function osrsettargetlinearunits(arg1, arg2, arg3, arg4)
-    ccall((:OSRSetTargetLinearUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cdouble), arg1, arg2, arg3, arg4)
+    aftercare(ccall((:OSRSetTargetLinearUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cdouble), arg1, arg2, arg3, arg4))
 end
 
 """
@@ -501,7 +501,7 @@ end
 Set the linear units for the projection.
 """
 function osrsetlinearunitsandupdateparameters(arg1, arg2, arg3)
-    ccall((:OSRSetLinearUnitsAndUpdateParameters, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OSRSetLinearUnitsAndUpdateParameters, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -511,7 +511,7 @@ end
 Fetch linear projection units.
 """
 function osrgetlinearunits(arg1, arg2)
-    ccall((:OSRGetLinearUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRGetLinearUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -522,7 +522,7 @@ end
 Fetch linear projection units.
 """
 function osrgettargetlinearunits(arg1, arg2, arg3)
-    ccall((:OSRGetTargetLinearUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Ptr{Cstring}), arg1, arg2, arg3)
+    aftercare(ccall((:OSRGetTargetLinearUnits, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Ptr{Cstring}), arg1, arg2, arg3))
 end
 
 """
@@ -532,7 +532,7 @@ end
 Fetch prime meridian info.
 """
 function osrgetprimemeridian(arg1, arg2)
-    ccall((:OSRGetPrimeMeridian, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2)
+    aftercare(ccall((:OSRGetPrimeMeridian, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2))
 end
 
 """
@@ -541,7 +541,7 @@ end
 Check if geographic coordinate system.
 """
 function osrisgeographic(arg1)
-    ccall((:OSRIsGeographic, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsGeographic, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -550,7 +550,7 @@ end
 Check if local coordinate system.
 """
 function osrislocal(arg1)
-    ccall((:OSRIsLocal, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsLocal, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -559,7 +559,7 @@ end
 Check if projected coordinate system.
 """
 function osrisprojected(arg1)
-    ccall((:OSRIsProjected, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsProjected, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -568,7 +568,7 @@ end
 Check if the coordinate system is compound.
 """
 function osriscompound(arg1)
-    ccall((:OSRIsCompound, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsCompound, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -577,7 +577,7 @@ end
 Check if geocentric coordinate system.
 """
 function osrisgeocentric(arg1)
-    ccall((:OSRIsGeocentric, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsGeocentric, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -586,7 +586,7 @@ end
 Check if vertical coordinate system.
 """
 function osrisvertical(arg1)
-    ccall((:OSRIsVertical, libgdal), Cint, (OGRSpatialReferenceH,), arg1)
+    aftercare(ccall((:OSRIsVertical, libgdal), Cint, (OGRSpatialReferenceH,), arg1))
 end
 
 """
@@ -596,7 +596,7 @@ end
 Do the GeogCS'es match?
 """
 function osrissamegeogcs(arg1, arg2)
-    ccall((:OSRIsSameGeogCS, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:OSRIsSameGeogCS, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -606,7 +606,7 @@ end
 Do the VertCS'es match?
 """
 function osrissamevertcs(arg1, arg2)
-    ccall((:OSRIsSameVertCS, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:OSRIsSameVertCS, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -616,7 +616,7 @@ end
 Do these two spatial references describe the same system ?
 """
 function osrissame(arg1, arg2)
-    ccall((:OSRIsSame, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2)
+    aftercare(ccall((:OSRIsSame, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH), arg1, arg2))
 end
 
 """
@@ -627,7 +627,7 @@ end
 Do these two spatial references describe the same system ?
 """
 function osrissameex(arg1, arg2, papszOptions)
-    ccall((:OSRIsSameEx, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2, papszOptions)
+    aftercare(ccall((:OSRIsSameEx, libgdal), Cint, (OGRSpatialReferenceH, OGRSpatialReferenceH, Ptr{Cstring}), arg1, arg2, papszOptions))
 end
 
 """
@@ -637,7 +637,7 @@ end
 Set the user visible LOCAL_CS name.
 """
 function osrsetlocalcs(hSRS, pszName)
-    ccall((:OSRSetLocalCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName)
+    aftercare(ccall((:OSRSetLocalCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName))
 end
 
 """
@@ -647,7 +647,7 @@ end
 Set the user visible PROJCS name.
 """
 function osrsetprojcs(hSRS, pszName)
-    ccall((:OSRSetProjCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName)
+    aftercare(ccall((:OSRSetProjCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName))
 end
 
 """
@@ -657,7 +657,7 @@ end
 Set the user visible PROJCS name.
 """
 function osrsetgeoccs(hSRS, pszName)
-    ccall((:OSRSetGeocCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName)
+    aftercare(ccall((:OSRSetGeocCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName))
 end
 
 """
@@ -667,7 +667,7 @@ end
 Set a GeogCS based on well known name.
 """
 function osrsetwellknowngeogcs(hSRS, pszName)
-    ccall((:OSRSetWellKnownGeogCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName)
+    aftercare(ccall((:OSRSetWellKnownGeogCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, pszName))
 end
 
 """
@@ -677,7 +677,7 @@ end
 Set spatial reference from various text formats.
 """
 function osrsetfromuserinput(hSRS, arg1)
-    ccall((:OSRSetFromUserInput, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, arg1)
+    aftercare(ccall((:OSRSetFromUserInput, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), hSRS, arg1))
 end
 
 """
@@ -687,7 +687,7 @@ end
 Copy GEOGCS from another OGRSpatialReference.
 """
 function osrcopygeogcsfrom(hSRS, hSrcSRS)
-    ccall((:OSRCopyGeogCSFrom, libgdal), OGRErr, (OGRSpatialReferenceH, OGRSpatialReferenceH), hSRS, hSrcSRS)
+    aftercare(ccall((:OSRCopyGeogCSFrom, libgdal), OGRErr, (OGRSpatialReferenceH, OGRSpatialReferenceH), hSRS, hSrcSRS))
 end
 
 """
@@ -703,7 +703,7 @@ end
 Set the Bursa-Wolf conversion to WGS84.
 """
 function osrsettowgs84(hSRS, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-    ccall((:OSRSetTOWGS84, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    aftercare(ccall((:OSRSetTOWGS84, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, arg1, arg2, arg3, arg4, arg5, arg6, arg7))
 end
 
 """
@@ -714,7 +714,7 @@ end
 Fetch TOWGS84 parameters, if available.
 """
 function osrgettowgs84(hSRS, arg1, arg2)
-    ccall((:OSRGetTOWGS84, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cdouble}, Cint), hSRS, arg1, arg2)
+    aftercare(ccall((:OSRGetTOWGS84, libgdal), OGRErr, (OGRSpatialReferenceH, Ptr{Cdouble}, Cint), hSRS, arg1, arg2))
 end
 
 """
@@ -726,7 +726,7 @@ end
 Setup a compound coordinate system.
 """
 function osrsetcompoundcs(hSRS, pszName, hHorizSRS, hVertSRS)
-    ccall((:OSRSetCompoundCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, OGRSpatialReferenceH, OGRSpatialReferenceH), hSRS, pszName, hHorizSRS, hVertSRS)
+    aftercare(ccall((:OSRSetCompoundCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, OGRSpatialReferenceH, OGRSpatialReferenceH), hSRS, pszName, hHorizSRS, hVertSRS))
 end
 
 """
@@ -744,7 +744,7 @@ end
 Set geographic coordinate system.
 """
 function osrsetgeogcs(hSRS, pszGeogName, pszDatumName, pszEllipsoidName, dfSemiMajor, dfInvFlattening, pszPMName, dfPMOffset, pszUnits, dfConvertToRadians)
-    ccall((:OSRSetGeogCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring, Cdouble, Cdouble, Cstring, Cdouble, Cstring, Cdouble), hSRS, pszGeogName, pszDatumName, pszEllipsoidName, dfSemiMajor, dfInvFlattening, pszPMName, dfPMOffset, pszUnits, dfConvertToRadians)
+    aftercare(ccall((:OSRSetGeogCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cstring, Cdouble, Cdouble, Cstring, Cdouble, Cstring, Cdouble), hSRS, pszGeogName, pszDatumName, pszEllipsoidName, dfSemiMajor, dfInvFlattening, pszPMName, dfPMOffset, pszUnits, dfConvertToRadians))
 end
 
 """
@@ -756,7 +756,7 @@ end
 Setup the vertical coordinate system.
 """
 function osrsetvertcs(hSRS, pszVertCSName, pszVertDatumName, nVertDatumType)
-    ccall((:OSRSetVertCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cint), hSRS, pszVertCSName, pszVertDatumName, nVertDatumType)
+    aftercare(ccall((:OSRSetVertCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cint), hSRS, pszVertCSName, pszVertDatumName, nVertDatumType))
 end
 
 """
@@ -766,7 +766,7 @@ end
 Get spheroid semi major axis.
 """
 function osrgetsemimajor(arg1, arg2)
-    ccall((:OSRGetSemiMajor, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2)
+    aftercare(ccall((:OSRGetSemiMajor, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2))
 end
 
 """
@@ -776,7 +776,7 @@ end
 Get spheroid semi minor axis.
 """
 function osrgetsemiminor(arg1, arg2)
-    ccall((:OSRGetSemiMinor, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2)
+    aftercare(ccall((:OSRGetSemiMinor, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2))
 end
 
 """
@@ -786,7 +786,7 @@ end
 Get spheroid inverse flattening.
 """
 function osrgetinvflattening(arg1, arg2)
-    ccall((:OSRGetInvFlattening, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2)
+    aftercare(ccall((:OSRGetInvFlattening, libgdal), Cdouble, (OGRSpatialReferenceH, Ptr{OGRErr}), arg1, arg2))
 end
 
 """
@@ -798,7 +798,7 @@ end
 Set the authority for a node.
 """
 function osrsetauthority(hSRS, pszTargetKey, pszAuthority, nCode)
-    ccall((:OSRSetAuthority, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cint), hSRS, pszTargetKey, pszAuthority, nCode)
+    aftercare(ccall((:OSRSetAuthority, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, Cint), hSRS, pszTargetKey, pszAuthority, nCode))
 end
 
 """
@@ -808,7 +808,7 @@ end
 Get the authority code for a node.
 """
 function osrgetauthoritycode(hSRS, pszTargetKey)
-    string_or_nothing(ccall((:OSRGetAuthorityCode, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
+    aftercare(ccall((:OSRGetAuthorityCode, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey), false)
 end
 
 """
@@ -818,7 +818,7 @@ end
 Get the authority name for a node.
 """
 function osrgetauthorityname(hSRS, pszTargetKey)
-    string_or_nothing(ccall((:OSRGetAuthorityName, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
+    aftercare(ccall((:OSRGetAuthorityName, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey), false)
 end
 
 """
@@ -832,7 +832,7 @@ end
 Return the area of use of the CRS.
 """
 function osrgetareaofuse(hSRS, pdfWestLongitudeDeg, pdfSouthLatitudeDeg, pdfEastLongitudeDeg, pdfNorthLatitudeDeg, ppszAreaName)
-    ccall((:OSRGetAreaOfUse, libgdal), Cint, (OGRSpatialReferenceH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cstring}), hSRS, pdfWestLongitudeDeg, pdfSouthLatitudeDeg, pdfEastLongitudeDeg, pdfNorthLatitudeDeg, ppszAreaName)
+    aftercare(ccall((:OSRGetAreaOfUse, libgdal), Cint, (OGRSpatialReferenceH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cstring}), hSRS, pdfWestLongitudeDeg, pdfSouthLatitudeDeg, pdfEastLongitudeDeg, pdfNorthLatitudeDeg, ppszAreaName))
 end
 
 """
@@ -842,7 +842,7 @@ end
 Set a projection name.
 """
 function osrsetprojection(arg1, arg2)
-    ccall((:OSRSetProjection, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2)
+    aftercare(ccall((:OSRSetProjection, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring), arg1, arg2))
 end
 
 """
@@ -853,7 +853,7 @@ end
 Set a projection parameter value.
 """
 function osrsetprojparm(arg1, arg2, arg3)
-    ccall((:OSRSetProjParm, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OSRSetProjParm, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -865,7 +865,7 @@ end
 Fetch a projection parameter value.
 """
 function osrgetprojparm(hSRS, pszParmName, dfDefault, arg1)
-    ccall((:OSRGetProjParm, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Cdouble, Ptr{OGRErr}), hSRS, pszParmName, dfDefault, arg1)
+    aftercare(ccall((:OSRGetProjParm, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Cdouble, Ptr{OGRErr}), hSRS, pszParmName, dfDefault, arg1))
 end
 
 """
@@ -876,7 +876,7 @@ end
 Set a projection parameter with a normalized value.
 """
 function osrsetnormprojparm(arg1, arg2, arg3)
-    ccall((:OSRSetNormProjParm, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3)
+    aftercare(ccall((:OSRSetNormProjParm, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble), arg1, arg2, arg3))
 end
 
 """
@@ -888,7 +888,7 @@ end
 This function is the same as OGRSpatialReference::
 """
 function osrgetnormprojparm(hSRS, pszParmName, dfDefault, arg1)
-    ccall((:OSRGetNormProjParm, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Cdouble, Ptr{OGRErr}), hSRS, pszParmName, dfDefault, arg1)
+    aftercare(ccall((:OSRGetNormProjParm, libgdal), Cdouble, (OGRSpatialReferenceH, Cstring, Cdouble, Ptr{OGRErr}), hSRS, pszParmName, dfDefault, arg1))
 end
 
 """
@@ -899,7 +899,7 @@ end
 Set UTM projection definition.
 """
 function osrsetutm(hSRS, nZone, bNorth)
-    ccall((:OSRSetUTM, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint), hSRS, nZone, bNorth)
+    aftercare(ccall((:OSRSetUTM, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint), hSRS, nZone, bNorth))
 end
 
 """
@@ -909,7 +909,7 @@ end
 Get utm zone information.
 """
 function osrgetutmzone(hSRS, pbNorth)
-    ccall((:OSRGetUTMZone, libgdal), Cint, (OGRSpatialReferenceH, Ptr{Cint}), hSRS, pbNorth)
+    aftercare(ccall((:OSRGetUTMZone, libgdal), Cint, (OGRSpatialReferenceH, Ptr{Cint}), hSRS, pbNorth))
 end
 
 """
@@ -920,7 +920,7 @@ end
 Set State Plane projection definition.
 """
 function osrsetstateplane(hSRS, nZone, bNAD83)
-    ccall((:OSRSetStatePlane, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint), hSRS, nZone, bNAD83)
+    aftercare(ccall((:OSRSetStatePlane, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint), hSRS, nZone, bNAD83))
 end
 
 """
@@ -933,7 +933,7 @@ end
 Set State Plane projection definition.
 """
 function osrsetstateplanewithunits(hSRS, nZone, bNAD83, pszOverrideUnitName, dfOverrideUnit)
-    ccall((:OSRSetStatePlaneWithUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint, Cstring, Cdouble), hSRS, nZone, bNAD83, pszOverrideUnitName, dfOverrideUnit)
+    aftercare(ccall((:OSRSetStatePlaneWithUnits, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cint, Cstring, Cdouble), hSRS, nZone, bNAD83, pszOverrideUnitName, dfOverrideUnit))
 end
 
 """
@@ -942,7 +942,7 @@ end
 Set EPSG authority info if possible.
 """
 function osrautoidentifyepsg(hSRS)
-    ccall((:OSRAutoIdentifyEPSG, libgdal), OGRErr, (OGRSpatialReferenceH,), hSRS)
+    aftercare(ccall((:OSRAutoIdentifyEPSG, libgdal), OGRErr, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
@@ -963,7 +963,7 @@ Try to identify a match between the passed SRS and a related SRS in a catalog (c
 an array of SRS that match the passed SRS, or NULL. Must be freed with OSRFreeSRSArray()
 """
 function osrfindmatches(hSRS, papszOptions, pnEntries, ppanMatchConfidence)
-    ccall((:OSRFindMatches, libgdal), Ptr{OGRSpatialReferenceH}, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{Cint}}), hSRS, papszOptions, pnEntries, ppanMatchConfidence)
+    aftercare(ccall((:OSRFindMatches, libgdal), Ptr{OGRSpatialReferenceH}, (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{Cint}}), hSRS, papszOptions, pnEntries, ppanMatchConfidence))
 end
 
 """
@@ -975,7 +975,7 @@ Free return of OSRIdentifyMatches()
 * **pahSRS**: array of SRS (must be NULL terminated)
 """
 function osrfreesrsarray(pahSRS)
-    ccall((:OSRFreeSRSArray, libgdal), Cvoid, (Ptr{OGRSpatialReferenceH},), pahSRS)
+    aftercare(ccall((:OSRFreeSRSArray, libgdal), Cvoid, (Ptr{OGRSpatialReferenceH},), pahSRS))
 end
 
 """
@@ -984,16 +984,16 @@ end
 This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having lat/long coordinate ordering.
 """
 function osrepsgtreatsaslatlong(hSRS)
-    ccall((:OSREPSGTreatsAsLatLong, libgdal), Cint, (OGRSpatialReferenceH,), hSRS)
+    aftercare(ccall((:OSREPSGTreatsAsLatLong, libgdal), Cint, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
-    (OGRSpatialReferenceH hSRS) -> int
+    OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH hSRS) -> int
 
 This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having northing/easting coordinate ordering.
 """
 function osrepsgtreatsasnorthingeasting(hSRS)
-    ccall((:OSREPSGTreatsAsNorthingEasting, libgdal), Cint, (OGRSpatialReferenceH,), hSRS)
+    aftercare(ccall((:OSREPSGTreatsAsNorthingEasting, libgdal), Cint, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
@@ -1005,7 +1005,7 @@ end
 Fetch the orientation of one axis.
 """
 function osrgetaxis(hSRS, pszTargetKey, iAxis, peOrientation)
-    string_or_nothing(ccall((:OSRGetAxis, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint, Ptr{OGRAxisOrientation}), hSRS, pszTargetKey, iAxis, peOrientation))
+    aftercare(ccall((:OSRGetAxis, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint, Ptr{OGRAxisOrientation}), hSRS, pszTargetKey, iAxis, peOrientation), false)
 end
 
 """
@@ -1019,7 +1019,7 @@ end
 Set the axes for a coordinate system.
 """
 function osrsetaxes(hSRS, pszTargetKey, pszXAxisName, eXAxisOrientation, pszYAxisName, eYAxisOrientation)
-    ccall((:OSRSetAxes, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, OGRAxisOrientation, Cstring, OGRAxisOrientation), hSRS, pszTargetKey, pszXAxisName, eXAxisOrientation, pszYAxisName, eYAxisOrientation)
+    aftercare(ccall((:OSRSetAxes, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cstring, OGRAxisOrientation, Cstring, OGRAxisOrientation), hSRS, pszTargetKey, pszXAxisName, eXAxisOrientation, pszYAxisName, eYAxisOrientation))
 end
 
 """
@@ -1028,7 +1028,7 @@ end
 Retun the data axis to CRS axis mapping strategy.
 """
 function osrgetaxismappingstrategy(hSRS)
-    ccall((:OSRGetAxisMappingStrategy, libgdal), OSRAxisMappingStrategy, (OGRSpatialReferenceH,), hSRS)
+    aftercare(ccall((:OSRGetAxisMappingStrategy, libgdal), OSRAxisMappingStrategy, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
@@ -1038,7 +1038,7 @@ end
 Set the data axis to CRS axis mapping strategy.
 """
 function osrsetaxismappingstrategy(hSRS, strategy)
-    ccall((:OSRSetAxisMappingStrategy, libgdal), Cvoid, (OGRSpatialReferenceH, OSRAxisMappingStrategy), hSRS, strategy)
+    aftercare(ccall((:OSRSetAxisMappingStrategy, libgdal), Cvoid, (OGRSpatialReferenceH, OSRAxisMappingStrategy), hSRS, strategy))
 end
 
 """
@@ -1048,7 +1048,7 @@ end
 Return the data axis to SRS axis mapping.
 """
 function osrgetdataaxistosrsaxismapping(hSRS, pnCount)
-    ccall((:OSRGetDataAxisToSRSAxisMapping, libgdal), Ptr{Cint}, (OGRSpatialReferenceH, Ptr{Cint}), hSRS, pnCount)
+    aftercare(ccall((:OSRGetDataAxisToSRSAxisMapping, libgdal), Ptr{Cint}, (OGRSpatialReferenceH, Ptr{Cint}), hSRS, pnCount))
 end
 
 """
@@ -1063,7 +1063,7 @@ end
 Albers Conic Equal Area.
 """
 function osrsetacea(hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetACEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetACEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1076,7 +1076,7 @@ end
 Azimuthal Equidistant.
 """
 function osrsetae(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetAE, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetAE, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1089,7 +1089,7 @@ end
 Bonne.
 """
 function osrsetbonne(hSRS, dfStandardParallel, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetBonne, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStandardParallel, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetBonne, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStandardParallel, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1102,7 +1102,7 @@ end
 Cylindrical Equal Area.
 """
 function osrsetcea(hSRS, dfStdP1, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetCEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetCEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1115,7 +1115,7 @@ end
 Cassini-Soldner.
 """
 function osrsetcs(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetCS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1130,7 +1130,7 @@ end
 Equidistant Conic.
 """
 function osrsetec(hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1143,7 +1143,7 @@ end
 Eckert I-VI.
 """
 function osrseteckert(hSRS, nVariation, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEckert, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cdouble, Cdouble, Cdouble), hSRS, nVariation, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEckert, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cdouble, Cdouble, Cdouble), hSRS, nVariation, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1155,7 +1155,7 @@ end
 Eckert IV.
 """
 function osrseteckertiv(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEckertIV, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEckertIV, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1167,7 +1167,7 @@ end
 Eckert VI.
 """
 function osrseteckertvi(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEckertVI, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEckertVI, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1180,7 +1180,7 @@ end
 Equirectangular.
 """
 function osrsetequirectangular(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEquirectangular, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEquirectangular, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1194,7 +1194,7 @@ end
 Equirectangular generalized form.
 """
 function osrsetequirectangular2(hSRS, dfCenterLat, dfCenterLong, dfPseudoStdParallel1, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetEquirectangular2, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfPseudoStdParallel1, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetEquirectangular2, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfPseudoStdParallel1, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1206,7 +1206,7 @@ end
 Gall Stereograpic.
 """
 function osrsetgs(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetGS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetGS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1218,7 +1218,7 @@ end
 Goode Homolosine.
 """
 function osrsetgh(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetGH, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetGH, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1227,7 +1227,7 @@ end
 Interrupted Goode Homolosine.
 """
 function osrsetigh(hSRS)
-    ccall((:OSRSetIGH, libgdal), OGRErr, (OGRSpatialReferenceH,), hSRS)
+    aftercare(ccall((:OSRSetIGH, libgdal), OGRErr, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
@@ -1240,7 +1240,7 @@ end
 GEOS - Geostationary Satellite View.
 """
 function osrsetgeos(hSRS, dfCentralMeridian, dfSatelliteHeight, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetGEOS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfSatelliteHeight, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetGEOS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfSatelliteHeight, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1254,7 +1254,7 @@ end
 Gauss Schreiber Transverse Mercator.
 """
 function osrsetgaussschreibertmercator(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetGaussSchreiberTMercator, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetGaussSchreiberTMercator, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1267,7 +1267,7 @@ end
 Gnomonic.
 """
 function osrsetgnomonic(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetGnomonic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetGnomonic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1283,7 +1283,7 @@ end
 Set a Hotine Oblique Mercator projection using azimuth angle.
 """
 function osrsethom(hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetHOM, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetHOM, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1299,7 +1299,7 @@ end
 Set an Oblique Mercator projection using azimuth angle.
 """
 function osrsethomac(hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetHOMAC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetHOMAC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfRectToSkew, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1316,7 +1316,7 @@ end
 Set a Hotine Oblique Mercator projection using two points on projection centerline.
 """
 function osrsethom2pno(hSRS, dfCenterLat, dfLat1, dfLong1, dfLat2, dfLong2, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetHOM2PNO, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfLat1, dfLong1, dfLat2, dfLong2, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetHOM2PNO, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfLat1, dfLong1, dfLat2, dfLong2, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1330,7 +1330,7 @@ end
 International Map of the World Polyconic.
 """
 function osrsetiwmpolyconic(hSRS, dfLat1, dfLat2, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetIWMPolyconic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLat1, dfLat2, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetIWMPolyconic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLat1, dfLat2, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1346,7 +1346,7 @@ end
 Krovak Oblique Conic Conformal.
 """
 function osrsetkrovak(hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfPseudoStdParallelLat, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetKrovak, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfPseudoStdParallelLat, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetKrovak, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfAzimuth, dfPseudoStdParallelLat, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1359,7 +1359,7 @@ end
 Lambert Azimuthal Equal-Area.
 """
 function osrsetlaea(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetLAEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetLAEA, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1374,7 +1374,7 @@ end
 Lambert Conformal Conic.
 """
 function osrsetlcc(hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetLCC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetLCC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1388,7 +1388,7 @@ end
 Lambert Conformal Conic 1SP.
 """
 function osrsetlcc1sp(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetLCC1SP, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetLCC1SP, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1403,7 +1403,7 @@ end
 Lambert Conformal Conic (Belgium)
 """
 function osrsetlccb(hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetLCCB, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetLCCB, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfStdP2, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1416,7 +1416,7 @@ end
 Miller Cylindrical.
 """
 function osrsetmc(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetMC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetMC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1430,7 +1430,7 @@ end
 Mercator.
 """
 function osrsetmercator(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetMercator, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetMercator, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1444,7 +1444,7 @@ end
 Mercator 2SP.
 """
 function osrsetmercator2sp(hSRS, dfStdP1, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetMercator2SP, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetMercator2SP, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfStdP1, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1456,7 +1456,7 @@ end
 Mollweide.
 """
 function osrsetmollweide(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetMollweide, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetMollweide, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1469,7 +1469,7 @@ end
 New Zealand Map Grid.
 """
 function osrsetnzmg(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetNZMG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetNZMG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1483,7 +1483,7 @@ end
 Oblique Stereographic.
 """
 function osrsetos(hSRS, dfOriginLat, dfCMeridian, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetOS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfOriginLat, dfCMeridian, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetOS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfOriginLat, dfCMeridian, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1496,7 +1496,7 @@ end
 Orthographic.
 """
 function osrsetorthographic(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetOrthographic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetOrthographic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1509,7 +1509,7 @@ end
 Polyconic.
 """
 function osrsetpolyconic(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetPolyconic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetPolyconic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1523,7 +1523,7 @@ end
 Polar Stereographic.
 """
 function osrsetps(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetPS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetPS, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1535,7 +1535,7 @@ end
 Robinson.
 """
 function osrsetrobinson(hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetRobinson, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetRobinson, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1547,7 +1547,7 @@ end
 Sinusoidal.
 """
 function osrsetsinusoidal(hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetSinusoidal, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetSinusoidal, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1561,7 +1561,7 @@ end
 Stereographic.
 """
 function osrsetstereographic(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetStereographic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetStereographic, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1574,7 +1574,7 @@ end
 Swiss Oblique Cylindrical.
 """
 function osrsetsoc(hSRS, dfLatitudeOfOrigin, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetSOC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLatitudeOfOrigin, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetSOC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLatitudeOfOrigin, dfCentralMeridian, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1588,7 +1588,7 @@ end
 Transverse Mercator.
 """
 function osrsettm(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetTM, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetTM, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1603,7 +1603,7 @@ end
 Transverse Mercator variant.
 """
 function osrsettmvariant(hSRS, pszVariantName, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetTMVariant, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, pszVariantName, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetTMVariant, libgdal), OGRErr, (OGRSpatialReferenceH, Cstring, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, pszVariantName, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1616,7 +1616,7 @@ end
 Tunesia Mining Grid.
 """
 function osrsettmg(hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetTMG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetTMG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1630,7 +1630,7 @@ end
 Transverse Mercator (South Oriented)
 """
 function osrsettmso(hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetTMSO, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetTMSO, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong, dfScale, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1645,7 +1645,7 @@ end
 TPED (Two Point Equi Distant)
 """
 function osrsettped(hSRS, dfLat1, dfLong1, dfLat2, dfLong2, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetTPED, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLat1, dfLong1, dfLat2, dfLong2, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetTPED, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfLat1, dfLong1, dfLat2, dfLong2, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1657,7 +1657,7 @@ end
 VanDerGrinten.
 """
 function osrsetvdg(hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetVDG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetVDG, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble), hSRS, dfCenterLong, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1670,7 +1670,7 @@ end
 Wagner I  VII.
 """
 function osrsetwagner(hSRS, nVariation, dfCenterLat, dfFalseEasting, dfFalseNorthing)
-    ccall((:OSRSetWagner, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cdouble, Cdouble, Cdouble), hSRS, nVariation, dfCenterLat, dfFalseEasting, dfFalseNorthing)
+    aftercare(ccall((:OSRSetWagner, libgdal), OGRErr, (OGRSpatialReferenceH, Cint, Cdouble, Cdouble, Cdouble), hSRS, nVariation, dfCenterLat, dfFalseEasting, dfFalseNorthing))
 end
 
 """
@@ -1681,7 +1681,7 @@ end
 Quadrilateralized Spherical Cube.
 """
 function osrsetqsc(hSRS, dfCenterLat, dfCenterLong)
-    ccall((:OSRSetQSC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong)
+    aftercare(ccall((:OSRSetQSC, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble), hSRS, dfCenterLat, dfCenterLong))
 end
 
 """
@@ -1694,7 +1694,7 @@ end
 Spherical, Cross-track, Height.
 """
 function osrsetsch(hSRS, dfPegLat, dfPegLong, dfPegHeading, dfPegHgt)
-    ccall((:OSRSetSCH, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfPegLat, dfPegLong, dfPegHeading, dfPegHgt)
+    aftercare(ccall((:OSRSetSCH, libgdal), OGRErr, (OGRSpatialReferenceH, Cdouble, Cdouble, Cdouble, Cdouble), hSRS, dfPegLat, dfPegLong, dfPegHeading, dfPegHgt))
 end
 
 """
@@ -1711,7 +1711,7 @@ Compute inverse flattening from semi-major and semi-minor axis.
 inverse flattening, or 0 if both axis are equal.
 """
 function osrcalcinvflattening(dfSemiMajor, dfSemiMinor)
-    ccall((:OSRCalcInvFlattening, libgdal), Cdouble, (Cdouble, Cdouble), dfSemiMajor, dfSemiMinor)
+    aftercare(ccall((:OSRCalcInvFlattening, libgdal), Cdouble, (Cdouble, Cdouble), dfSemiMajor, dfSemiMinor))
 end
 
 """
@@ -1728,7 +1728,7 @@ Compute semi-minor axis from semi-major axis and inverse flattening.
 semi-minor axis
 """
 function osrcalcsemiminorfrominvflattening(dfSemiMajor, dfInvFlattening)
-    ccall((:OSRCalcSemiMinorFromInvFlattening, libgdal), Cdouble, (Cdouble, Cdouble), dfSemiMajor, dfInvFlattening)
+    aftercare(ccall((:OSRCalcSemiMinorFromInvFlattening, libgdal), Cdouble, (Cdouble, Cdouble), dfSemiMajor, dfInvFlattening))
 end
 
 """
@@ -1737,7 +1737,7 @@ end
 Cleanup cached SRS related memory.
 """
 function osrcleanup()
-    ccall((:OSRCleanup, libgdal), Cvoid, ())
+    aftercare(ccall((:OSRCleanup, libgdal), Cvoid, ()))
 end
 
 """
@@ -1756,7 +1756,7 @@ Enumerate CRS objects from the database.
 an array of OSRCRSInfo* pointers to be freed with OSRDestroyCRSInfoList(), or NULL in case of error.
 """
 function osrgetcrsinfolistfromdatabase(pszAuthName, params, pnOutResultCount)
-    ccall((:OSRGetCRSInfoListFromDatabase, libgdal), Ptr{Ptr{OSRCRSInfo}}, (Cstring, Ptr{OSRCRSListParameters}, Ptr{Cint}), pszAuthName, params, pnOutResultCount)
+    aftercare(ccall((:OSRGetCRSInfoListFromDatabase, libgdal), Ptr{Ptr{OSRCRSInfo}}, (Cstring, Ptr{OSRCRSListParameters}, Ptr{Cint}), pszAuthName, params, pnOutResultCount))
 end
 
 """
@@ -1765,7 +1765,7 @@ end
 Destroy the result returned by OSRGetCRSInfoListFromDatabase().
 """
 function osrdestroycrsinfolist(list)
-    ccall((:OSRDestroyCRSInfoList, libgdal), Cvoid, (Ptr{Ptr{OSRCRSInfo}},), list)
+    aftercare(ccall((:OSRDestroyCRSInfoList, libgdal), Cvoid, (Ptr{Ptr{OSRCRSInfo}},), list))
 end
 
 """
@@ -1782,7 +1782,7 @@ Create transformation object.
 NULL on failure or a ready to use transformation object.
 """
 function octnewcoordinatetransformation(hSourceSRS, hTargetSRS)
-    failsafe(ccall((:OCTNewCoordinateTransformation, libgdal), OGRCoordinateTransformationH, (OGRSpatialReferenceH, OGRSpatialReferenceH), hSourceSRS, hTargetSRS))
+    aftercare(ccall((:OCTNewCoordinateTransformation, libgdal), OGRCoordinateTransformationH, (OGRSpatialReferenceH, OGRSpatialReferenceH), hSourceSRS, hTargetSRS))
 end
 
 """
@@ -1791,7 +1791,7 @@ end
 Create coordinate transformation options.
 """
 function octnewcoordinatetransformationoptions()
-    failsafe(ccall((:OCTNewCoordinateTransformationOptions, libgdal), OGRCoordinateTransformationOptionsH, ()))
+    aftercare(ccall((:OCTNewCoordinateTransformationOptions, libgdal), OGRCoordinateTransformationOptionsH, ()))
 end
 
 """
@@ -1802,7 +1802,7 @@ end
 Sets a coordinate operation.
 """
 function octcoordinatetransformationoptionssetoperation(hOptions, pszCO, bReverseCO)
-    ccall((:OCTCoordinateTransformationOptionsSetOperation, libgdal), Cint, (OGRCoordinateTransformationOptionsH, Cstring, Cint), hOptions, pszCO, bReverseCO)
+    aftercare(ccall((:OCTCoordinateTransformationOptionsSetOperation, libgdal), Cint, (OGRCoordinateTransformationOptionsH, Cstring, Cint), hOptions, pszCO, bReverseCO))
 end
 
 """
@@ -1815,7 +1815,7 @@ end
 Sets an area of interest.
 """
 function octcoordinatetransformationoptionssetareaofinterest(hOptions, dfWestLongitudeDeg, dfSouthLatitudeDeg, dfEastLongitudeDeg, dfNorthLatitudeDeg)
-    ccall((:OCTCoordinateTransformationOptionsSetAreaOfInterest, libgdal), Cint, (OGRCoordinateTransformationOptionsH, Cdouble, Cdouble, Cdouble, Cdouble), hOptions, dfWestLongitudeDeg, dfSouthLatitudeDeg, dfEastLongitudeDeg, dfNorthLatitudeDeg)
+    aftercare(ccall((:OCTCoordinateTransformationOptionsSetAreaOfInterest, libgdal), Cint, (OGRCoordinateTransformationOptionsH, Cdouble, Cdouble, Cdouble, Cdouble), hOptions, dfWestLongitudeDeg, dfSouthLatitudeDeg, dfEastLongitudeDeg, dfNorthLatitudeDeg))
 end
 
 """
@@ -1824,7 +1824,7 @@ end
 Destroy coordinate transformation options.
 """
 function octdestroycoordinatetransformationoptions(arg1)
-    ccall((:OCTDestroyCoordinateTransformationOptions, libgdal), Cvoid, (OGRCoordinateTransformationOptionsH,), arg1)
+    aftercare(ccall((:OCTDestroyCoordinateTransformationOptions, libgdal), Cvoid, (OGRCoordinateTransformationOptionsH,), arg1))
 end
 
 """
@@ -1843,7 +1843,7 @@ Create transformation object.
 NULL on failure or a ready to use transformation object.
 """
 function octnewcoordinatetransformationex(hSourceSRS, hTargetSRS, hOptions)
-    failsafe(ccall((:OCTNewCoordinateTransformationEx, libgdal), OGRCoordinateTransformationH, (OGRSpatialReferenceH, OGRSpatialReferenceH, OGRCoordinateTransformationOptionsH), hSourceSRS, hTargetSRS, hOptions))
+    aftercare(ccall((:OCTNewCoordinateTransformationEx, libgdal), OGRCoordinateTransformationH, (OGRSpatialReferenceH, OGRSpatialReferenceH, OGRCoordinateTransformationOptionsH), hSourceSRS, hTargetSRS, hOptions))
 end
 
 """
@@ -1855,7 +1855,7 @@ OGRCoordinateTransformation destructor.
 * **hCT**: the object to delete
 """
 function octdestroycoordinatetransformation(arg1)
-    ccall((:OCTDestroyCoordinateTransformation, libgdal), Cvoid, (OGRCoordinateTransformationH,), arg1)
+    aftercare(ccall((:OCTDestroyCoordinateTransformation, libgdal), Cvoid, (OGRCoordinateTransformationH,), arg1))
 end
 
 """
@@ -1878,7 +1878,7 @@ Transform an array of points.
 TRUE or FALSE
 """
 function octtransform(hCT, nCount, x, y, z)
-    ccall((:OCTTransform, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), hCT, nCount, x, y, z)
+    aftercare(ccall((:OCTTransform, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), hCT, nCount, x, y, z))
 end
 
 """
@@ -1903,7 +1903,7 @@ Transform an array of points.
 TRUE or FALSE
 """
 function octtransformex(hCT, nCount, x, y, z, pabSuccess)
-    ccall((:OCTTransformEx, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), hCT, nCount, x, y, z, pabSuccess)
+    aftercare(ccall((:OCTTransformEx, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), hCT, nCount, x, y, z, pabSuccess))
 end
 
 """
@@ -1930,5 +1930,5 @@ Transform an array of points.
 TRUE or FALSE
 """
 function octtransform4d(hCT, nCount, x, y, z, t, pabSuccess)
-    ccall((:OCTTransform4D, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), hCT, nCount, x, y, z, t, pabSuccess)
+    aftercare(ccall((:OCTTransform4D, libgdal), Cint, (OGRCoordinateTransformationH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}), hCT, nCount, x, y, z, t, pabSuccess))
 end

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -11,7 +11,7 @@ Return the string representation for the OGRAxisOrientation enumeration.
 an internal string
 """
 function osraxisenumtoname(eOrientation)
-    unsafe_string(ccall((:OSRAxisEnumToName, libgdal), Cstring, (OGRAxisOrientation,), eOrientation))
+    string_or_nothing(ccall((:OSRAxisEnumToName, libgdal), Cstring, (OGRAxisOrientation,), eOrientation))
 end
 
 """
@@ -424,7 +424,7 @@ end
 Return the CRS name.
 """
 function osrgetname(hSRS)
-    unsafe_string(ccall((:OSRGetName, libgdal), Cstring, (OGRSpatialReferenceH,), hSRS))
+    string_or_nothing(ccall((:OSRGetName, libgdal), Cstring, (OGRSpatialReferenceH,), hSRS))
 end
 
 """
@@ -446,7 +446,7 @@ end
 Fetch indicated attribute of named node.
 """
 function osrgetattrvalue(hSRS, pszName, iChild)
-    unsafe_string(ccall((:OSRGetAttrValue, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint), hSRS, pszName, iChild))
+    string_or_nothing(ccall((:OSRGetAttrValue, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint), hSRS, pszName, iChild))
 end
 
 """
@@ -808,7 +808,7 @@ end
 Get the authority code for a node.
 """
 function osrgetauthoritycode(hSRS, pszTargetKey)
-    unsafe_string(ccall((:OSRGetAuthorityCode, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
+    string_or_nothing(ccall((:OSRGetAuthorityCode, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
 end
 
 """
@@ -818,7 +818,7 @@ end
 Get the authority name for a node.
 """
 function osrgetauthorityname(hSRS, pszTargetKey)
-    unsafe_string(ccall((:OSRGetAuthorityName, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
+    string_or_nothing(ccall((:OSRGetAuthorityName, libgdal), Cstring, (OGRSpatialReferenceH, Cstring), hSRS, pszTargetKey))
 end
 
 """
@@ -988,7 +988,7 @@ function osrepsgtreatsaslatlong(hSRS)
 end
 
 """
-    OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH hSRS) -> int
+    (OGRSpatialReferenceH hSRS) -> int
 
 This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having northing/easting coordinate ordering.
 """
@@ -1005,7 +1005,7 @@ end
 Fetch the orientation of one axis.
 """
 function osrgetaxis(hSRS, pszTargetKey, iAxis, peOrientation)
-    unsafe_string(ccall((:OSRGetAxis, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint, Ptr{OGRAxisOrientation}), hSRS, pszTargetKey, iAxis, peOrientation))
+    string_or_nothing(ccall((:OSRGetAxis, libgdal), Cstring, (OGRSpatialReferenceH, Cstring, Cint, Ptr{OGRAxisOrientation}), hSRS, pszTargetKey, iAxis, peOrientation))
 end
 
 """

--- a/test/error.jl
+++ b/test/error.jl
@@ -2,7 +2,7 @@
     # throw errors on non existing files
     @test_throws GDAL.GDALError GDAL.gdalopen("NonExistent", GDAL.GA_ReadOnly)
     # if a driver is not found it doesn't throw a GDALError
-    @test GDAL.gdalgetdriverbyname("NonExistent") === C_NULL
+    @test GDAL.gdalgetdriverbyname("NotADriver") === C_NULL
 
     @testset "error reset" begin
         # everything ok, no errors

--- a/test/error.jl
+++ b/test/error.jl
@@ -39,6 +39,12 @@
         @test err.msg === "Unknown option name '-novalidoption'"
     end
 
+    @testset "Cstring handling" begin
+        # string_or_nothing should return nothing here
+        srs = GDAL.osrnewspatialreference(C_NULL)
+        @test GDAL.osrgetattrvalue(srs, "NoSuchAttr", 0) === nothing
+    end
+
     # Quoting cpl_error.cpp regarding CE_Fatal:
     # > The default behaviour of CPLError() is to report errors to stderr,
     # > and to abort() after reporting a CE_Fatal error.  It is expected that


### PR DESCRIPTION
Fixes #67.

Currently this errors with `ArgumentError: cannot convert NULL to string` in `unsafe_string`, even though many functions are documented to return NULL in certain cases, that are not errors. This now works similarly to many Base functions like `findfirst`, that return `nothing` in case nothing is found.