### PR TITLE
test HDF5 and netCDF driver availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ libraries as added dependencies. This means an Yggdrasil build also needs to be 
 for that library, and added as a dependency. See [issue
 #65](https://github.com/JuliaGeo/GDAL.jl/issues/65) for a discussion on which new drivers
 should be prioritized.
+
+In general GDAL format support will be the same across platforms. HDF5 and netCDF are the
+exception to this rule, since they are only available on [the major
+platforms](https://github.com/JuliaPackaging/Yggdrasil/blob/ce6939a8f751083cd683a6eba6083e2abc47956d/G/GDAL/build_tarballs.jl#L99-L104) for now.

--- a/test/drivers.jl
+++ b/test/drivers.jl
@@ -12,6 +12,8 @@ available_drivers = [
     "MEM",
     "OGCAPI",
     "PCRaster",
+    "HDF5",
+    "netCDF",
     # libcurl raster drivers
     "EEDAI",
     "PLMosaic",


### PR DESCRIPTION
I'd say let's close #134, since we also add a note to the readme that these drivers are not universally available across platforms.

Thanks to @evetion for https://github.com/JuliaPackaging/Yggdrasil/pull/5466.