### PR TITLE
update to GDAL 3.4.1, require julia 1.6+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-GDAL_jll = "300.200"
+GDAL_jll = "300.400"
 NetworkOptions = "1.2"
-PROJ_jll = "700.200"
-julia = "1.3"
+PROJ_jll = "800.200"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.2.6"
+version = "1.3.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -52,9 +52,9 @@ deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+git-tree-sha1 = "b618084b49e78985ffa8422f32b9838e397b9fc2"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+version = "4.1.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -91,16 +91,16 @@ uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 version = "1.1.0"
 
 [[deps.GDAL_jll]]
-deps = ["Artifacts", "Expat_jll", "GEOS_jll", "JLLWrappers", "LibCURL_jll", "LibSSH2_jll", "Libdl", "Libtiff_jll", "MbedTLS_jll", "OpenJpeg_jll", "PROJ_jll", "Pkg", "SQLite_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "nghttp2_jll"]
-git-tree-sha1 = "439c33eb4dfa74a43a1e96b1d758aeb3cbc33dc3"
+deps = ["Artifacts", "Expat_jll", "GEOS_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "OpenJpeg_jll", "PROJ_jll", "Pkg", "SQLite_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll"]
+git-tree-sha1 = "5272b856ca84a20871858b46a1f3b529e12c38a7"
 uuid = "a7073274-a066-55f0-b90d-d619367d196c"
-version = "300.202.100+0"
+version = "300.400.100+0"
 
 [[deps.GEOS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "45d0ddfd29620ac9b2d1072801e90fb016c5f94c"
+git-tree-sha1 = "07f6426d716d0d110cdede90ebd3bbb2f3be0d8c"
 uuid = "d604d12d-fa86-5845-992e-78dc15976526"
-version = "3.9.0+0"
+version = "3.10.0+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -213,10 +213,10 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
 [[deps.PROJ_jll]]
-deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "LibSSH2_jll", "Libdl", "Libtiff_jll", "MbedTLS_jll", "Pkg", "SQLite_jll", "Zlib_jll", "nghttp2_jll"]
-git-tree-sha1 = "2435e91710d7f97f53ef7a4872bf1f948dc8e5f8"
+deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "Pkg", "SQLite_jll"]
+git-tree-sha1 = "59c43648bf081f732eae1e44b8883f713d2ca1b6"
 uuid = "58948b4f-47e0-5654-a9ad-f609743f8632"
-version = "700.202.100+0"
+version = "800.200.100+0"
 
 [[deps.Parsers]]
 deps = ["Dates"]
@@ -327,10 +327,10 @@ deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[deps.libgeotiff_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libtiff_jll", "PROJ_jll", "Pkg"]
-git-tree-sha1 = "a5cc2e3dd7b1c1e783a61b8ab7de03eebddfed60"
+deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "PROJ_jll", "Pkg"]
+git-tree-sha1 = "91197a1c90fc19ce66e5151c92d41679a52ad4b5"
 uuid = "06c338fa-64ff-565b-ac2f-249532af990e"
-version = "1.6.0+1"
+version = "1.7.0+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]

--- a/gen/combine_gdal_doxygen_xml.py
+++ b/gen/combine_gdal_doxygen_xml.py
@@ -41,10 +41,3 @@ for elem in tree.xpath('/doxygen/compounddef'):
             elem.remove(subelem)
 
 tree.write(outxml)
-
-# remove hidden character that the julia parser won't accept, fixed in GDAL 3.4.1
-# https://github.com/OSGeo/gdal/pull/5043
-with open(outxml) as f:
-    clean_text = f.read().replace('&#8236;', '')
-with open(outxml, "w") as f:
-    f.write(clean_text)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -2,9 +2,6 @@
 library_name = "libgdal"
 output_file_path = "../src/libgdal.jl"
 print_using_CEnum = false
-
-# node with an id in the `printer_blacklist` will be ignored in the printing passes.
-# this is very useful for custom editing.
 output_ignorelist = [
     "VSI_FOPEN64",
     "VSI_FSEEK64",
@@ -23,56 +20,29 @@ output_ignorelist = [
     "OGRUnknownType",
     "VSI_STAT64",
     "VSI_STAT64_T",
+    "GDALExtractRPCInfo",
+    "RPCInfoToMD",
+    "GDALCreateRPCTransformer",
+    "CPL_WARN_DEPRECATED_GDALOpenVerticalShiftGrid",
+    "CPL_WARN_DEPRECATED_GDALApplyVerticalShiftGrid",
 ]
-
 use_deterministic_symbol = true
-
 smart_de_anonymize = true
-
-# if set to "raw", extract and dump raw c comment;
-# if set to "doxygen", parse and format doxygen comment.
-# note: by default, Clang only parses doxygen comment, pass `-fparse-all-comments` to Clang in order to parse non-doxygen comments.
 extract_c_comment_style = "doxygen"
-
-# if set to true, single line comment will be printed as """comment""" instead of """\ncomment\n"""
 fold_single_line_comment = true
-
-# if set to "outofline", documentation of struct fields will be collected at the "Fields" section of the struct
-# if set to "inline", documentation of struct fields will go right above struct definition
 struct_field_comment_style = "outofline"
-
-# if set to "outofline", documentation of enumerators will be collected at the "Enumerators" section of the enum
 enumerator_comment_style = "outofline"
-
-# if set to true, C function prototype will be included in documentation
 show_c_function_prototype = false
 
 [codegen]
 use_julia_bool = true
-
-# set this to true if the C routine always expects a NUL-terminated string.
-# TODO: support filtering
 always_NUL_terminated_string = true
-
-# if true, opaque pointers in function arguments will be translated to `Ptr{Cvoid}`.
 opaque_func_arg_as_PtrCvoid = true
-
-# if true, opaque types are translated to `mutable struct` instead of `Cvoid`.
 opaque_as_mutable_struct = false
 
 [codegen.macro]
-# it‘s highly recommended to set this entry to "basic".
-# if you'd like to skip all of the macros, please set this entry to "disable".
-# if you'd like to translate function-like macros to Julia, please set this entry to "aggressive".
 macro_mode = "basic"
-
-# if true, the generator prints the following message as comments.
-# "# Skipping MacroDefinition: ..."
 add_comment_for_skipped_macro = true
-
-# if true, ignore any macros that is suffixed with "_H" or in the `ignore_header_guards_with_suffixes` list
 ignore_header_guards = true
 ignore_header_guards_with_suffixes = []
-
-# if true, ignore those pure definition macros in the C code
 ignore_pure_definition = true


### PR DESCRIPTION
This updates the GDAL, PROJ and GEOS builds used, and reruns the wrapper to add the new functions, and update docstrings.

This upgrades GDAL from 3.2 straight to 3.4, the news can be read here: https://github.com/OSGeo/gdal/blob/v3.4.1/gdal/NEWS.md

The [GDAL_jll](https://github.com/JuliaBinaryWrappers/GDAL_jll.jl) build, updated in [this PR](https://github.com/JuliaPackaging/Yggdrasil/pull/4193), now includes more platforms such as Apple M1, so this should fix #130. These platforms are only supported on Julia 1.6 and above, and to avoid having to maintain a complex build that targets unsupported Julia versions, I dropped support for Julia 1.5 and older. It is worth noting that it is now built with GCC 6 instead of 4 as well.

The diff in libgdal.jl is quite large, but seems reasonable. I had to filter out a few new constants in generator.toml that were undefined and unused. There are some generated structs like `__JL_Ctag_159` that now have a new number. That is a bit unfortunate, but I don't think anyone uses them right now. If you do, please create an issue and we can look into wrapping them better.

The GEOS_jll bump brings it back in line with the build used in the latest LibGEOS.jl. The PROJ_jll bump, from 7.2 to 8.2, moves it ahead of Proj4.jl, so the latest Proj.jl and GDAL.jl can't be used together, but Pkg will take care of that. Updating Proj4.jl to use PROJ 8 is a bit more work since PROJ 8 removes APIs that are still used in Proj4.jl. The idea was to use this opportunity to rename Proj4.jl to Proj.jl, and shed the old API. I've started working on that in https://github.com/JuliaGeo/Proj4.jl/tree/rename.

This passes tests on ArchGDAL.jl, which are much more extensive, with minor modifications, so that is encouraging.