### PR TITLE
`gdaldestroy` registered first at exit in GDAL.jl/gen/epilogue.jl `__init__()`

### DIFF
--- a/gen/epilogue.jl
+++ b/gen/epilogue.jl
@@ -5,10 +5,14 @@ const GDAL_DATA = Ref{String}()
 const PROJ_LIB = Ref{String}()
 
 function __init__()
+    # Cleanup at exit
+    atexit(gdaldestroy)
+    # atexit(() -> gdaldumpopendatasets("/dev/stderr")) # TODO find a way to pass a pointer to stderr
+    
     # register custom error handler
     funcptr = @cfunction(gdaljl_errorhandler, Ptr{Cvoid}, (CPLErr, Cint, Cstring))
     cplseterrorhandler(funcptr)
-    atexit(() -> cplseterrorhandler(C_NULL))
+    # atexit(() -> cplseterrorhandler(C_NULL))
 
     # get GDAL version number
     versionstring = gdalversioninfo("RELEASE_NAME")


### PR DESCRIPTION
@visr as discussed in https://github.com/yeesian/ArchGDAL.jl/pull/245#discussion_r720805777 here is a PR proposition for comments.

I have kept commented the registration at exit of `cplseterrorhandler(C_NULL)` and of a trial wih `gdaldumpopendatasets` for easy revert for the former and comment for the latter