### PR TITLE
test if JP2OpenJPEG driver is available

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 [compat]
 CEnum = "0.2, 0.3, 0.4"
 GDAL_jll = "3.0.4"
-PROJ_jll = "6.3.0"
+PROJ_jll = "7.0.1"
 julia = "1.3"
 
 [extras]

--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -7,6 +7,7 @@ available_drivers = [
     "AAIGrid",
     "GPKG",
     "GTiff",
+    "JP2OpenJPEG",
     "MEM",
     "PCRaster",
     # libcurl raster drivers
@@ -44,12 +45,4 @@ available_drivers = [
 
 for drivername in available_drivers
     @test GDAL.gdalgetdriverbyname(drivername) != C_NULL
-end
-
-not_available_drivers = [
-    "JP2OpenJPEG",  # up next, see #64
-]
-
-for drivername in not_available_drivers
-    @test_broken GDAL.gdalgetdriverbyname(drivername) != C_NULL
 end


### PR DESCRIPTION
A new GDAL_jll build was just released in https://github.com/JuliaPackaging/Yggdrasil/pull/1185. Let's confirm if indeed it fixes #64.