### PR TITLE
Add workflow_dispatch to CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     tags: '*'
+  workflow_dispatch:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
So I can just trigger CI manually rather than needing a PR like this to test https://github.com/JuliaBinaryWrappers/GDAL_jll.jl/releases/tag/GDAL-v301.902.300%2B0.