### PR TITLE
fix on Julia 1.6 for MozillaCACerts_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.1.4"
+version = "1.1.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -2,7 +2,7 @@ module GDAL
 
 using PROJ_jll
 using GDAL_jll
-using MozillaCACerts_jll
+using MozillaCACerts_jll: cacert
 using CEnum
 
 const Ctm = Base.Libc.TmStruct


### PR DESCRIPTION
stdlib dummy MozillaCACerts_jll does not export `cacert`, which we use in `__init__`