### PR TITLE
regenerate with a released Clang.jl

### DIFF
--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,334 +1,347 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[ArgTools]]
+julia_version = "1.7.1"
+manifest_format = "2.0"
+
+[[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
-[[Artifacts]]
+[[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
-[[Base64]]
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[CEnum]]
+[[deps.CEnum]]
 git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.4.1"
 
-[[CSTParser]]
+[[deps.CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "b2667530e42347b10c10ba6623cfebc09ac5c7b6"
+git-tree-sha1 = "f9a6389348207faf5e5c62cbc7e89d19688d338a"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "3.2.4"
+version = "3.3.0"
 
-[[Clang]]
+[[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "847c607053e8976d4b6a2e236015c384a44f01b4"
-repo-rev = "dump-doc-patch"
-repo-url = "https://github.com/melonedo/Clang.jl"
+git-tree-sha1 = "45a5a25b76dbdaf8e794a585936ec56020e606d7"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.14.0"
+version = "0.15.0"
 
-[[Clang_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libLLVM_jll"]
-git-tree-sha1 = "a5923c06de3178dd755f4b9411ea8922a7ae6fb8"
+[[deps.Clang_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll", "libLLVM_jll"]
+git-tree-sha1 = "8cf7e67e264dedc5d321ec87e78525e958aea057"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "11.0.1+3"
+version = "12.0.1+3"
 
-[[CommonMark]]
+[[deps.CommonMark]]
 deps = ["Crayons", "JSON", "URIs"]
-git-tree-sha1 = "1060c5023d2ac8210c73078cb7c0c567101d201c"
+git-tree-sha1 = "4aff51293dbdbd268df314827b7f409ea57f5b70"
 uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
-version = "0.8.2"
+version = "0.8.5"
 
-[[Compat]]
+[[deps.Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "344f143fa0ec67e47917848795ab19c6a455f32c"
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.32.0"
+version = "3.41.0"
 
-[[Crayons]]
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 version = "4.0.4"
 
-[[DataStructures]]
+[[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.10"
+version = "0.18.11"
 
-[[Dates]]
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[DelimitedFiles]]
+[[deps.DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
-[[Distributed]]
+[[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[Downloads]]
+[[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
-[[Expat_jll]]
+[[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
 version = "2.2.10+0"
 
-[[EzXML]]
+[[deps.EzXML]]
 deps = ["Printf", "XML2_jll"]
 git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
 uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 version = "1.1.0"
 
-[[GDAL_jll]]
+[[deps.GDAL_jll]]
 deps = ["Artifacts", "Expat_jll", "GEOS_jll", "JLLWrappers", "LibCURL_jll", "LibSSH2_jll", "Libdl", "Libtiff_jll", "MbedTLS_jll", "OpenJpeg_jll", "PROJ_jll", "Pkg", "SQLite_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "nghttp2_jll"]
 git-tree-sha1 = "439c33eb4dfa74a43a1e96b1d758aeb3cbc33dc3"
 uuid = "a7073274-a066-55f0-b90d-d619367d196c"
 version = "300.202.100+0"
 
-[[GEOS_jll]]
+[[deps.GEOS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "45d0ddfd29620ac9b2d1072801e90fb016c5f94c"
 uuid = "d604d12d-fa86-5845-992e-78dc15976526"
 version = "3.9.0+0"
 
-[[InteractiveUtils]]
+[[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[JLLWrappers]]
+[[deps.JLLWrappers]]
 deps = ["Preferences"]
 git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
-[[JSON]]
+[[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
-[[JpegTurbo_jll]]
+[[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
 version = "2.1.0+0"
 
-[[JuliaFormatter]]
+[[deps.JuliaFormatter]]
 deps = ["CSTParser", "CommonMark", "DataStructures", "Pkg", "Tokenize"]
-git-tree-sha1 = "01de4719a784d520199608f8996ec8ff11e8fa24"
+git-tree-sha1 = "51e6716cc630c157dc5fbd466429c891f5ce6462"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "0.15.7"
+version = "0.20.5"
 
-[[LibCURL]]
+[[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 
-[[LibCURL_jll]]
+[[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
-[[LibGit2]]
+[[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[LibSSH2_jll]]
+[[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[Libiconv_jll]]
+[[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
 version = "1.16.1+1"
 
-[[Libtiff_jll]]
+[[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
 git-tree-sha1 = "340e257aada13f95f98ee352d316c3bed37c8ab9"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
 version = "4.3.0+0"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[LittleCMS_jll]]
+[[deps.LittleCMS_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pkg"]
 git-tree-sha1 = "110897e7db2d6836be22c18bffd9422218ee6284"
 uuid = "d3a379c0-f9a3-5b72-a4c0-6bf4d2e8af0f"
 version = "2.12.0+0"
 
-[[Logging]]
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[MacroTools]]
+[[deps.MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "0fb723cd8c45858c22169b2e42269e53271a6df7"
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.7"
+version = "0.5.9"
 
-[[Markdown]]
+[[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MbedTLS_jll]]
+[[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
-[[Mmap]]
+[[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MozillaCACerts_jll]]
+[[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
-[[NetworkOptions]]
+[[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
-[[OpenJpeg_jll]]
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OpenJpeg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libtiff_jll", "LittleCMS_jll", "Pkg", "libpng_jll"]
 git-tree-sha1 = "76374b6e7f632c130e78100b166e5a48464256f8"
 uuid = "643b3616-a352-519d-856d-80112ee9badc"
 version = "2.4.0+0"
 
-[[OrderedCollections]]
+[[deps.OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
-[[PROJ_jll]]
+[[deps.PROJ_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "LibSSH2_jll", "Libdl", "Libtiff_jll", "MbedTLS_jll", "Pkg", "SQLite_jll", "Zlib_jll", "nghttp2_jll"]
 git-tree-sha1 = "2435e91710d7f97f53ef7a4872bf1f948dc8e5f8"
 uuid = "58948b4f-47e0-5654-a9ad-f609743f8632"
 version = "700.202.100+0"
 
-[[Parsers]]
+[[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "477bf42b4d1496b454c10cce46645bb5b8a0cf2c"
+git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.2"
+version = "2.1.3"
 
-[[Pkg]]
+[[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
-[[Preferences]]
+[[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.2.3"
 
-[[Printf]]
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[REPL]]
+[[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
-[[Random]]
-deps = ["Serialization"]
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[SQLite_jll]]
+[[deps.SQLite_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "9a0e24b81e3ce02c4b2eb855476467c7b93b8a8f"
+git-tree-sha1 = "cca82caa0b6bf7f0bc977e69063c0cf5d7da36e5"
 uuid = "76ed43ae-9a5d-5a62-8c75-30186b810ce8"
-version = "3.36.0+0"
+version = "3.37.0+0"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[SharedArrays]]
+[[deps.SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
-[[Sockets]]
+[[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[TOML]]
+[[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
-[[Tar]]
+[[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
-[[Test]]
+[[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[Tokenize]]
-git-tree-sha1 = "eee92eda3cc8e104b7e56ff4c1fcf0d78ca37c89"
+[[deps.Tokenize]]
+git-tree-sha1 = "0952c9cee34988092d73a5708780b3917166a0dd"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.18"
+version = "0.5.21"
 
-[[URIs]]
+[[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 version = "1.3.0"
 
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[XML2_jll]]
+[[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
 git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
 version = "2.9.12+0"
 
-[[Zlib_jll]]
+[[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 
-[[Zstd_jll]]
+[[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "cc4bf3fdde8b7e3e9fa0351bdeedba1cf3b7f6e6"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.0+0"
 
-[[libLLVM_jll]]
+[[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
 
-[[libgeotiff_jll]]
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.libgeotiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libtiff_jll", "PROJ_jll", "Pkg"]
 git-tree-sha1 = "a5cc2e3dd7b1c1e783a61b8ab7de03eebddfed60"
 uuid = "06c338fa-64ff-565b-ac2f-249532af990e"
 version = "1.6.0+1"
 
-[[libpng_jll]]
+[[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
 git-tree-sha1 = "94d180a6d2b5e55e447e2d27a29ed04fe79eb30c"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 version = "1.6.38+0"
 
-[[nghttp2_jll]]
+[[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 
-[[p7zip_jll]]
+[[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/gen/combine_gdal_doxygen_xml.py
+++ b/gen/combine_gdal_doxygen_xml.py
@@ -41,3 +41,10 @@ for elem in tree.xpath('/doxygen/compounddef'):
             elem.remove(subelem)
 
 tree.write(outxml)
+
+# remove hidden character that the julia parser won't accept, fixed in GDAL 3.4.1
+# https://github.com/OSGeo/gdal/pull/5043
+with open(outxml) as f:
+    clean_text = f.read().replace('&#8236;', '')
+with open(outxml, "w") as f:
+    f.write(clean_text)

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -15539,7 +15539,7 @@ Create viewshed from raster DEM.
 * **dfInvisibleVal**: pixel value for invisibility (default 0)
 * **dfOutOfRangeVal**: The value to be set for the cells that fall outside of the range specified by dfMaxDistance.
 * **dfNoDataVal**: The value to be set for the cells that have no data. If set to a negative value, nodata is not set. Note: currently, no special processing of input cells at a nodata value is done (which may result in erroneous results).
-* **dfCurvCoeff**: Coefficient to consider the effect of the curvature and refraction. The height of the DEM is corrected according to the following formula: [Height] -= dfCurvCoeff * [Target Distance]^2 / [Earth Diameter] For the effect of the atmospheric refraction we can use 0.85714‬.
+* **dfCurvCoeff**: Coefficient to consider the effect of the curvature and refraction. The height of the DEM is corrected according to the following formula: [Height] -= dfCurvCoeff * [Target Distance]^2 / [Earth Diameter] For the effect of the atmospheric refraction we can use 0.85714.
 * **eMode**: The mode of the viewshed calculation. Possible values GVM_Diagonal = 1, GVM_Edge = 2 (default), GVM_Max = 3, GVM_Min = 4.
 * **dfMaxDistance**: maximum distance range to compute viewshed. It is also used to clamp the extent of the output raster. If set to 0, then unlimited range is assumed, that is to say the computation is performed on the extent of the whole raster.
 * **pfnProgress**: A GDALProgressFunc that may be used to report progress to the user, or to interrupt the algorithm. May be NULL if not required.

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -31,6 +31,15 @@ GDAL_COMPUTE_VERSION(maj, min, rev) = begin
 end
 
 """
+    VSIFree(void * pData) -> void
+
+Analog of free() for data allocated with VSIMalloc(), VSICalloc(), VSIRealloc()
+"""
+function vsifree(arg1)
+    aftercare(ccall((:VSIFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
+end
+
+"""
     cplverifyconfiguration()
 
 Doxygen\\_Suppress 
@@ -844,7 +853,7 @@ function cplprinttime(arg1, arg2, arg3, arg4, arg5)
         ccall(
             (:CPLPrintTime, libgdal),
             Cint,
-            (Cstring, Cint, Cstring, Ptr{tm}, Cstring),
+            (Cstring, Cint, Cstring, Ptr{Cvoid}, Cstring),
             arg1,
             arg2,
             arg3,
@@ -2425,14 +2434,17 @@ function cplserializexmltreetofile(psTree, pszFilename)
     )
 end
 
-"Int16 type "
-const GInt16 = Cshort
-
 "Unsigned int16 type "
 const GUInt16 = Cushort
 
+"Unsigned 64 bit integer type "
+const GUInt64 = GUIntBig
+
 "Unsigned byte type "
 const GByte = Cuchar
+
+"Int16 type "
+const GInt16 = Cshort
 
 """
 
@@ -2443,9 +2455,6 @@ const GBool = Cint
 
 "Signed 64 bit integer type "
 const GInt64 = GIntBig
-
-"Unsigned 64 bit integer type "
-const GUInt64 = GUIntBig
 
 "Integer type large enough to hold the difference between 2 addresses "
 const GPtrDiff_t = GIntBig
@@ -3071,6 +3080,155 @@ This function must be called after the last [`CPLVirtualMem`](@ref) object has b
 """
 function cplvirtualmemmanagerterminate()
     aftercare(ccall((:CPLVirtualMemManagerTerminate, libgdal), Cvoid, ()))
+end
+
+"""
+    VSIMallocAlignedAutoVerbose(size_t nSize,
+                                const char * pszFile,
+                                int nLine) -> void *
+
+See VSIMallocAlignedAuto()
+"""
+function vsimallocalignedautoverbose(nSize, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIMallocAlignedAutoVerbose, libgdal),
+            Ptr{Cvoid},
+            (Csize_t, Cstring, Cint),
+            nSize,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsimallocverbose(nSize, pszFile, nLine)
+
+[`VSIMallocVerbose`](@ref) 
+"""
+function vsimallocverbose(nSize, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIMallocVerbose, libgdal),
+            Ptr{Cvoid},
+            (Csize_t, Cstring, Cint),
+            nSize,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsimalloc2verbose(nSize1, nSize2, pszFile, nLine)
+
+[`VSIMalloc2Verbose`](@ref) 
+"""
+function vsimalloc2verbose(nSize1, nSize2, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIMalloc2Verbose, libgdal),
+            Ptr{Cvoid},
+            (Csize_t, Csize_t, Cstring, Cint),
+            nSize1,
+            nSize2,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsimalloc3verbose(nSize1, nSize2, nSize3, pszFile, nLine)
+
+[`VSIMalloc3Verbose`](@ref) 
+"""
+function vsimalloc3verbose(nSize1, nSize2, nSize3, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIMalloc3Verbose, libgdal),
+            Ptr{Cvoid},
+            (Csize_t, Csize_t, Csize_t, Cstring, Cint),
+            nSize1,
+            nSize2,
+            nSize3,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsicallocverbose(nCount, nSize, pszFile, nLine)
+
+[`VSICallocVerbose`](@ref) 
+"""
+function vsicallocverbose(nCount, nSize, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSICallocVerbose, libgdal),
+            Ptr{Cvoid},
+            (Csize_t, Csize_t, Cstring, Cint),
+            nCount,
+            nSize,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsireallocverbose(pOldPtr, nNewSize, pszFile, nLine)
+
+[`VSIReallocVerbose`](@ref) 
+"""
+function vsireallocverbose(pOldPtr, nNewSize, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIReallocVerbose, libgdal),
+            Ptr{Cvoid},
+            (Ptr{Cvoid}, Csize_t, Cstring, Cint),
+            pOldPtr,
+            nNewSize,
+            pszFile,
+            nLine,
+        ),
+    )
+end
+
+"""
+    vsistrdupverbose(pszStr, pszFile, nLine)
+
+[`VSIStrdupVerbose`](@ref) 
+"""
+function vsistrdupverbose(pszStr, pszFile, nLine)
+    aftercare(
+        ccall(
+            (:VSIStrdupVerbose, libgdal),
+            Cstring,
+            (Cstring, Cstring, Cint),
+            pszStr,
+            pszFile,
+            nLine,
+        ),
+        false,
+    )
+end
+
+"""
+    VSIReadDir(const char * pszPath) -> char **
+
+Read names in a directory.
+
+### Parameters
+* **pszPath**: the relative, or absolute path of a directory to read. UTF-8 encoded.
+
+### Returns
+The list of entries in the directory, or NULL if the directory doesn't exist. Filenames are returned in UTF-8 encoding.
+"""
+function vsireaddir(arg1)
+    aftercare(ccall((:VSIReadDir, libgdal), Ptr{Cstring}, (Cstring,), arg1))
 end
 
 """
@@ -3885,15 +4043,6 @@ function vsimalloc(arg1)
 end
 
 """
-    VSIFree(void * pData) -> void
-
-Analog of free() for data allocated with VSIMalloc(), VSICalloc(), VSIRealloc()
-"""
-function vsifree(arg1)
-    aftercare(ccall((:VSIFree, libgdal), Cvoid, (Ptr{Cvoid},), arg1))
-end
-
-"""
     VSIRealloc(void * pData,
                size_t nNewSize) -> void *
 
@@ -3965,26 +4114,6 @@ function vsifreealigned(ptr)
 end
 
 """
-    VSIMallocAlignedAutoVerbose(size_t nSize,
-                                const char * pszFile,
-                                int nLine) -> void *
-
-See VSIMallocAlignedAuto()
-"""
-function vsimallocalignedautoverbose(nSize, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIMallocAlignedAutoVerbose, libgdal),
-            Ptr{Cvoid},
-            (Csize_t, Cstring, Cint),
-            nSize,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
     vsimalloc2(nSize1, nSize2)
 
 [`VSIMalloc2`](@ref) allocates (nSize1 * nSize2) bytes. In case of overflow of the multiplication, or if memory allocation fails, a NULL pointer is returned and a CE\\_Failure error is raised with [`CPLError`](@ref)(). If nSize1 == 0 || nSize2 == 0, a NULL pointer will also be returned. [`CPLFree`](@ref)() or [`VSIFree`](@ref)() can be used to free memory allocated by this function.
@@ -4012,120 +4141,6 @@ function vsimalloc3(nSize1, nSize2, nSize3)
 end
 
 """
-    vsimallocverbose(nSize, pszFile, nLine)
-
-[`VSIMallocVerbose`](@ref) 
-"""
-function vsimallocverbose(nSize, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIMallocVerbose, libgdal),
-            Ptr{Cvoid},
-            (Csize_t, Cstring, Cint),
-            nSize,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
-    vsimalloc2verbose(nSize1, nSize2, pszFile, nLine)
-
-[`VSIMalloc2Verbose`](@ref) 
-"""
-function vsimalloc2verbose(nSize1, nSize2, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIMalloc2Verbose, libgdal),
-            Ptr{Cvoid},
-            (Csize_t, Csize_t, Cstring, Cint),
-            nSize1,
-            nSize2,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
-    vsimalloc3verbose(nSize1, nSize2, nSize3, pszFile, nLine)
-
-[`VSIMalloc3Verbose`](@ref) 
-"""
-function vsimalloc3verbose(nSize1, nSize2, nSize3, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIMalloc3Verbose, libgdal),
-            Ptr{Cvoid},
-            (Csize_t, Csize_t, Csize_t, Cstring, Cint),
-            nSize1,
-            nSize2,
-            nSize3,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
-    vsicallocverbose(nCount, nSize, pszFile, nLine)
-
-[`VSICallocVerbose`](@ref) 
-"""
-function vsicallocverbose(nCount, nSize, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSICallocVerbose, libgdal),
-            Ptr{Cvoid},
-            (Csize_t, Csize_t, Cstring, Cint),
-            nCount,
-            nSize,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
-    vsireallocverbose(pOldPtr, nNewSize, pszFile, nLine)
-
-[`VSIReallocVerbose`](@ref) 
-"""
-function vsireallocverbose(pOldPtr, nNewSize, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIReallocVerbose, libgdal),
-            Ptr{Cvoid},
-            (Ptr{Cvoid}, Csize_t, Cstring, Cint),
-            pOldPtr,
-            nNewSize,
-            pszFile,
-            nLine,
-        ),
-    )
-end
-
-"""
-    vsistrdupverbose(pszStr, pszFile, nLine)
-
-[`VSIStrdupVerbose`](@ref) 
-"""
-function vsistrdupverbose(pszStr, pszFile, nLine)
-    aftercare(
-        ccall(
-            (:VSIStrdupVerbose, libgdal),
-            Cstring,
-            (Cstring, Cstring, Cint),
-            pszStr,
-            pszFile,
-            nLine,
-        ),
-        false,
-    )
-end
-
-"""
     CPLGetPhysicalRAM(void) -> GIntBig
 
 Return the total physical RAM in bytes.
@@ -4147,21 +4162,6 @@ the total physical RAM, usable by a process, in bytes (or 0 in case of failure).
 """
 function cplgetusablephysicalram()
     aftercare(ccall((:CPLGetUsablePhysicalRAM, libgdal), GIntBig, ()))
-end
-
-"""
-    VSIReadDir(const char * pszPath) -> char **
-
-Read names in a directory.
-
-### Parameters
-* **pszPath**: the relative, or absolute path of a directory to read. UTF-8 encoded.
-
-### Returns
-The list of entries in the directory, or NULL if the directory doesn't exist. Filenames are returned in UTF-8 encoding.
-"""
-function vsireaddir(arg1)
-    aftercare(ccall((:VSIReadDir, libgdal), Ptr{Cstring}, (Cstring,), arg1))
 end
 
 """
@@ -5131,7 +5131,13 @@ end
 """
 function vsigmtime(pnTime, poBrokenTime)
     aftercare(
-        ccall((:VSIGMTime, libgdal), Ptr{tm}, (Ptr{time_t}, Ptr{tm}), pnTime, poBrokenTime),
+        ccall(
+            (:VSIGMTime, libgdal),
+            Ptr{Cvoid},
+            (Ptr{time_t}, Ptr{Cvoid}),
+            pnTime,
+            poBrokenTime,
+        ),
     )
 end
 
@@ -5143,8 +5149,8 @@ function vsilocaltime(pnTime, poBrokenTime)
     aftercare(
         ccall(
             (:VSILocalTime, libgdal),
-            Ptr{tm},
-            (Ptr{time_t}, Ptr{tm}),
+            Ptr{Cvoid},
+            (Ptr{time_t}, Ptr{Cvoid}),
             pnTime,
             poBrokenTime,
         ),
@@ -19609,6 +19615,45 @@ function gdalmultidimtranslate(
     )
 end
 
+"""
+    OGR_L_ResetReading(OGRLayerH) -> void
+
+Reset feature reading to start on the first feature.
+
+### Parameters
+* **hLayer**: handle to the layer on which features are read.
+"""
+function ogr_l_resetreading(arg1)
+    aftercare(ccall((:OGR_L_ResetReading, libgdal), Cvoid, (OGRLayerH,), arg1))
+end
+
+"""
+    OGR_F_Destroy(OGRFeatureH hFeat) -> void
+
+Destroy feature.
+
+### Parameters
+* **hFeat**: handle to the feature to destroy.
+"""
+function ogr_f_destroy(arg1)
+    aftercare(ccall((:OGR_F_Destroy, libgdal), Cvoid, (OGRFeatureH,), arg1))
+end
+
+"""
+    OGR_L_GetNextFeature(OGRLayerH) -> OGRFeatureH
+
+Fetch the next available feature from this layer.
+
+### Parameters
+* **hLayer**: handle to the layer from which feature are read.
+
+### Returns
+a handle to a feature, or NULL if no more features are available.
+"""
+function ogr_l_getnextfeature(arg1)
+    aftercare(ccall((:OGR_L_GetNextFeature, libgdal), OGRFeatureH, (OGRLayerH,), arg1))
+end
+
 "Opaque type for a coordinate transformation object "
 const OGRCoordinateTransformationH = Ptr{Cvoid}
 
@@ -23743,18 +23788,6 @@ function ogr_f_create(arg1)
 end
 
 """
-    OGR_F_Destroy(OGRFeatureH hFeat) -> void
-
-Destroy feature.
-
-### Parameters
-* **hFeat**: handle to the feature to destroy.
-"""
-function ogr_f_destroy(arg1)
-    aftercare(ccall((:OGR_F_Destroy, libgdal), Cvoid, (OGRFeatureH,), arg1))
-end
-
-"""
     OGR_F_GetDefnRef(OGRFeatureH hFeat) -> OGRFeatureDefnH
 
 Fetch feature definition.
@@ -25487,33 +25520,6 @@ function ogr_l_setattributefilter(arg1, arg2)
             arg2,
         ),
     )
-end
-
-"""
-    OGR_L_ResetReading(OGRLayerH) -> void
-
-Reset feature reading to start on the first feature.
-
-### Parameters
-* **hLayer**: handle to the layer on which features are read.
-"""
-function ogr_l_resetreading(arg1)
-    aftercare(ccall((:OGR_L_ResetReading, libgdal), Cvoid, (OGRLayerH,), arg1))
-end
-
-"""
-    OGR_L_GetNextFeature(OGRLayerH) -> OGRFeatureH
-
-Fetch the next available feature from this layer.
-
-### Parameters
-* **hLayer**: handle to the layer from which feature are read.
-
-### Returns
-a handle to a feature, or NULL if no more features are available.
-"""
-function ogr_l_getnextfeature(arg1)
-    aftercare(ccall((:OGR_L_GetNextFeature, libgdal), OGRFeatureH, (OGRLayerH,), arg1))
 end
 
 """
@@ -27760,6 +27766,114 @@ function ogr_stbl_getlaststylename(hStyleTable)
 end
 
 """
+    OGR_GT_Flatten(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the 2D geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+2D geometry type corresponding to the passed geometry type.
+"""
+function ogr_gt_flatten(eType)
+    aftercare(
+        ccall((:OGR_GT_Flatten, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
+    )
+end
+
+"""
+    OGR_GT_HasZ(OGRwkbGeometryType eType) -> int
+
+Return if the geometry type is a 3D geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+TRUE if the geometry type is a 3D geometry type.
+"""
+function ogr_gt_hasz(eType)
+    aftercare(ccall((:OGR_GT_HasZ, libgdal), Cint, (OGRwkbGeometryType,), eType))
+end
+
+"""
+    OGR_GT_SetZ(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the 3D geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+3D geometry type corresponding to the passed geometry type.
+"""
+function ogr_gt_setz(eType)
+    aftercare(
+        ccall((:OGR_GT_SetZ, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
+    )
+end
+
+"""
+    OGR_GT_HasM(OGRwkbGeometryType eType) -> int
+
+Return if the geometry type is a measured type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+TRUE if the geometry type is a measured type.
+"""
+function ogr_gt_hasm(eType)
+    aftercare(ccall((:OGR_GT_HasM, libgdal), Cint, (OGRwkbGeometryType,), eType))
+end
+
+"""
+    OGR_GT_SetM(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the measured geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+measured geometry type corresponding to the passed geometry type.
+"""
+function ogr_gt_setm(eType)
+    aftercare(
+        ccall((:OGR_GT_SetM, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
+    )
+end
+
+"""
+    gdalcheckversion(nVersionMajor, nVersionMinor, pszCallingComponentName)
+
+Return [`TRUE`](@ref) if GDAL library version at runtime matches nVersionMajor.nVersionMinor.
+
+The purpose of this method is to ensure that calling code will run with the GDAL version it is compiled for. It is primarily indented for external plugins.
+
+### Parameters
+* `nVersionMajor`: Major version to be tested against 
+
+* `nVersionMinor`: Minor version to be tested against 
+
+* `pszCallingComponentName`: If not NULL, in case of version mismatch, the method will issue a failure mentioning the name of the calling component.
+"""
+function gdalcheckversion(nVersionMajor, nVersionMinor, pszCallingComponentName)
+    aftercare(
+        ccall(
+            (:GDALCheckVersion, libgdal),
+            Cint,
+            (Cint, Cint, Cstring),
+            nVersionMajor,
+            nVersionMinor,
+            pszCallingComponentName,
+        ),
+    )
+end
+
+"""
     ogrmalloc(arg1)
 
 Doxygen\\_Suppress 
@@ -27891,57 +28005,6 @@ function ogrmergegeometrytypesex(eMain, eExtra, bAllowPromotingToCurves)
 end
 
 """
-    OGR_GT_Flatten(OGRwkbGeometryType eType) -> OGRwkbGeometryType
-
-Returns the 2D geometry type corresponding to the passed geometry type.
-
-### Parameters
-* **eType**: Input geometry type
-
-### Returns
-2D geometry type corresponding to the passed geometry type.
-"""
-function ogr_gt_flatten(eType)
-    aftercare(
-        ccall((:OGR_GT_Flatten, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
-    )
-end
-
-"""
-    OGR_GT_SetZ(OGRwkbGeometryType eType) -> OGRwkbGeometryType
-
-Returns the 3D geometry type corresponding to the passed geometry type.
-
-### Parameters
-* **eType**: Input geometry type
-
-### Returns
-3D geometry type corresponding to the passed geometry type.
-"""
-function ogr_gt_setz(eType)
-    aftercare(
-        ccall((:OGR_GT_SetZ, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
-    )
-end
-
-"""
-    OGR_GT_SetM(OGRwkbGeometryType eType) -> OGRwkbGeometryType
-
-Returns the measured geometry type corresponding to the passed geometry type.
-
-### Parameters
-* **eType**: Input geometry type
-
-### Returns
-measured geometry type corresponding to the passed geometry type.
-"""
-function ogr_gt_setm(eType)
-    aftercare(
-        ccall((:OGR_GT_SetM, libgdal), OGRwkbGeometryType, (OGRwkbGeometryType,), eType),
-    )
-end
-
-"""
     OGR_GT_SetModifier(OGRwkbGeometryType eType,
                        int bHasZ,
                        int bHasM) -> OGRwkbGeometryType
@@ -27967,36 +28030,6 @@ function ogr_gt_setmodifier(eType, bSetZ, bSetM)
             bSetM,
         ),
     )
-end
-
-"""
-    OGR_GT_HasZ(OGRwkbGeometryType eType) -> int
-
-Return if the geometry type is a 3D geometry type.
-
-### Parameters
-* **eType**: Input geometry type
-
-### Returns
-TRUE if the geometry type is a 3D geometry type.
-"""
-function ogr_gt_hasz(eType)
-    aftercare(ccall((:OGR_GT_HasZ, libgdal), Cint, (OGRwkbGeometryType,), eType))
-end
-
-"""
-    OGR_GT_HasM(OGRwkbGeometryType eType) -> int
-
-Return if the geometry type is a measured type.
-
-### Parameters
-* **eType**: Input geometry type
-
-### Returns
-TRUE if the geometry type is a measured type.
-"""
-function ogr_gt_hasm(eType)
-    aftercare(ccall((:OGR_GT_HasM, libgdal), Cint, (OGRwkbGeometryType,), eType))
 end
 
 """
@@ -28334,33 +28367,6 @@ an internal string containing the requested information.
 """
 function gdalversioninfo(arg1)
     aftercare(ccall((:GDALVersionInfo, libgdal), Cstring, (Cstring,), arg1), false)
-end
-
-"""
-    gdalcheckversion(nVersionMajor, nVersionMinor, pszCallingComponentName)
-
-Return [`TRUE`](@ref) if GDAL library version at runtime matches nVersionMajor.nVersionMinor.
-
-The purpose of this method is to ensure that calling code will run with the GDAL version it is compiled for. It is primarily indented for external plugins.
-
-### Parameters
-* `nVersionMajor`: Major version to be tested against 
-
-* `nVersionMinor`: Minor version to be tested against 
-
-* `pszCallingComponentName`: If not NULL, in case of version mismatch, the method will issue a failure mentioning the name of the calling component.
-"""
-function gdalcheckversion(nVersionMajor, nVersionMinor, pszCallingComponentName)
-    aftercare(
-        ccall(
-            (:GDALCheckVersion, libgdal),
-            Cint,
-            (Cint, Cint, Cstring),
-            nVersionMajor,
-            nVersionMinor,
-            pszCallingComponentName,
-        ),
-    )
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,6 @@ using Test
 
 @testset "GDAL" begin
 
-    # drivers
-    # before being able to use any drivers, they must be registered first
-    GDAL.gdalallregister()
-
     version = GDAL.gdalversioninfo("--version")
     n_gdal_driver = GDAL.gdalgetdrivercount()
     n_ogr_driver = GDAL.ogrgetdrivercount()


### PR DESCRIPTION
No functional changes. Some methods are in different order in GDAL.jl.

Previously a custom branch of Clang.jl was needed (see #120). The needed changes have been incorporated in Clang.jl.