### PR TITLE
Test new drivers for new GDAL_jll release.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.1.5"
+version = "1.1.6"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.1.6"
+version = "1.1.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -15,7 +15,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 CEnum = "0.2, 0.3, 0.4"
 GDAL_jll = "3.0.4"
 MozillaCACerts_jll = ">= 2020"
-PROJ_jll = "7.0.1"
+PROJ_jll = "7.2.0"
 julia = "1.3"
 
 [extras]

--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -18,7 +18,7 @@ available_drivers = [
     "WMS",
     "WMTS",
     # webp raster drivers
-    "WEBP",
+    # "WEBP",
     # vector drivers
     "ARCGEN",
     "GeoJSON",

--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -17,6 +17,8 @@ available_drivers = [
     "WCS",
     "WMS",
     "WMTS",
+    # webp raster drivers
+    "WEBP",
     # vector drivers
     "ARCGEN",
     "GeoJSON",
@@ -28,6 +30,14 @@ available_drivers = [
     "TopoJSON",
     "VRT",
     "SQLite",
+    # libexpat vector drivers
+    "JML",
+    "GML",
+    "GPX",
+    "GeoRSS",
+    "LVBAG",
+    "ODS",
+    "OSM",
     # libcurl vector drivers
     "AmigoCloud",
     "Carto",
@@ -43,8 +53,12 @@ available_drivers = [
     "WFS3",
 ]
 
-for drivername in available_drivers
-    @test GDAL.gdalgetdriverbyname(drivername) != C_NULL
+@testset "Drivers" begin
+    for drivername in available_drivers
+        @testset "$drivername" begin
+            @test GDAL.gdalgetdriverbyname(drivername) != C_NULL
+        end
+    end
 end
 
 # errors with BADCERT_NOT_TRUSTED if the CA certificate paths is not properly configured

--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -35,7 +35,6 @@ available_drivers = [
     "GML",
     "GPX",
     "GeoRSS",
-    "LVBAG",
     "ODS",
     "OSM",
     # libcurl vector drivers


### PR DESCRIPTION
Still needs a release of https://github.com/JuliaPackaging/Yggdrasil/pull/1941. 

Because no version has been upped of GDAL_jll, not sure how to actually point to it apart from a git hash. v3.0.4+2 is not a valid version number.