### PR TITLE
remove /deps/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-/deps/deps.jl
-/deps/deps_*.jl
-/deps/build.log
-/deps/usr
 /gen/doxygen.xml
 *.jl.cov
 *.jl.*.cov


### PR DESCRIPTION
Actually I want to verify if the MacOS build still works. EDIT: It does. :)