### PR TITLE
Require latest PROJ and GDAL builds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -14,9 +14,9 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 [compat]
 Aqua = "0.8"
 CEnum = "0.2, 0.3, 0.4, 0.5"
-GDAL_jll = "301.900"
+GDAL_jll = "301.902"
 NetworkOptions = "1.2"
-PROJ_jll = "901"
+PROJ_jll = "902"
 Test = "<0.0.1,1"
 julia = "1.6"
 


### PR DESCRIPTION
Since we have an old PROJ_jll dependency, we cannot pull in the latest GDAL_jll without bumping that as well.

Easiest to require both on the latest and tag a new release.
