### PR TITLE
test new drivers included in GDAL 3.2.0

### DIFF
--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -5,10 +5,12 @@
 available_drivers = [
     # raster drivers
     "AAIGrid",
+    "COG",
     "GPKG",
     "GTiff",
     "JP2OpenJPEG",
     "MEM",
+    "OGCAPI",
     "PCRaster",
     # libcurl raster drivers
     "EEDAI",
@@ -21,10 +23,12 @@ available_drivers = [
     # "WEBP",
     # vector drivers
     "ARCGEN",
+    "FlatGeoBuf",
     "GeoJSON",
     "GML",
     "GPKG",
     "KML",
+    "LVBAG",
     "OpenFileGDB",
     "ESRI Shapefile",
     "TopoJSON",
@@ -45,11 +49,10 @@ available_drivers = [
     "CSW",
     "EEDA",
     "ElasticSearch",
-    "GFT",
     "NGW",
+    "OAPIF",
     "PLScenes",
     "WFS",
-    "WFS3",
 ]
 
 @testset "Drivers" begin


### PR DESCRIPTION
Since https://github.com/JuliaPackaging/Yggdrasil/pull/2311 we have a build of GDAL 3.2.0: https://github.com/JuliaBinaryWrappers/GDAL_jll.jl/releases/tag/GDAL-v3.2.0%2B0

The tests were failing due to the GFT and WFS3 drivers not being available anymore. But in https://github.com/OSGeo/gdal/blob/v3.2.0/gdal/NEWS I saw that one is removed and the other renamed:

- Remove GFT driver now that the online service no longer exists
- OAPIF driver (previously WFS3)

Furthermore I added some of the new drivers that I want to make sure are included:

- COG - Cloud Optimized GeoTIFF: https://gdal.org/drivers/raster/cog.html#raster-cog
- OGCAPI: https://gdal.org/drivers/raster/ogcapi.html
- FlatGeoBuf: https://gdal.org/drivers/vector/flatgeobuf.html, see also https://github.com/evetion/FlatGeoBuf.jl
- LVBAG (because I'm Dutch): https://gdal.org/drivers/vector/lvbag.html