### PR TITLE
test GDAL 3.7.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 CEnum = "0.2, 0.3, 0.4"
 GDAL_jll = "301.600"
 NetworkOptions = "1.2"
-PROJ_jll = "900"
+PROJ_jll = "900, 901"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This in turn allows GDAL 3.7.2, which requires PROJ_jll v901 (which is PROJ 9.3).

I want to see about downstream failures.