### PR TITLE
fix PROJ_jll to 7.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 CEnum = "0.2, 0.3, 0.4"
 GDAL_jll = "3.0.4"
 MozillaCACerts_jll = ">= 2020"
-PROJ_jll = "7.0.1"
+PROJ_jll = "= 7.0.1"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
It looks like the latest PROJ build, 7.2.0, is causing the tests of GDAL to fail. If so, then this should pass on CI. Not sure if we'd want to merge this as is though, since on previous GDAL.jl versions it would still allow newer PROJ builds.

If you run into issues like:
```
ERROR: LoadError: InitError: could not load library "C:\Users\appveyor\.julia\artifacts\5ef006d7efdd27e9e2777126967ac7e86e2a0a1d\bin\libgdal-26.dll"
The specified module could not be found.
```
You can pin PROJ_jll in your own environment as a temporary workaround.
```
pkg> add PROJ_jll
pkg> pin PROJ_jll@7.0.1
```

I should note that the new PROJ_jll does seem to work fine with Proj4.jl, as that passes tests: https://github.com/JuliaGeo/Proj4.jl