### PR TITLE
Deregister custom `gdaljl_errorhandler` at Julia exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.*.cov
 *.jl.mem
 log.txt
+.DS_Store

--- a/gen/epilogue.jl
+++ b/gen/epilogue.jl
@@ -8,6 +8,7 @@ function __init__()
     # register custom error handler
     funcptr = @cfunction(gdaljl_errorhandler, Ptr{Cvoid}, (CPLErr, Cint, Cstring))
     cplseterrorhandler(funcptr)
+    atexit(() -> cplseterrorhandler(C_NULL))
 
     # get GDAL version number
     versionstring = gdalversioninfo("RELEASE_NAME")


### PR DESCRIPTION
Fixes ArchGDAL issue https://github.com/yeesian/ArchGDAL.jl/issues/241 as discussed in PR https://github.com/yeesian/ArchGDAL.jl/pull/245#pullrequestreview-768552407