### PR TITLE
exclude OSX on julia 1.3 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       arch: arm64
     - julia: nightly
       arch: arm64
+    - julia: 1.3
+      os: osx
 notifications:
   email: false
 cache:


### PR DESCRIPTION
It is passing on the latest julia, but on 1.3 I currently get:

https://travis-ci.com/github/JuliaGeo/GDAL.jl/jobs/432690353

```
ERROR: LoadError: InitError: could not load library "/Users/travis/.julia/artifacts/8526016289eece179220fb1206bfb41fa30bef56/lib/libgdal.26.dylib"
dlopen(/Users/travis/.julia/artifacts/8526016289eece179220fb1206bfb41fa30bef56/lib/libgdal.26.dylib, 1): Library not loaded: @rpath/libnghttp2.14.dylib
  Referenced from: /Users/travis/.julia/artifacts/8526016289eece179220fb1206bfb41fa30bef56/lib/libgdal.26.dylib
  Reason: Incompatible library version: libgdal.26.dylib requires version 35.0.0 or later, but libnghttp2.14.dylib provides version 34.0.0
```

The alternative is dropping 1.3 support, but since only OSX has this issue, I was thinking to just let it be.