### PR TITLE
Wrap and require GDAL 3.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -14,7 +14,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 [compat]
 Aqua = "0.8"
 CEnum = "0.2, 0.3, 0.4, 0.5"
-GDAL_jll = "301.902"
+GDAL_jll = "302.1000"
 NetworkOptions = "1.2"
 PROJ_jll = "902"
 Test = "<0.0.1,1"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,38 +1,36 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.0-rc1"
+julia_version = "1.10.7"
 manifest_format = "2.0"
 project_hash = "6469c52ab64d3d01941621e7123e0a34856c2340"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.2"
+version = "1.1.1"
 
 [[deps.Arrow_jll]]
-deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Lz4_jll", "Pkg", "Thrift_jll", "Zlib_jll", "boost_jll", "snappy_jll"]
-git-tree-sha1 = "d64cb60c0e6a138fbe5ea65bcbeea47813a9a700"
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Lz4_jll", "Thrift_jll", "Zlib_jll", "Zstd_jll", "boost_jll", "brotli_jll", "snappy_jll"]
+git-tree-sha1 = "5b56aaf814eeaaf8dd0f9184436286ae0869ad21"
 uuid = "8ce61222-c28f-5041-a97a-c2198fb817bf"
-version = "10.0.0+1"
+version = "18.1.1+0"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-version = "1.11.0"
 
 [[deps.Blosc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Lz4_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "19b98ee7e3db3b4eff74c5c9c72bf32144e24f10"
+git-tree-sha1 = "ef12cdd1c7fb7e1dfd6fa8fd60d4db6bc61d2f23"
 uuid = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
-version = "1.21.5+0"
+version = "1.21.6+0"
 
 [[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9e2a6b69137e6969bab0152632dcb3bc108c8bdd"
+git-tree-sha1 = "8873e196c2eb87962a2048b3b8e08946535864a1"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.8+1"
+version = "1.0.8+2"
 
 [[deps.CEnum]]
 git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
@@ -53,21 +51,21 @@ version = "0.18.3"
 
 [[deps.Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
-git-tree-sha1 = "0dc9bd89383fd6fffed127e03fc42ed409cc865b"
+git-tree-sha1 = "de2204d98741f57e7ddb9a6a738db74ba8a608cb"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "16.0.6+4"
+version = "15.0.7+10"
 
 [[deps.CommonMark]]
-deps = ["Crayons", "JSON", "PrecompileTools", "URIs"]
-git-tree-sha1 = "532c4185d3c9037c0237546d817858b23cf9e071"
+deps = ["Crayons", "PrecompileTools"]
+git-tree-sha1 = "3faae67b8899797592335832fccf4b3c80bb04fa"
 uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
-version = "0.8.12"
+version = "0.8.15"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "b1c55339b7c6c350ee89f2c1604299660525b248"
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.15.0"
+version = "4.16.0"
 
     [deps.Compat.extensions]
     CompatLinearAlgebraExt = "LinearAlgebra"
@@ -95,7 +93,6 @@ version = "0.18.20"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-version = "1.11.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -104,9 +101,9 @@ version = "1.6.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1c6317308b9dc757616f0b5cb379db10494443a7"
+git-tree-sha1 = "e51db81749b0777b2147fbe7b783ee79045b8e99"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.2+0"
+version = "2.6.4+1"
 
 [[deps.EzXML]]
 deps = ["Printf", "XML2_jll"]
@@ -116,24 +113,18 @@ version = "1.2.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-version = "1.11.0"
 
 [[deps.GDAL_jll]]
-deps = ["Arrow_jll", "Artifacts", "Blosc_jll", "Expat_jll", "GEOS_jll", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "LibPQ_jll", "Libdl", "Libtiff_jll", "Lz4_jll", "NetCDF_jll", "OpenJpeg_jll", "PCRE2_jll", "PROJ_jll", "Qhull_jll", "SQLite_jll", "XML2_jll", "XZ_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "libpng_jll", "libwebp_jll"]
-git-tree-sha1 = "1a607f3fb5c0ef3b5149692e615086f487af1d89"
+deps = ["Arrow_jll", "Artifacts", "Blosc_jll", "Expat_jll", "GEOS_jll", "HDF5_jll", "JLLWrappers", "LERC_jll", "LibCURL_jll", "LibPQ_jll", "Libdl", "Libtiff_jll", "Lz4_jll", "NetCDF_jll", "OpenJpeg_jll", "PCRE2_jll", "PROJ_jll", "Qhull_jll", "SQLite_jll", "XML2_jll", "XZ_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "libpng_jll", "libwebp_jll"]
+git-tree-sha1 = "f3c0245f9afab0f1b6b2af9044d6788df3cb2f06"
 uuid = "a7073274-a066-55f0-b90d-d619367d196c"
-version = "301.901.101+0"
+version = "302.1000.0+0"
 
 [[deps.GEOS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a190d1f793963b93be8fd37cf36d319ac682d2dd"
+git-tree-sha1 = "f561356a09a8f650b622f6697a30f2ad76fc29ce"
 uuid = "d604d12d-fa86-5845-992e-78dc15976526"
-version = "3.12.2+0"
-
-[[deps.GMP_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-version = "6.3.0+0"
+version = "3.13.0+0"
 
 [[deps.Giflib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -146,12 +137,6 @@ git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
 uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
 version = "1.3.1"
 
-[[deps.GnuTLS_jll]]
-deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Nettle_jll", "P11Kit_jll", "Zlib_jll"]
-git-tree-sha1 = "383db7d3f900f4c1f47a8a04115b053c095e48d3"
-uuid = "0951126a-58fd-58f1-b5b3-b08c7c4a876d"
-version = "3.8.4+0"
-
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
 git-tree-sha1 = "82a471768b513dc39e471540fdadc84ff80ff997"
@@ -160,9 +145,9 @@ version = "1.14.3+3"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1d334207121865ac8c1c97eb7f42d0339e4635bf"
+git-tree-sha1 = "50aedf345a709ab75872f80a2779568dc0bb461b"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.11.0+0"
+version = "2.11.2+1"
 
 [[deps.ICU_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -173,31 +158,24 @@ version = "69.1.0+0"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
-
-[[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.6.1"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "c84a835e1a09b289ffcd2271bf2a337bbdda6637"
+git-tree-sha1 = "ef10afc9f4b942bcd75f4c3bc9d9e8d802944c23"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.0.3+0"
+version = "3.1.0+0"
 
 [[deps.JuliaFormatter]]
-deps = ["CSTParser", "CommonMark", "DataStructures", "Glob", "Pkg", "PrecompileTools", "Tokenize"]
-git-tree-sha1 = "b101a476705594c2a8ba106d731497058874bcf4"
+deps = ["CSTParser", "CommonMark", "DataStructures", "Glob", "PrecompileTools", "TOML", "Tokenize"]
+git-tree-sha1 = "59cf7ad64f1b0708a4fa4369879d33bad3239b56"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "1.0.57"
+version = "1.0.62"
 
 [[deps.Kerberos_krb5_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -206,21 +184,20 @@ uuid = "b39eb1a6-c29a-53d7-8c32-632cd16f18da"
 version = "1.19.3+0"
 
 [[deps.LERC_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "bf36f528eec6634efc60d7ec062008f171071434"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "4ec1e8fac04150b570e315baaa68950e368a803d"
 uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
-version = "3.0.0+1"
+version = "4.0.0+1"
 
 [[deps.LZO_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "70c5da094887fd2cae843b8db33920bac4b6f07d"
+git-tree-sha1 = "854a9c268c43b77b0a27f22d7fab8d33cdb3a731"
 uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
-version = "2.10.2+0"
+version = "2.10.2+1"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
-version = "1.11.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -230,17 +207,16 @@ version = "0.6.4"
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
 deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-version = "1.11.0"
 
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.6.4+0"
 
 [[deps.LibPQ_jll]]
 deps = ["Artifacts", "ICU_jll", "JLLWrappers", "Kerberos_krb5_jll", "Libdl", "OpenSSL_jll", "Zstd_jll"]
@@ -255,37 +231,36 @@ version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-version = "1.11.0"
 
 [[deps.Libgcrypt_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll"]
-git-tree-sha1 = "9fd170c4bbfd8b935fdc5f8b7aa33532c991a673"
+git-tree-sha1 = "8be878062e0ffa2c3f67bb58a595375eda5de80b"
 uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
-version = "1.8.11+0"
+version = "1.11.0+0"
 
 [[deps.Libglvnd_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll"]
-git-tree-sha1 = "6f73d1dd803986947b2c750138528a999a6c7733"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "ff3b4b9d35de638936a525ecd36e86a8bb919d11"
 uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
-version = "1.6.0+0"
+version = "1.7.0+0"
 
 [[deps.Libgpg_error_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "fbb1f2bef882392312feb1ede3615ddc1e9b99ed"
+git-tree-sha1 = "a7f43994b47130e4f491c3b2dbe78fe9e2aed2b3"
 uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
-version = "1.49.0+0"
+version = "1.51.0+0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "61dfdba58e585066d8bce214c5a51eaa0539f269"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.17.0+1"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "6355fb9a4d22d867318db186fd09b09b35bd2ed7"
+git-tree-sha1 = "b404131d06f7886402758c9ce2214b636eb4d54a"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.6.0+0"
+version = "4.7.0+0"
 
 [[deps.LittleCMS_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll"]
@@ -295,19 +270,18 @@ version = "2.16.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-version = "1.11.0"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "6c26c5e8a4203d43b5497be3ec5d4e0c3cde240a"
+git-tree-sha1 = "abf88ff67f4fd89839efcae2f4c39cbc4ecd0846"
 uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
-version = "1.9.4+0"
+version = "1.10.0+1"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "4099bb6809ac109bfc17d521dad33763bcf026b7"
+git-tree-sha1 = "7715e65c47ba3941c502bffb7f266a41a7f54423"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.2.1+1"
+version = "4.2.3+0"
 
 [[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
@@ -317,9 +291,9 @@ version = "0.1.11"
 
 [[deps.MPItrampoline_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "8c35d5420193841b2f367e658540e8d9e0601ed0"
+git-tree-sha1 = "70e830dab5d0775183c99fc75e4c24c614ed7142"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.4.0+0"
+version = "5.5.1+0"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -330,26 +304,21 @@ version = "0.5.13"
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-version = "1.11.0"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
+version = "2.28.2+1"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f12a29c4400ba812841c6ace3f4efbb6dbb3ba01"
+git-tree-sha1 = "bc95bf4149bf535c09602e3acdf950d9b4376227"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.4+2"
-
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-version = "1.11.0"
+version = "10.1.4+3"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2023.1.10"
 
 [[deps.NetCDF_jll]]
 deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
@@ -357,21 +326,15 @@ git-tree-sha1 = "4686378c4ae1d1948cfbe46c002a11a4265dcb07"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 version = "400.902.211+1"
 
-[[deps.Nettle_jll]]
-deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "eca63e3847dad608cfa6a3329b95ef674c7160b4"
-uuid = "4c82536e-c426-54e4-b420-14f461c4ed8b"
-version = "3.7.2+0"
-
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[deps.OpenJpeg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libtiff_jll", "LittleCMS_jll", "libpng_jll"]
-git-tree-sha1 = "f4cb457ffac5f5cf695699f82c537073958a6a6c"
+git-tree-sha1 = "0a41c2d8e204a3ad713242139628e01a29556967"
 uuid = "643b3616-a352-519d-856d-80112ee9badc"
-version = "2.5.2+0"
+version = "2.5.3+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
@@ -381,20 +344,14 @@ version = "4.1.6+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
+git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.14+0"
+version = "3.0.15+1"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
+git-tree-sha1 = "12f1439c4f986bb868acda6ea33ebc78e19b95ad"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.3"
-
-[[deps.P11Kit_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "2cd396108e178f3ae8dedbd8e938a18726ab2fbf"
-uuid = "c2071276-7c44-58a7-b746-946036e04d0a"
-version = "0.24.1+0"
+version = "1.7.0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -403,26 +360,14 @@ version = "10.42.0+1"
 
 [[deps.PROJ_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "SQLite_jll"]
-git-tree-sha1 = "84aa844bd56f62282116b413fbefb45e370e54d6"
+git-tree-sha1 = "998e61a32a78e191ac9d63f203fc3020dfa45cdd"
 uuid = "58948b4f-47e0-5654-a9ad-f609743f8632"
-version = "901.300.0+1"
-
-[[deps.Parsers]]
-deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.1"
+version = "902.500.0+0"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
-
-    [deps.Pkg.extensions]
-    REPLExt = "REPL"
-
-    [deps.Pkg.weakdeps]
-    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.10.0"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
@@ -439,7 +384,6 @@ version = "1.4.3"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-version = "1.11.0"
 
 [[deps.Qhull_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -447,10 +391,13 @@ git-tree-sha1 = "be2449911f4d6cfddacdf7efc895eceda3eee5c1"
 uuid = "784f63db-0788-585a-bace-daefebcd302b"
 version = "8.0.1003+0"
 
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -458,9 +405,15 @@ version = "0.7.0"
 
 [[deps.SQLite_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "004fffbe2711abdc7263a980bbb1af9620781dd9"
+git-tree-sha1 = "e84fab7d16107342d7638fbd519151d9a0d80720"
 uuid = "76ed43ae-9a5d-5a62-8c75-30186b810ce8"
-version = "3.45.3+0"
+version = "3.47.2+0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -473,89 +426,82 @@ uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
 [[deps.Thrift_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "boost_jll"]
-git-tree-sha1 = "fd7da49fae680c18aa59f421f0ba468e658a2d7a"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "boost_jll"]
+git-tree-sha1 = "ad25cef5920812da7ade7e9627ffc3cc7ec46ef2"
 uuid = "e0b8ae26-5307-5830-91fd-398402328850"
-version = "0.16.0+0"
+version = "0.21.0+0"
 
 [[deps.Tokenize]]
 git-tree-sha1 = "468b4685af4abe0e9fd4d7bf495a6554a6276e75"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 version = "0.5.29"
 
-[[deps.URIs]]
-git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.5.1"
-
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-version = "1.11.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "d9717ce3518dc68a99e6b96300813760d887a01d"
+git-tree-sha1 = "a2fccc6559132927d4c5dc183e3e01048c6dcbd6"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.1+0"
+version = "2.13.5+0"
 
 [[deps.XSLT_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "XML2_jll", "Zlib_jll"]
-git-tree-sha1 = "a54ee957f4c86b526460a720dbc882fa5edcbefc"
+git-tree-sha1 = "7d1671acbe47ac88e981868a078bd6b4e27c5191"
 uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
-version = "1.1.41+0"
+version = "1.1.42+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "ac88fb95ae6447c8dda6a5503f3bafd496ae8632"
+git-tree-sha1 = "15e637a697345f6743674f1322beefbc5dcd5cfc"
 uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
-version = "5.4.6+0"
+version = "5.6.3+0"
 
 [[deps.Xorg_libX11_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
-git-tree-sha1 = "afead5aba5aa507ad5a3bf01f58f82c8d1403495"
+git-tree-sha1 = "9dafcee1d24c4f024e7edc92603cedba72118283"
 uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
-version = "1.8.6+0"
+version = "1.8.6+1"
 
 [[deps.Xorg_libXau_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "6035850dcc70518ca32f012e46015b9beeda49d8"
+git-tree-sha1 = "2b0e27d52ec9d8d483e2ca0b72b3cb1a8df5c27a"
 uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
-version = "1.0.11+0"
+version = "1.0.11+1"
 
 [[deps.Xorg_libXdmcp_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "34d526d318358a859d7de23da945578e8e8727b7"
+git-tree-sha1 = "02054ee01980c90297412e4c809c8694d7323af3"
 uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
-version = "1.1.4+0"
+version = "1.1.4+1"
 
 [[deps.Xorg_libXext_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
-git-tree-sha1 = "d2d1a5c49fae4ba39983f63de6afcbea47194e85"
+git-tree-sha1 = "d7155fea91a4123ef59f42c4afb5ab3b4ca95058"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
-version = "1.3.6+0"
+version = "1.3.6+1"
 
 [[deps.Xorg_libpthread_stubs_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "8fdda4c692503d44d04a0603d9ac0982054635f9"
+git-tree-sha1 = "fee57a273563e273f0f53275101cd41a8153517a"
 uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
-version = "0.1.1+0"
+version = "0.1.1+1"
 
 [[deps.Xorg_libxcb_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
-git-tree-sha1 = "bcd466676fef0878338c61e655629fa7bbc69d8e"
+git-tree-sha1 = "1a74296303b6524a0472a8cb12d3d87a78eb3612"
 uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
-version = "1.17.0+0"
+version = "1.17.0+1"
 
 [[deps.Xorg_xtrans_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e92a1a012a10506618f10b7047e478403a046c77"
+git-tree-sha1 = "b9ead2d2bdb27330545eb14234a2e300da61232e"
 uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
-version = "1.5.0+0"
+version = "1.5.0+1"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
@@ -564,20 +510,26 @@ version = "1.2.13+1"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e678132f07ddb5bfa46857f0d7620fb9be675d3b"
+git-tree-sha1 = "555d1076590a6cc2fdee2ef1469451f872d8b41b"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.6+0"
+version = "1.5.6+1"
 
 [[deps.boost_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "7a89efe0137720ca82f99e8daa526d23120d0d37"
+git-tree-sha1 = "d9484c66c733c1c84f1d4cfef538d3c7b9d32199"
 uuid = "28df3c45-c428-5900-9ff8-a3135698ca75"
-version = "1.76.0+1"
+version = "1.79.0+1"
+
+[[deps.brotli_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8b866063e234476f32bfe49668ba06f7586d13eb"
+uuid = "4611771a-a7d2-5e23-8d00-b1becdba1aae"
+version = "1.1.0+1"
 
 [[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
-version = "16.0.6+4"
+version = "15.0.7+10"
 
 [[deps.libaec_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -586,16 +538,16 @@ uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
 version = "1.1.2+0"
 
 [[deps.libgeotiff_jll]]
-deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "PROJ_jll"]
-git-tree-sha1 = "c48ca6e850d4190dcb8e0ccd220380c2bc678403"
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LibCURL_jll", "Libdl", "Libtiff_jll", "PROJ_jll", "Zlib_jll"]
+git-tree-sha1 = "f9b0609367e0dc096ebce9a5a777d7dbd6b75bf9"
 uuid = "06c338fa-64ff-565b-ac2f-249532af990e"
-version = "100.701.300+0"
+version = "100.702.300+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "d7015d2e18a5fd9a4f47de711837e980519781a4"
+git-tree-sha1 = "b70c870239dc3d7bc094eb2d6be9b73d27bef280"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.43+1"
+version = "1.6.44+0"
 
 [[deps.libwebp_jll]]
 deps = ["Artifacts", "Giflib_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libglvnd_jll", "Libtiff_jll", "libpng_jll"]
@@ -604,15 +556,15 @@ uuid = "c5f90fcd-3b7e-5836-afba-fc50a0988cb2"
 version = "1.4.0+0"
 
 [[deps.libzip_jll]]
-deps = ["Artifacts", "Bzip2_jll", "GnuTLS_jll", "JLLWrappers", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "3282b7d16ae7ac3e57ec2f3fa8fafb564d8f9f7f"
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "OpenSSL_jll", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "e797fa066eba69f4c0585ffbd81bc780b5118ce2"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
-version = "1.10.1+0"
+version = "1.11.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -620,7 +572,7 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 version = "17.4.0+2"
 
 [[deps.snappy_jll]]
-deps = ["Artifacts", "JLLWrappers", "LZO_jll", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "ab27636e7c8222f14b9318a983fcd89cf130d419"
+deps = ["Artifacts", "JLLWrappers", "LZO_jll", "Libdl", "Lz4_jll", "Zlib_jll"]
+git-tree-sha1 = "a6c92533edec9755b3c1083b028da19a41f92e25"
 uuid = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
-version = "1.1.10+0"
+version = "1.2.1+1"

--- a/src/libgdal.jl
+++ b/src/libgdal.jl
@@ -1742,11 +1742,9 @@ Error category
 end
 
 """
-    CPLCreateFileInZip(void * hZip,
-                       const char * pszFilename,
-                       char ** papszOptions) -> CPLErr
-
-Create a file in a ZIP file.
+    CPLCreateFileInZip(void *,
+                       const char *,
+                       char **) -> CPLErr
 """
 function cplcreatefileinzip(hZip, pszFilename, papszOptions)
     aftercare(
@@ -1762,11 +1760,9 @@ function cplcreatefileinzip(hZip, pszFilename, papszOptions)
 end
 
 """
-    CPLWriteFileInZip(void * hZip,
-                      const void * pBuffer,
-                      int nBufferSize) -> CPLErr
-
-Write in current file inside a ZIP file.
+    CPLWriteFileInZip(void *,
+                      const void *,
+                      int) -> CPLErr
 """
 function cplwritefileinzip(hZip, pBuffer, nBufferSize)
     aftercare(
@@ -1782,9 +1778,7 @@ function cplwritefileinzip(hZip, pBuffer, nBufferSize)
 end
 
 """
-    CPLCloseFileInZip(void * hZip) -> CPLErr
-
-Close current file inside ZIP file.
+    CPLCloseFileInZip(void *) -> CPLErr
 """
 function cplclosefileinzip(hZip)
     aftercare(ccall((:CPLCloseFileInZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
@@ -1849,34 +1843,19 @@ function cpladdfileinzip(
 end
 
 """
-    CPLCloseZip(void * hZip) -> CPLErr
-
-Close ZIP file.
+    CPLCloseZip(void *) -> CPLErr
 """
 function cplclosezip(hZip)
     aftercare(ccall((:CPLCloseZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
 end
 
 """
-    CPLZLibDeflate(const void * ptr,
-                   size_t nBytes,
-                   int nLevel,
-                   void * outptr,
-                   size_t nOutAvailableBytes,
+    CPLZLibDeflate(const void *,
+                   size_t,
+                   int,
+                   void *,
+                   size_t,
                    size_t * pnOutBytes) -> void *
-
-Compress a buffer with ZLib compression.
-
-### Parameters
-* **ptr**: input buffer.
-* **nBytes**: size of input buffer in bytes.
-* **nLevel**: ZLib compression level (-1 for default).
-* **outptr**: output buffer, or NULL to let the function allocate it.
-* **nOutAvailableBytes**: size of output buffer if provided, or ignored.
-* **pnOutBytes**: pointer to a size_t, where to store the size of the output buffer.
-
-### Returns
-the output buffer (to be freed with VSIFree() if not provided) or NULL in case of error.
 """
 function cplzlibdeflate(ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBytes)
     aftercare(
@@ -1895,23 +1874,11 @@ function cplzlibdeflate(ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBy
 end
 
 """
-    CPLZLibInflate(const void * ptr,
-                   size_t nBytes,
-                   void * outptr,
-                   size_t nOutAvailableBytes,
+    CPLZLibInflate(const void *,
+                   size_t,
+                   void *,
+                   size_t,
                    size_t * pnOutBytes) -> void *
-
-Uncompress a buffer compressed with ZLib compression.
-
-### Parameters
-* **ptr**: input buffer.
-* **nBytes**: size of input buffer in bytes.
-* **outptr**: output buffer, or NULL to let the function allocate it.
-* **nOutAvailableBytes**: size of output buffer if provided, or ignored.
-* **pnOutBytes**: pointer to a size_t, where to store the size of the output buffer.
-
-### Returns
-the output buffer (to be freed with VSIFree() if not provided) or NULL in case of error.
 """
 function cplzlibinflate(ptr, nBytes, outptr, nOutAvailableBytes, pnOutBytes)
     aftercare(
@@ -3614,7 +3581,7 @@ end
                 const char * pszAccess,
                 int bSetError) -> VSILFILE *
 
-Open file.
+Open/create file.
 
 ### Parameters
 * **pszFilename**: the file to open. UTF-8 encoded.
@@ -3643,7 +3610,7 @@ end
                  int bSetError,
                  CSLConstList papszOptions) -> VSILFILE *
 
-Open file.
+Open/create file.
 
 ### Parameters
 * **pszFilename**: the file to open. UTF-8 encoded.
@@ -3753,7 +3720,7 @@ Read bytes from file.
 * **fp**: file handle opened with VSIFOpenL().
 
 ### Returns
-number of objects successfully read.
+number of objects successfully read. If that number is less than nCount, VSIFEofL() or VSIFErrorL() can be used to determine the reason for the short read.
 """
 function vsifreadl(arg1, arg2, arg3, arg4)
     aftercare(
@@ -3835,6 +3802,33 @@ function vsifwritel(arg1, arg2, arg3, arg4)
 end
 
 """
+    VSIFClearErrL(VSILFILE * fp) -> void
+
+Reset the error and end-of-file indicators.
+
+### Parameters
+* **fp**: file handle opened with VSIFOpenL().
+"""
+function vsifclearerrl(arg1)
+    aftercare(ccall((:VSIFClearErrL, libgdal), Cvoid, (Ptr{VSILFILE},), arg1))
+end
+
+"""
+    VSIFErrorL(VSILFILE * fp) -> int
+
+Test the error indicator.
+
+### Parameters
+* **fp**: file handle opened with VSIFOpenL().
+
+### Returns
+TRUE if the error indicator is set, else FALSE.
+"""
+function vsiferrorl(arg1)
+    aftercare(ccall((:VSIFErrorL, libgdal), Cint, (Ptr{VSILFILE},), arg1))
+end
+
+"""
     VSIFEofL(VSILFILE * fp) -> int
 
 Test for end of file.
@@ -3843,7 +3837,7 @@ Test for end of file.
 * **fp**: file handle opened with VSIFOpenL().
 
 ### Returns
-TRUE if at EOF else FALSE.
+TRUE if at EOF, else FALSE.
 """
 function vsifeofl(arg1)
     aftercare(ccall((:VSIFEofL, libgdal), Cint, (Ptr{VSILFILE},), arg1))
@@ -4005,7 +3999,7 @@ function vsioverwritefile(fpTarget, pszSourceFilename)
 end
 
 "Type for [`VSIStatL`](@ref)()"
-const VSIStatBufL = stat
+const VSIStatBufL = _stat64
 
 """
     VSIStatL(const char * pszFilename,
@@ -4398,7 +4392,7 @@ end
 Set a path specific option for a given path prefix.
 
 ### Parameters
-* **pszPathPrefix**: a path prefix of a virtual file system handler. Typically of the form "/vsiXXX/bucket". Must NOT be NULL.
+* **pszPathPrefix**: a path prefix of a virtual file system handler. Typically of the form "/vsiXXX/bucket". Must NOT be NULL. Should not include trailing slashes.
 * **pszKey**: Option name. Must NOT be NULL.
 * **pszValue**: Option value. May be NULL to erase it.
 """
@@ -4958,6 +4952,59 @@ function vsicopyfile(
 end
 
 """
+    VSICopyFileRestartable(const char * pszSource,
+                           const char * pszTarget,
+                           const char * pszInputPayload,
+                           char ** ppszOutputPayload,
+                           const char *const * papszOptions,
+                           GDALProgressFunc pProgressFunc,
+                           void * pProgressData) -> int
+
+Copy a source file into a target file in a way that can (potentially) be restarted.
+
+### Parameters
+* **pszSource**: Source filename. UTF-8 encoded. Must not be NULL
+* **pszTarget**: Target filename. UTF-8 encoded. Must not be NULL
+* **pszInputPayload**: NULL at the first invocation. When doing a retry, should be the content of *ppszOutputPayload from a previous invocation.
+* **ppszOutputPayload**: Pointer to an output string that will be set to a value that can be provided as pszInputPayload for a next call to VSICopyFileRestartable(). ppszOutputPayload must not be NULL. The string set in *ppszOutputPayload, if not NULL, is JSON-encoded, and can be re-used in another process instance. It must be freed with VSIFree() when no longer needed.
+* **papszOptions**: Null terminated list of options, or NULL. Currently accepted options are: 
+
+NUM_THREADS=integer or ALL_CPUS. Number of threads to use for parallel file copying. Only use for when /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ is in source or target. The default is 10.  
+
+
+CHUNK_SIZE=integer. Maximum size of chunk (in bytes) to use to split large objects. For upload to /vsis3/, this chunk size must be set at least to 5 MB. The default is 50 MB.
+* **pProgressFunc**: Progress callback, or NULL.
+* **pProgressData**: User data of progress callback, or NULL.
+
+### Returns
+0 on success, -1 on (non-restartable) failure, 1 if VSICopyFileRestartable() can be called again in a restartable way
+"""
+function vsicopyfilerestartable(
+    pszSource,
+    pszTarget,
+    pszInputPayload,
+    ppszOutputPayload,
+    papszOptions,
+    pProgressFunc,
+    pProgressData,
+)
+    aftercare(
+        ccall(
+            (:VSICopyFileRestartable, libgdal),
+            Cint,
+            (Cstring, Cstring, Cstring, Ptr{Cstring}, Ptr{Cstring}, GDALProgressFunc, Any),
+            pszSource,
+            pszTarget,
+            pszInputPayload,
+            ppszOutputPayload,
+            papszOptions,
+            pProgressFunc,
+            pProgressData,
+        ),
+    )
+end
+
+"""
     VSISync(const char * pszSource,
             const char * pszTarget,
             const char *const * papszOptions,
@@ -5026,9 +5073,212 @@ function vsisync(
 end
 
 """
+    VSIMultipartUploadGetCapabilities(const char * pszFilename,
+                                      int * pbNonSequentialUploadSupported,
+                                      int * pbParallelUploadSupported,
+                                      int * pbAbortSupported,
+                                      size_t * pnMinPartSize,
+                                      size_t * pnMaxPartSize,
+                                      int * pnMaxPartCount) -> int
+
+Return capabilities for multiple part file upload.
+
+### Parameters
+* **pszFilename**: Filename, or virtual file system prefix, onto which capabilities should apply.
+* **pbNonSequentialUploadSupported**: If not null, the pointed value is set if parts can be uploaded in a non-sequential way.
+* **pbParallelUploadSupported**: If not null, the pointed value is set if parts can be uploaded in a parallel way. (implies *pbNonSequentialUploadSupported = true)
+* **pbAbortSupported**: If not null, the pointed value is set if VSIMultipartUploadAbort() is implemented.
+* **pnMinPartSize**: If not null, the pointed value is set to the minimum size of parts (but the last one), in MiB.
+* **pnMaxPartSize**: If not null, the pointed value is set to the maximum size of parts, in MiB.
+* **pnMaxPartCount**: If not null, the pointed value is set to the maximum number of parts that can be uploaded.
+
+### Returns
+TRUE in case of success, FALSE otherwise.
+"""
+function vsimultipartuploadgetcapabilities(
+    pszFilename,
+    pbNonSequentialUploadSupported,
+    pbParallelUploadSupported,
+    pbAbortSupported,
+    pnMinPartSize,
+    pnMaxPartSize,
+    pnMaxPartCount,
+)
+    aftercare(
+        ccall(
+            (:VSIMultipartUploadGetCapabilities, libgdal),
+            Cint,
+            (
+                Cstring,
+                Ptr{Cint},
+                Ptr{Cint},
+                Ptr{Cint},
+                Ptr{Csize_t},
+                Ptr{Csize_t},
+                Ptr{Cint},
+            ),
+            pszFilename,
+            pbNonSequentialUploadSupported,
+            pbParallelUploadSupported,
+            pbAbortSupported,
+            pnMinPartSize,
+            pnMaxPartSize,
+            pnMaxPartCount,
+        ),
+    )
+end
+
+"""
+    VSIMultipartUploadStart(const char * pszFilename,
+                            CSLConstList papszOptions) -> char *
+
+Initiates the upload a (big) file in a piece-wise way.
+
+### Parameters
+* **pszFilename**: Filename to create
+* **papszOptions**: NULL or null-terminated list of options.
+
+### Returns
+an upload ID to pass to other VSIMultipartUploadXXXXX() functions, and to free with CPLFree() once done, or nullptr in case of error.
+"""
+function vsimultipartuploadstart(pszFilename, papszOptions)
+    aftercare(
+        ccall(
+            (:VSIMultipartUploadStart, libgdal),
+            Cstring,
+            (Cstring, CSLConstList),
+            pszFilename,
+            papszOptions,
+        ),
+        false,
+    )
+end
+
+"""
+    VSIMultipartUploadAddPart(const char * pszFilename,
+                              const char * pszUploadId,
+                              int nPartNumber,
+                              vsi_l_offset nFileOffset,
+                              const void * pData,
+                              size_t nDataLength,
+                              CSLConstList papszOptions) -> char *
+
+Uploads a new part to a multi-part uploaded file.
+
+### Parameters
+* **pszFilename**: Filename to which to append the new part. Should be the same as the one used for VSIMultipartUploadStart()
+* **pszUploadId**: Value returned by VSIMultipartUploadStart()
+* **nPartNumber**: Part number, starting at 1.
+* **nFileOffset**: Offset within the file at which (starts at 0) the passed data starts.
+* **pData**: Pointer to an array of nDataLength bytes.
+* **nDataLength**: Size in bytes of pData.
+* **papszOptions**: Unused. Should be nullptr.
+
+### Returns
+a part identifier that must be passed into the apszPartIds[] array of VSIMultipartUploadEnd(), and to free with CPLFree() once done, or nullptr in case of error.
+"""
+function vsimultipartuploadaddpart(
+    pszFilename,
+    pszUploadId,
+    nPartNumber,
+    nFileOffset,
+    pData,
+    nDataLength,
+    papszOptions,
+)
+    aftercare(
+        ccall(
+            (:VSIMultipartUploadAddPart, libgdal),
+            Cstring,
+            (Cstring, Cstring, Cint, vsi_l_offset, Ptr{Cvoid}, Csize_t, CSLConstList),
+            pszFilename,
+            pszUploadId,
+            nPartNumber,
+            nFileOffset,
+            pData,
+            nDataLength,
+            papszOptions,
+        ),
+        false,
+    )
+end
+
+"""
+    VSIMultipartUploadEnd(const char * pszFilename,
+                          const char * pszUploadId,
+                          size_t nPartIdsCount,
+                          const char *const * apszPartIds,
+                          vsi_l_offset nTotalSize,
+                          CSLConstList papszOptions) -> int
+
+Completes a multi-part file upload.
+
+### Parameters
+* **pszFilename**: Filename for which multipart upload should be completed. Should be the same as the one used for VSIMultipartUploadStart()
+* **pszUploadId**: Value returned by VSIMultipartUploadStart()
+* **nPartIdsCount**: Number of parts, andsize of apszPartIds
+* **apszPartIds**: Array of part identifiers (as returned by VSIMultipartUploadAddPart()), that must be ordered in the sequential order of parts, and of size nPartIdsCount.
+* **nTotalSize**: Total size of the file in bytes (must be equal to the sum of nDataLength passed to VSIMultipartUploadAddPart())
+* **papszOptions**: Unused. Should be nullptr.
+
+### Returns
+TRUE in case of success, FALSE in case of failure.
+"""
+function vsimultipartuploadend(
+    pszFilename,
+    pszUploadId,
+    nPartIdsCount,
+    apszPartIds,
+    nTotalSize,
+    papszOptions,
+)
+    aftercare(
+        ccall(
+            (:VSIMultipartUploadEnd, libgdal),
+            Cint,
+            (Cstring, Cstring, Csize_t, Ptr{Cstring}, vsi_l_offset, CSLConstList),
+            pszFilename,
+            pszUploadId,
+            nPartIdsCount,
+            apszPartIds,
+            nTotalSize,
+            papszOptions,
+        ),
+    )
+end
+
+"""
+    VSIMultipartUploadAbort(const char * pszFilename,
+                            const char * pszUploadId,
+                            CSLConstList papszOptions) -> int
+
+Aborts a multi-part file upload.
+
+### Parameters
+* **pszFilename**: Filename for which multipart upload should be completed. Should be the same as the one used for VSIMultipartUploadStart()
+* **pszUploadId**: Value returned by VSIMultipartUploadStart()
+* **papszOptions**: Unused. Should be nullptr.
+
+### Returns
+TRUE in case of success, FALSE in case of failure.
+"""
+function vsimultipartuploadabort(pszFilename, pszUploadId, papszOptions)
+    aftercare(
+        ccall(
+            (:VSIMultipartUploadAbort, libgdal),
+            Cint,
+            (Cstring, Cstring, CSLConstList),
+            pszFilename,
+            pszUploadId,
+            papszOptions,
+        ),
+    )
+end
+
+"""
     VSIAbortPendingUploads(const char * pszFilename) -> int
 
-Abort ongoing multi-part uploads.
+Abort all ongoing multi-part uploads.
 
 ### Parameters
 * **pszFilename**: filename or prefix of a directory into which multipart uploads must be aborted. This can be the root directory of a bucket. UTF-8 encoded.
@@ -5472,6 +5722,24 @@ function vsigetmemfilebuffer(pszFilename, pnDataLength, bUnlinkAndSeize)
     )
 end
 
+"""
+    VSIMemGenerateHiddenFilename(const char * pszFilename) -> const char *
+
+Generates a unique filename that can be used with the /vsimem/ virtual file system.
+
+### Parameters
+* **pszFilename**: the filename to be appended at the end of the returned filename. If not specified, defaults to "unnamed".
+
+### Returns
+pointer to a short-lived string (rotating buffer of strings in thread-local storage). It is recommended to use CPLStrdup() or std::string() immediately on it.
+"""
+function vsimemgeneratehiddenfilename(pszFilename)
+    aftercare(
+        ccall((:VSIMemGenerateHiddenFilename, libgdal), Cstring, (Cstring,), pszFilename),
+        false,
+    )
+end
+
 "Callback used by [`VSIStdoutSetRedirection`](@ref)()"
 const VSIWriteFunction = Ptr{Cvoid}
 
@@ -5637,6 +5905,20 @@ Offsets may be given in a non-increasing order, and may potentially overlap.
 const VSIFilesystemPluginAdviseReadCallback = Ptr{Cvoid}
 
 """
+Has a read error (non end-of-file related) has occurred?
+
+\\since GDAL 3.10
+"""
+const VSIFilesystemPluginErrorCallback = Ptr{Cvoid}
+
+"""
+Clear error and end-of-file flags.
+
+\\since GDAL 3.10
+"""
+const VSIFilesystemPluginClearErrCallback = Ptr{Cvoid}
+
+"""
     VSIFilesystemPluginCallbacksStruct
 
 struct containing callbacks to used by the handler. (rw), (r), (w) or () at the end indicate whether the given callback is mandatory for reading and or writing handlers. A (?) indicates that the callback might be mandatory for certain drivers only.
@@ -5667,6 +5949,8 @@ struct containing callbacks to used by the handler. (rw), (r), (w) or () at the 
 | nCacheSize           | max mem to use per file when buffering                                                 |
 | sibling\\_files      | list related files                                                                     |
 | advise\\_read        | AdviseRead()                                                                           |
+| error                | has read error occurred (r)                                                            |
+| clear\\_err          | clear error flags(r)                                                                   |
 """
 struct VSIFilesystemPluginCallbacksStruct
     pUserData::Ptr{Cvoid}
@@ -5691,6 +5975,8 @@ struct VSIFilesystemPluginCallbacksStruct
     nCacheSize::Csize_t
     sibling_files::VSIFilesystemPluginSiblingFilesCallback
     advise_read::VSIFilesystemPluginAdviseReadCallback
+    error::VSIFilesystemPluginErrorCallback
+    clear_err::VSIFilesystemPluginClearErrCallback
 end
 
 """
@@ -6067,18 +6353,18 @@ end
 
 """
     GDALDataTypeUnionWithValue(GDALDataType eDT,
-                               double dValue,
+                               double dfValue,
                                int bComplex) -> GDALDataType
 
 Union a data type with the one found for a value.
 
 ### Parameters
 * **eDT**: the first data type
-* **dValue**: the value for which to find a data type and union with eDT
+* **dfValue**: the value for which to find a data type and union with eDT
 * **bComplex**: if the value is complex
 
 ### Returns
-a data type able to express eDT and dValue.
+a data type able to express eDT and dfValue.
 """
 function gdaldatatypeunionwithvalue(eDT, dValue, bComplex)
     aftercare(
@@ -6177,6 +6463,25 @@ function gdaladjustvaluetodatatype(eDT, dfValue, pbClamped, pbRounded)
             pbClamped,
             pbRounded,
         ),
+    )
+end
+
+"""
+    GDALIsValueExactAs(double dfValue,
+                       GDALDataType eDT) -> bool
+
+Check whether the provided value can be exactly represented in a data type.
+
+### Parameters
+* **dfValue**: value to check.
+* **eDT**: target data type.
+
+### Returns
+true if the provided value can be exactly represented in the data type.
+"""
+function gdalisvalueexactas(dfValue, eDT)
+    aftercare(
+        ccall((:GDALIsValueExactAs, libgdal), Bool, (Cdouble, GDALDataType), dfValue, eDT),
     )
 end
 
@@ -6383,26 +6688,55 @@ end
 
 Types of color interpretation for raster bands.
 
-| Enumerator           | Note                                                          |
-| :------------------- | :------------------------------------------------------------ |
-| GCI\\_Undefined      | Undefined                                                     |
-| GCI\\_GrayIndex      | Greyscale                                                     |
-| GCI\\_PaletteIndex   | Paletted (see associated color table)                         |
-| GCI\\_RedBand        | Red band of RGBA image                                        |
-| GCI\\_GreenBand      | Green band of RGBA image                                      |
-| GCI\\_BlueBand       | Blue band of RGBA image                                       |
-| GCI\\_AlphaBand      | Alpha (0=transparent, 255=opaque)                             |
-| GCI\\_HueBand        | Hue band of HLS image                                         |
-| GCI\\_SaturationBand | Saturation band of HLS image                                  |
-| GCI\\_LightnessBand  | Lightness band of HLS image                                   |
-| GCI\\_CyanBand       | Cyan band of CMYK image                                       |
-| GCI\\_MagentaBand    | Magenta band of CMYK image                                    |
-| GCI\\_YellowBand     | Yellow band of CMYK image                                     |
-| GCI\\_BlackBand      | Black band of CMYK image                                      |
-| GCI\\_YCbCr\\_YBand  | Y Luminance                                                   |
-| GCI\\_YCbCr\\_CbBand | Cb Chroma                                                     |
-| GCI\\_YCbCr\\_CrBand | Cr Chroma                                                     |
-| GCI\\_Max            | Max current value (equals to GCI\\_YCbCr\\_CrBand currently)  |
+For spectral bands, the wavelength ranges are indicative only, and may vary depending on sensors. The CENTRAL\\_WAVELENGTH\\_UM and FWHM\\_UM metadata items in the IMAGERY metadata domain of the raster band, when present, will give more accurate characteristics.
+
+Values belonging to the IR domain are in the [[`GCI_IR_Start`](@ref), [`GCI_IR_End`](@ref)] range. Values belonging to the SAR domain are in the [[`GCI_SAR_Start`](@ref), [`GCI_SAR_End`](@ref)] range.
+
+Values between GCI\\_PanBand to GCI\\_SAR\\_Reserved\\_2 have been added in GDAL 3.10.
+
+| Enumerator               | Note                                                                 |
+| :----------------------- | :------------------------------------------------------------------- |
+| GCI\\_Undefined          | Undefined                                                            |
+| GCI\\_GrayIndex          | Greyscale                                                            |
+| GCI\\_PaletteIndex       | Paletted (see associated color table)                                |
+| GCI\\_RedBand            | Red band of RGBA image, or red spectral band [0.62 - 0.69 um]        |
+| GCI\\_GreenBand          | Green band of RGBA image, or green spectral band [0.51 - 0.60 um]    |
+| GCI\\_BlueBand           | Blue band of RGBA image, or blue spectral band [0.45 - 0.53 um]      |
+| GCI\\_AlphaBand          | Alpha (0=transparent, 255=opaque)                                    |
+| GCI\\_HueBand            | Hue band of HLS image                                                |
+| GCI\\_SaturationBand     | Saturation band of HLS image                                         |
+| GCI\\_LightnessBand      | Lightness band of HLS image                                          |
+| GCI\\_CyanBand           | Cyan band of CMYK image                                              |
+| GCI\\_MagentaBand        | Magenta band of CMYK image                                           |
+| GCI\\_YellowBand         | Yellow band of CMYK image, or yellow spectral band [0.58 - 0.62 um]  |
+| GCI\\_BlackBand          | Black band of CMYK image                                             |
+| GCI\\_YCbCr\\_YBand      | Y Luminance                                                          |
+| GCI\\_YCbCr\\_CbBand     | Cb Chroma                                                            |
+| GCI\\_YCbCr\\_CrBand     | Cr Chroma                                                            |
+| GCI\\_PanBand            | Panchromatic band [0.40 - 1.00 um]                                   |
+| GCI\\_CoastalBand        | Coastal band [0.40 - 0.45 um]                                        |
+| GCI\\_RedEdgeBand        | Red-edge band [0.69 - 0.79 um]                                       |
+| GCI\\_NIRBand            | Near-InfraRed (NIR) band [0.75 - 1.40 um]                            |
+| GCI\\_SWIRBand           | Short-Wavelength InfraRed (SWIR) band [1.40 - 3.00 um]               |
+| GCI\\_MWIRBand           | Mid-Wavelength InfraRed (MWIR) band [3.00 - 8.00 um]                 |
+| GCI\\_LWIRBand           | Long-Wavelength InfraRed (LWIR) band [8.00 - 15 um]                  |
+| GCI\\_TIRBand            | Thermal InfraRed (TIR) band (MWIR or LWIR) [3 - 15 um]               |
+| GCI\\_OtherIRBand        | Other infrared band [0.75 - 1000 um]                                 |
+| GCI\\_IR\\_Reserved\\_1  | Reserved value. Do not set it !                                      |
+| GCI\\_IR\\_Reserved\\_2  |                                                                      |
+| GCI\\_IR\\_Reserved\\_3  |                                                                      |
+| GCI\\_IR\\_Reserved\\_4  |                                                                      |
+| GCI\\_SAR\\_Ka\\_Band    | Synthetic Aperture Radar (SAR) Ka band [0.8 - 1.1 cm / 27 - 40 GHz]  |
+| GCI\\_SAR\\_K\\_Band     | Synthetic Aperture Radar (SAR) K band [1.1 - 1.7 cm / 18 - 27 GHz]   |
+| GCI\\_SAR\\_Ku\\_Band    | Synthetic Aperture Radar (SAR) Ku band [1.7 - 2.4 cm / 12 - 18 GHz]  |
+| GCI\\_SAR\\_X\\_Band     | Synthetic Aperture Radar (SAR) X band [2.4 - 3.8 cm / 8 - 12 GHz]    |
+| GCI\\_SAR\\_C\\_Band     | Synthetic Aperture Radar (SAR) C band [3.8 - 7.5 cm / 4 - 8 GHz]     |
+| GCI\\_SAR\\_S\\_Band     | Synthetic Aperture Radar (SAR) S band [7.5 - 15 cm / 2 - 4 GHz]      |
+| GCI\\_SAR\\_L\\_Band     | Synthetic Aperture Radar (SAR) L band [15 - 30 cm / 1 - 2 GHz]       |
+| GCI\\_SAR\\_P\\_Band     | Synthetic Aperture Radar (SAR) P band [30 - 100 cm / 0.3 - 1 GHz]    |
+| GCI\\_SAR\\_Reserved\\_1 | Reserved value. Do not set it !                                      |
+| GCI\\_SAR\\_Reserved\\_2 |                                                                      |
+| GCI\\_Max                | Max current value (equals to GCI\\_SAR\\_Reserved\\_2 currently)     |
 """
 @cenum GDALColorInterp::UInt32 begin
     GCI_Undefined = 0
@@ -6422,7 +6756,30 @@ Types of color interpretation for raster bands.
     GCI_YCbCr_YBand = 14
     GCI_YCbCr_CbBand = 15
     GCI_YCbCr_CrBand = 16
-    GCI_Max = 16
+    GCI_PanBand = 17
+    GCI_CoastalBand = 18
+    GCI_RedEdgeBand = 19
+    GCI_NIRBand = 20
+    GCI_SWIRBand = 21
+    GCI_MWIRBand = 22
+    GCI_LWIRBand = 23
+    GCI_TIRBand = 24
+    GCI_OtherIRBand = 25
+    GCI_IR_Reserved_1 = 26
+    GCI_IR_Reserved_2 = 27
+    GCI_IR_Reserved_3 = 28
+    GCI_IR_Reserved_4 = 29
+    GCI_SAR_Ka_Band = 30
+    GCI_SAR_K_Band = 31
+    GCI_SAR_Ku_Band = 32
+    GCI_SAR_X_Band = 33
+    GCI_SAR_C_Band = 34
+    GCI_SAR_S_Band = 35
+    GCI_SAR_L_Band = 36
+    GCI_SAR_P_Band = 37
+    GCI_SAR_Reserved_1 = 38
+    GCI_SAR_Reserved_2 = 39
+    GCI_Max = 39
 end
 
 """
@@ -6824,13 +7181,16 @@ GDAL_OF_VECTOR for vector drivers,
 GDAL_OF_GNM for Geographic Network Model drivers. 
 
 
-GDAL_OF_RASTER and GDAL_OF_MULTIDIM_RASTER are generally mutually exclusive. If none of the value is specified, GDAL_OF_RASTER | GDAL_OF_VECTOR | GDAL_OF_GNM is implied. 
+GDAL_OF_RASTER and GDAL_OF_MULTIDIM_RASTER are generally mutually exclusive. If none of the value is specified, GDAL_OF_RASTER | GDAL_OF_VECTOR | GDAL_OF_GNM is implied.  
 
 
-Access mode: GDAL_OF_READONLY (exclusive)or GDAL_OF_UPDATE. 
+Access mode: GDAL_OF_READONLY (exclusive)or GDAL_OF_UPDATE.  
 
 
-Shared mode: GDAL_OF_SHARED. If set, it allows the sharing of GDALDataset handles for a dataset with other callers that have set GDAL_OF_SHARED. In particular, GDALOpenEx() will first consult its list of currently open and shared GDALDataset's, and if the GetDescription() name for one exactly matches the pszFilename passed to GDALOpenEx() it will be referenced and returned, if GDALOpenEx() is called from the same thread. 
+Shared mode: GDAL_OF_SHARED. If set, it allows the sharing of GDALDataset handles for a dataset with other callers that have set GDAL_OF_SHARED. In particular, GDALOpenEx() will first consult its list of currently open and shared GDALDataset's, and if the GetDescription() name for one exactly matches the pszFilename passed to GDALOpenEx() it will be referenced and returned, if GDALOpenEx() is called from the same thread.  
+
+
+Thread safe mode: GDAL_OF_THREAD_SAFE (added in 3.10). This must be use in combination with GDAL_OF_RASTER, and is mutually exclusive with GDAL_OF_UPDATE, GDAL_OF_VECTOR, GDAL_OF_MULTIDIM_RASTER or GDAL_OF_GNM.  
 
 
 Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file will lead to an error message to be reported.
@@ -6948,6 +7308,8 @@ end
 
 """
     GDALDestroy(void) -> void
+
+Finalize GDAL/OGR library.
 """
 function gdaldestroy()
     aftercare(ccall((:GDALDestroy, libgdal), Cvoid, ()))
@@ -7531,6 +7893,57 @@ function gdalgetrasterband(arg1, arg2)
 end
 
 """
+    GDALDatasetIsThreadSafe(GDALDatasetH hDS,
+                            int nScopeFlags,
+                            CSLConstList papszOptions) -> bool
+
+Return whether this dataset, and its related objects (typically raster bands), can be called for the intended scope.
+
+### Parameters
+* **hDS**: Source dataset
+* **nScopeFlags**: Intended scope of use. Only GDAL_OF_RASTER is supported currently.
+* **papszOptions**: Options. None currently.
+"""
+function gdaldatasetisthreadsafe(arg1, nScopeFlags, papszOptions)
+    aftercare(
+        ccall(
+            (:GDALDatasetIsThreadSafe, libgdal),
+            Bool,
+            (GDALDatasetH, Cint, CSLConstList),
+            arg1,
+            nScopeFlags,
+            papszOptions,
+        ),
+    )
+end
+
+"""
+    GDALGetThreadSafeDataset(std::unique_ptr< GDALDataset > poDS,
+                             int nScopeFlags) -> std::unique_ptr< GDALDataset >
+
+Return a thread-safe dataset.
+
+### Parameters
+* **poDS**: Source dataset
+* **nScopeFlags**: Intended scope of use. Only GDAL_OF_RASTER is supported currently.
+
+### Returns
+a new thread-safe dataset, or nullptr in case of error.
+"""
+function gdalgetthreadsafedataset(arg1, nScopeFlags, papszOptions)
+    aftercare(
+        ccall(
+            (:GDALGetThreadSafeDataset, libgdal),
+            GDALDatasetH,
+            (GDALDatasetH, Cint, CSLConstList),
+            arg1,
+            nScopeFlags,
+            papszOptions,
+        ),
+    )
+end
+
+"""
     GDALAddBand(GDALDatasetH hDataset,
                 GDALDataType eType,
                 CSLConstList papszOptions) -> CPLErr
@@ -7680,7 +8093,7 @@ end
                         int nBufYSize,
                         GDALDataType eBufType,
                         int nBandCount,
-                        int * panBandMap,
+                        const int * panBandMap,
                         int nPixelSpace,
                         int nLineSpace,
                         int nBandSpace) -> CPLErr
@@ -7756,7 +8169,7 @@ end
                           int nBufYSize,
                           GDALDataType eBufType,
                           int nBandCount,
-                          int * panBandMap,
+                          const int * panBandMap,
                           GSpacing nPixelSpace,
                           GSpacing nLineSpace,
                           GSpacing nBandSpace,
@@ -11064,6 +11477,46 @@ function gdaladdderivedbandpixelfuncwithargs(pszName, pfnPixelFunc, pszMetadata)
             pszName,
             pfnPixelFunc,
             pszMetadata,
+        ),
+    )
+end
+
+"""
+    GDALRasterInterpolateAtPoint(GDALRasterBandH hBand,
+                                 double dfPixel,
+                                 double dfLine,
+                                 GDALRIOResampleAlg eInterpolation,
+                                 double * pdfRealValue,
+                                 double * pdfImagValue) -> CPLErr
+
+Interpolates the value between pixels using a resampling algorithm.
+"""
+function gdalrasterinterpolateatpoint(
+    hBand,
+    dfPixel,
+    dfLine,
+    eInterpolation,
+    pdfRealValue,
+    pdfImagValue,
+)
+    aftercare(
+        ccall(
+            (:GDALRasterInterpolateAtPoint, libgdal),
+            CPLErr,
+            (
+                GDALRasterBandH,
+                Cdouble,
+                Cdouble,
+                GDALRIOResampleAlg,
+                Ptr{Cdouble},
+                Ptr{Cdouble},
+            ),
+            hBand,
+            dfPixel,
+            dfLine,
+            eInterpolation,
+            pdfRealValue,
+            pdfImagValue,
         ),
     )
 end
@@ -16182,6 +16635,42 @@ function gdalmdarraygetcoordinatevariables(hArray, pnCount)
 end
 
 """
+    GDALMDArrayGetMeshGrid(const GDALMDArrayH * pahInputArrays,
+                           size_t nCountInputArrays,
+                           size_t * pnCountOutputArrays,
+                           CSLConstList papszOptions) -> GDALMDArrayH *
+
+Return a list of multidimensional arrays from a list of one-dimensional arrays.
+
+### Parameters
+* **pahInputArrays**: Input arrays
+* **nCountInputArrays**: Number of input arrays
+* **pnCountOutputArrays**: Pointer to the number of values returned. Must NOT be NULL.
+* **papszOptions**: NULL, or NULL terminated list of options.
+
+### Returns
+an array of *pnCountOutputArrays arrays.
+"""
+function gdalmdarraygetmeshgrid(
+    pahInputArrays,
+    nCountInputArrays,
+    pnCountOutputArrays,
+    papszOptions,
+)
+    aftercare(
+        ccall(
+            (:GDALMDArrayGetMeshGrid, libgdal),
+            Ptr{GDALMDArrayH},
+            (Ptr{GDALMDArrayH}, Csize_t, Ptr{Csize_t}, CSLConstList),
+            pahInputArrays,
+            nCountInputArrays,
+            pnCountOutputArrays,
+            papszOptions,
+        ),
+    )
+end
+
+"""
     GDALReleaseArrays(GDALMDArrayH * arrays,
                       size_t nCount) -> void
 
@@ -16477,6 +16966,18 @@ function gdalattributereadasint(hAttr)
 end
 
 """
+    GDALAttributeReadAsInt64(GDALAttributeH hAttr) -> int64_t
+
+Return the value of an attribute as a int64_t.
+
+### Returns
+an int64_t, or INT64_MIN in case of error.
+"""
+function gdalattributereadasint64(hAttr)
+    aftercare(ccall((:GDALAttributeReadAsInt64, libgdal), Int64, (GDALAttributeH,), hAttr))
+end
+
+"""
     GDALAttributeReadAsDouble(GDALAttributeH hAttr) -> double
 
 Return the value of an attribute as a double.
@@ -16524,6 +17025,31 @@ function gdalattributereadasintarray(hAttr, pnCount)
         ccall(
             (:GDALAttributeReadAsIntArray, libgdal),
             Ptr{Cint},
+            (GDALAttributeH, Ptr{Csize_t}),
+            hAttr,
+            pnCount,
+        ),
+    )
+end
+
+"""
+    GDALAttributeReadAsInt64Array(GDALAttributeH hAttr,
+                                  size_t * pnCount) -> int64_t *
+
+Return the value of an attribute as an array of int64_t.
+
+### Parameters
+* **hAttr**: Attribute
+* **pnCount**: Pointer to the number of values returned. Must NOT be NULL.
+
+### Returns
+array to be freed with CPLFree(), or nullptr.
+"""
+function gdalattributereadasint64array(hAttr, pnCount)
+    aftercare(
+        ccall(
+            (:GDALAttributeReadAsInt64Array, libgdal),
+            Ptr{Int64},
             (GDALAttributeH, Ptr{Csize_t}),
             hAttr,
             pnCount,
@@ -16650,6 +17176,87 @@ TRUE in case of success.
 function gdalattributewriteint(hAttr, arg2)
     aftercare(
         ccall((:GDALAttributeWriteInt, libgdal), Cint, (GDALAttributeH, Cint), hAttr, arg2),
+    )
+end
+
+"""
+    GDALAttributeWriteIntArray(GDALAttributeH hAttr,
+                               const int * panValues,
+                               size_t nCount) -> int
+
+Write an attribute from an array of int.
+
+### Parameters
+* **hAttr**: Attribute
+* **panValues**: Array of int.
+* **nCount**: Should be equal to GetTotalElementsCount().
+
+### Returns
+TRUE in case of success.
+"""
+function gdalattributewriteintarray(hAttr, arg2, arg3)
+    aftercare(
+        ccall(
+            (:GDALAttributeWriteIntArray, libgdal),
+            Cint,
+            (GDALAttributeH, Ptr{Cint}, Csize_t),
+            hAttr,
+            arg2,
+            arg3,
+        ),
+    )
+end
+
+"""
+    GDALAttributeWriteInt64(GDALAttributeH hAttr,
+                            int64_t nVal) -> int
+
+Write an attribute from an int64_t value.
+
+### Parameters
+* **hAttr**: Attribute
+* **nVal**: Value.
+
+### Returns
+TRUE in case of success.
+"""
+function gdalattributewriteint64(hAttr, arg2)
+    aftercare(
+        ccall(
+            (:GDALAttributeWriteInt64, libgdal),
+            Cint,
+            (GDALAttributeH, Int64),
+            hAttr,
+            arg2,
+        ),
+    )
+end
+
+"""
+    GDALAttributeWriteInt64Array(GDALAttributeH hAttr,
+                                 const int64_t * panValues,
+                                 size_t nCount) -> int
+
+Write an attribute from an array of int64_t.
+
+### Parameters
+* **hAttr**: Attribute
+* **panValues**: Array of int64_t.
+* **nCount**: Should be equal to GetTotalElementsCount().
+
+### Returns
+TRUE in case of success.
+"""
+function gdalattributewriteint64array(hAttr, arg2, arg3)
+    aftercare(
+        ccall(
+            (:GDALAttributeWriteInt64Array, libgdal),
+            Cint,
+            (GDALAttributeH, Ptr{Int64}, Csize_t),
+            hAttr,
+            arg2,
+            arg3,
+        ),
     )
 end
 
@@ -17681,13 +18288,13 @@ AREA_OF_INTEREST=west_long,south_lat,east_long,north_lat: Values in degrees. lon
 COORDINATE_OPERATION=string: PROJ or WKT string representing a coordinate operation, overriding the default computed transformation. 
 
 
-COORDINATE_EPOCH=decimal_year: Coordinate epoch, expressed as a decimal year. Useful for time-dependant coordinate operations. 
+COORDINATE_EPOCH=decimal_year: Coordinate epoch, expressed as a decimal year. Useful for time-dependent coordinate operations. 
 
 
-SRC_COORDINATE_EPOCH: (GDAL >= 3.4) Coordinate epoch of source CRS, expressed as a decimal year. Useful for time-dependant coordinate operations. 
+SRC_COORDINATE_EPOCH: (GDAL >= 3.4) Coordinate epoch of source CRS, expressed as a decimal year. Useful for time-dependent coordinate operations. 
 
 
-DST_COORDINATE_EPOCH: (GDAL >= 3.4) Coordinate epoch of target CRS, expressed as a decimal year. Useful for time-dependant coordinate operations.
+DST_COORDINATE_EPOCH: (GDAL >= 3.4) Coordinate epoch of target CRS, expressed as a decimal year. Useful for time-dependent coordinate operations.
 
 ### Returns
 Handle for use with GDALReprojectionTransform(), or NULL if the system fails to initialize the reprojection.
@@ -17987,7 +18594,7 @@ end
 """
     GDALDestroyRPCTransformer(void * pTransformAlg) -> void
 
-Destroy RPC tranformer.
+Destroy RPC transformer.
 """
 function gdaldestroyrpctransformer(pTransformArg)
     aftercare(
@@ -18097,7 +18704,7 @@ Create an approximating transformer.
 ### Parameters
 * **pfnBaseTransformer**: the high precision transformer which should be approximated.
 * **pBaseTransformArg**: the callback argument for the high precision transformer.
-* **dfMaxError**: the maximum cartesian error in the "output" space that is to be accepted in the linear approximation.
+* **dfMaxError**: the maximum cartesian error in the "output" space that is to be accepted in the linear approximation, evaluated as a Manhattan distance.
 
 ### Returns
 callback pointer suitable for use with GDALApproxTransform(). It should be deallocated with GDALDestroyApproxTransformer().
@@ -18514,6 +19121,8 @@ struct OGRContourWriterInfo
     nElevFieldMax::Cint
     nIDField::Cint
     nNextID::Cint
+    nWrittenFeatureCountSinceLastCommit::GIntBig
+    nTransactionCommitInterval::GIntBig
 end
 
 """
@@ -18977,7 +19586,7 @@ Burn geometries from the specified list of layers into raster.
 "CHUNKYSIZE": The height in lines of the chunk to operate on. The larger the chunk size the less times we need to make a pass through all the shapes. If it is not set or set to zero the default chunk size will be used. Default size will be estimated based on the GDAL cache buffer size using formula: cache_size_bytes/scanline_size_bytes, so the chunk will not exceed the cache. 
 
 
-"ALL_TOUCHED": May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"ALL_TOUCHED": May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon (behavior is unspecified when the polygon is just touching the pixel center) or that are selected by Brezenham's line algorithm. Defaults to FALSE. 
 
 
 "BURN_VALUE_FROM": May be set to "Z" to use the Z values of the geometries. The value from padfLayerBurnValues or the attribute field value is added to this before burning. In default case dfBurnValue is burned as it is. This is implemented properly only for points and lines for now. Polygons will be burned using the Z value from the first point. The M value may be supported in the future. 
@@ -19074,7 +19683,7 @@ Burn geometries from the specified list of layer into raster.
 "ATTRIBUTE": Identifies an attribute field on the features to be used for a burn in value. The value will be burned into all output bands. If specified, padfLayerBurnValues will not be used and can be a NULL pointer. 
 
 
-"ALL_TOUCHED": May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"ALL_TOUCHED": May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon (behavior is unspecified when the polygon is just touching the pixel center) or that are selected by Brezenham's line algorithm. Defaults to FALSE. 
 
 
 "BURN_VALUE_FROM": May be set to "Z" to use the Z values of the geometries. dfBurnValue or the attribute field value is added to this before burning. In default case dfBurnValue is burned as it is. This is implemented properly only for points and lines for now. Polygons will be burned using the Z value from the first point. The M value may be supported in the future. 
@@ -19665,7 +20274,7 @@ struct GDALTriangulation
 end
 
 """
-    GDALHasTriangulation(void) -> int
+    GDALHasTriangulation() -> int
 
 Returns if GDAL is built with Delaunay triangulation support.
 
@@ -24879,7 +25488,7 @@ Compute a simplified geometry.
 * **dTolerance**: the distance tolerance for the simplification.
 
 ### Returns
-the simplified geometry or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_simplify(hThis, tolerance)
     aftercare(
@@ -24904,7 +25513,7 @@ Simplify the geometry while preserving topology.
 * **dTolerance**: the distance tolerance for the simplification.
 
 ### Returns
-the simplified geometry or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_simplifypreservetopology(hThis, tolerance)
     aftercare(
@@ -24931,7 +25540,7 @@ Return a Delaunay triangulation of the vertices of the geometry.
 * **bOnlyEdges**: if TRUE, will return a MULTILINESTRING, otherwise it will return a GEOMETRYCOLLECTION containing triangular POLYGONs.
 
 ### Returns
-the geometry resulting from the Delaunay triangulation or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_delaunaytriangulation(hThis, dfTolerance, bOnlyEdges)
     aftercare(
@@ -25129,7 +25738,7 @@ Compute boundary.
 * **hTarget**: The Geometry to calculate the boundary of.
 
 ### Returns
-a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_boundary(arg1)
     aftercare(ccall((:OGR_G_Boundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25144,7 +25753,7 @@ Compute convex hull.
 * **hTarget**: The Geometry to calculate the convex hull of.
 
 ### Returns
-a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_convexhull(arg1)
     aftercare(ccall((:OGR_G_ConvexHull, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25163,7 +25772,7 @@ Compute "concave hull" of a geometry.
 * **bAllowHoles**: Whether holes are allowed.
 
 ### Returns
-a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_concavehull(arg1, dfRatio, bAllowHoles)
     aftercare(
@@ -25191,17 +25800,45 @@ Compute buffer of geometry.
 * **nQuadSegs**: the number of segments used to approximate a 90 degree (quadrant) of curvature.
 
 ### Returns
-the newly created geometry, or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
-function ogr_g_buffer(arg1, arg2, arg3)
+function ogr_g_buffer(arg1, dfDist, nQuadSegs)
     aftercare(
         ccall(
             (:OGR_G_Buffer, libgdal),
             OGRGeometryH,
             (OGRGeometryH, Cdouble, Cint),
             arg1,
-            arg2,
-            arg3,
+            dfDist,
+            nQuadSegs,
+        ),
+    )
+end
+
+"""
+    OGR_G_BufferEx(OGRGeometryH hTarget,
+                   double dfDist,
+                   CSLConstList papszOptions) -> OGRGeometryH
+
+Compute buffer of geometry.
+
+### Parameters
+* **hTarget**: the geometry.
+* **dfDist**: the buffer distance to be applied. Should be expressed into the same unit as the coordinates of the geometry.
+* **papszOptions**: NULL terminated list of options (may be NULL)
+
+### Returns
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
+"""
+function ogr_g_bufferex(arg1, dfDist, papszOptions)
+    aftercare(
+        ccall(
+            (:OGR_G_BufferEx, libgdal),
+            OGRGeometryH,
+            (OGRGeometryH, Cdouble, CSLConstList),
+            arg1,
+            dfDist,
+            papszOptions,
         ),
     )
 end
@@ -25217,7 +25854,7 @@ Compute intersection.
 * **hOther**: the other geometry.
 
 ### Returns
-a new geometry representing the intersection or NULL if there is no intersection or an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if there is not intersection of if an error occurs.
 """
 function ogr_g_intersection(arg1, arg2)
     aftercare(
@@ -25242,7 +25879,7 @@ Compute union.
 * **hOther**: the other geometry.
 
 ### Returns
-a new geometry representing the union or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_union(arg1, arg2)
     aftercare(
@@ -25265,7 +25902,7 @@ Compute union using cascading.
 * **hThis**: the geometry.
 
 ### Returns
-a new geometry representing the union or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_unioncascaded(arg1)
     aftercare(ccall((:OGR_G_UnionCascaded, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25280,7 +25917,7 @@ Returns the union of all components of a single geometry.
 * **hThis**: the geometry.
 
 ### Returns
-a new geometry representing the union or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_unaryunion(arg1)
     aftercare(ccall((:OGR_G_UnaryUnion, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25295,7 +25932,7 @@ Returns a point guaranteed to lie on the surface.
 * **hGeom**: the geometry to operate on.
 
 ### Returns
-a point guaranteed to lie on the surface or NULL if an error occurred.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_pointonsurface(arg1)
     aftercare(ccall((:OGR_G_PointOnSurface, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25312,7 +25949,7 @@ Compute difference.
 * **hOther**: the other geometry.
 
 ### Returns
-a new geometry representing the difference or NULL if the difference is empty or an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if the difference is empty or if an error occurs.
 """
 function ogr_g_difference(arg1, arg2)
     aftercare(
@@ -25337,7 +25974,7 @@ Compute symmetric difference.
 * **hOther**: the other geometry.
 
 ### Returns
-a new geometry representing the symmetric difference or NULL if the difference is empty or an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if the difference is empty or if an error occurs.
 """
 function ogr_g_symdifference(arg1, arg2)
     aftercare(
@@ -25414,6 +26051,21 @@ the length or 0.0 for unsupported geometry types.
 """
 function ogr_g_length(arg1)
     aftercare(ccall((:OGR_G_Length, libgdal), Cdouble, (OGRGeometryH,), arg1))
+end
+
+"""
+    OGR_G_GeodesicLength(OGRGeometryH hGeom) -> double
+
+Get the length of the curve, considered as a geodesic line on the underlying ellipsoid of the SRS attached to the geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+the length or a negative value for unsupported geometry types.
+"""
+function ogr_g_geodesiclength(arg1)
+    aftercare(ccall((:OGR_G_GeodesicLength, libgdal), Cdouble, (OGRGeometryH,), arg1))
 end
 
 """
@@ -25549,7 +26201,7 @@ Attempts to make an invalid geometry valid without losing vertices.
 * **hGeom**: The Geometry to make valid.
 
 ### Returns
-a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_makevalid(arg1)
     aftercare(ccall((:OGR_G_MakeValid, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25566,7 +26218,7 @@ Attempts to make an invalid geometry valid without losing vertices.
 * **papszOptions**: Options.
 
 ### Returns
-a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_makevalidex(arg1, arg2)
     aftercare(
@@ -25589,7 +26241,7 @@ Attempts to bring geometry into normalized/canonical form.
 * **hGeom**: The Geometry to normalize.
 
 ### Returns
-a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_normalize(arg1)
     aftercare(ccall((:OGR_G_Normalize, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -25638,7 +26290,7 @@ Set the geometry's precision, rounding all its coordinates to the precision grid
 * **nFlags**: The bitwise OR of zero, one or several of OGR_GEOS_PREC_NO_TOPO and OGR_GEOS_PREC_KEEP_COLLAPSED
 
 ### Returns
-a new geometry or NULL if an error occurs.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_setprecision(arg1, dfGridSize, nFlags)
     aftercare(
@@ -25662,7 +26314,7 @@ Polygonizes a set of sparse edges.
 * **hTarget**: The Geometry to be polygonized.
 
 ### Returns
-a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
 """
 function ogr_g_polygonize(arg1)
     aftercare(ccall((:OGR_G_Polygonize, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -26680,7 +27332,7 @@ end
 Destroys a prepared geometry.
 
 ### Parameters
-* **hPreparedGeom**: preprated geometry.
+* **hPreparedGeom**: prepared geometry.
 """
 function ogrdestroypreparedgeometry(hPreparedGeom)
     aftercare(
@@ -26756,8 +27408,8 @@ List of feature field types. This list is likely to be extended in the future ..
 
 | Enumerator        | Note                             |
 | :---------------- | :------------------------------- |
-| OFTInteger        | Simple 32bit integer             |
-| OFTIntegerList    | List of 32bit integers           |
+| OFTInteger        | Single signed 32bit integer      |
+| OFTIntegerList    | List of signed 32bit integers    |
 | OFTReal           | Double Precision floating point  |
 | OFTRealList       | List of doubles                  |
 | OFTString         | String of ASCII chars            |
@@ -26768,8 +27420,8 @@ List of feature field types. This list is likely to be extended in the future ..
 | OFTDate           | Date                             |
 | OFTTime           | Time                             |
 | OFTDateTime       | Date and Time                    |
-| OFTInteger64      | Single 64bit integer             |
-| OFTInteger64List  | List of 64bit integers           |
+| OFTInteger64      | Single signed 64bit integer      |
+| OFTInteger64List  | List of signed 64bit integers    |
 | OFTMaxType        |                                  |
 """
 @cenum OGRFieldType::UInt32 begin
@@ -28546,41 +29198,13 @@ function Base.getproperty(x::Ptr{OGRField}, f::Symbol)
     f === :Integer64 && return Ptr{GIntBig}(x + 0)
     f === :Real && return Ptr{Cdouble}(x + 0)
     f === :String && return Ptr{Cstring}(x + 0)
-    f === :IntegerList && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:917:5)",
-    }(
-        x + 0,
-    )
-    f === :Integer64List && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:923:5)",
-    }(
-        x + 0,
-    )
-    f === :RealList && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:929:5)",
-    }(
-        x + 0,
-    )
-    f === :StringList && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:935:5)",
-    }(
-        x + 0,
-    )
-    f === :Binary && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:941:5)",
-    }(
-        x + 0,
-    )
-    f === :Set && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:947:5)",
-    }(
-        x + 0,
-    )
-    f === :Date && return Ptr{
-        var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:954:5)",
-    }(
-        x + 0,
-    )
+    f === :IntegerList && return Ptr{__JL_Ctag_164}(x + 0)
+    f === :Integer64List && return Ptr{__JL_Ctag_165}(x + 0)
+    f === :RealList && return Ptr{__JL_Ctag_166}(x + 0)
+    f === :StringList && return Ptr{__JL_Ctag_167}(x + 0)
+    f === :Binary && return Ptr{__JL_Ctag_168}(x + 0)
+    f === :Set && return Ptr{__JL_Ctag_169}(x + 0)
+    f === :Date && return Ptr{__JL_Ctag_170}(x + 0)
     return getfield(x, f)
 end
 
@@ -31020,7 +31644,7 @@ Get the list of SRS supported.
 * **pnCount**: Number of values in returned array. Must not be null.
 
 ### Returns
-list of supported SRS, to be freeds with OSRFreeSRSArray(), or nullptr
+list of supported SRS, to be freed with OSRFreeSRSArray(), or nullptr
 """
 function ogr_l_getsupportedsrslist(hLayer, iGeomField, pnCount)
     aftercare(
@@ -33620,6 +34244,15 @@ function ogr_gt_getlinear(eType)
 end
 
 """
+    ogr_get_ms(fSec)
+
+Return the number of milliseconds from a datetime with decimal seconds
+"""
+function ogr_get_ms(fSec)
+    aftercare(ccall((:OGR_GET_MS, libgdal), Cint, (Cfloat,), fSec))
+end
+
+"""
     OGRParseDate(const char * pszInput,
                  OGRField * psField,
                  int nOptions) -> int
@@ -35806,7 +36439,7 @@ end
 """
     OSREPSGTreatsAsLatLong(OGRSpatialReferenceH hSRS) -> int
 
-This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having lat/long coordinate ordering.
+This function returns TRUE if this geographic coordinate system should be treated as having lat/long coordinate ordering.
 """
 function osrepsgtreatsaslatlong(hSRS)
     aftercare(
@@ -35817,7 +36450,7 @@ end
 """
     OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH hSRS) -> int
 
-This function returns TRUE if EPSG feels this projected coordinate system should be treated as having northing/easting coordinate ordering.
+This function returns TRUE if this projected coordinate system should be treated as having northing/easting coordinate ordering.
 """
 function osrepsgtreatsasnorthingeasting(hSRS)
     aftercare(
@@ -37368,6 +38001,18 @@ function osrdestroycrsinfolist(list)
 end
 
 """
+    OSRGetAuthorityListFromDatabase() -> char **
+
+Return the list of CRS authorities used in the PROJ database.
+
+### Returns
+nullptr in case of error, or a NULL terminated list of strings to free with CSLDestroy()
+"""
+function osrgetauthoritylistfromdatabase()
+    aftercare(ccall((:OSRGetAuthorityListFromDatabase, libgdal), Ptr{Cstring}, ()))
+end
+
+"""
     OCTNewCoordinateTransformation(OGRSpatialReferenceH hSourceSRS,
                                    OGRSpatialReferenceH hTargetSRS) -> OGRCoordinateTransformationH
 
@@ -37904,38 +38549,141 @@ function octtransformbounds(
     )
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:917:5)"
+struct __JL_Ctag_164
     nCount::Cint
     paList::Ptr{Cint}
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:923:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_164}, f::Symbol)
+    f === :nCount && return Ptr{Cint}(x + 0)
+    f === :paList && return Ptr{Ptr{Cint}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_164, f::Symbol)
+    r = Ref{__JL_Ctag_164}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_164}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_164}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_165
     nCount::Cint
     paList::Ptr{GIntBig}
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:929:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_165}, f::Symbol)
+    f === :nCount && return Ptr{Cint}(x + 0)
+    f === :paList && return Ptr{Ptr{GIntBig}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_165, f::Symbol)
+    r = Ref{__JL_Ctag_165}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_165}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_165}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_166
     nCount::Cint
     paList::Ptr{Cdouble}
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:935:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_166}, f::Symbol)
+    f === :nCount && return Ptr{Cint}(x + 0)
+    f === :paList && return Ptr{Ptr{Cdouble}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_166, f::Symbol)
+    r = Ref{__JL_Ctag_166}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_166}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_166}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_167
     nCount::Cint
     paList::Ptr{Cstring}
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:941:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_167}, f::Symbol)
+    f === :nCount && return Ptr{Cint}(x + 0)
+    f === :paList && return Ptr{Ptr{Cstring}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_167, f::Symbol)
+    r = Ref{__JL_Ctag_167}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_167}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_167}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_168
     nCount::Cint
     paData::Ptr{GByte}
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:947:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_168}, f::Symbol)
+    f === :nCount && return Ptr{Cint}(x + 0)
+    f === :paData && return Ptr{Ptr{GByte}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_168, f::Symbol)
+    r = Ref{__JL_Ctag_168}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_168}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_168}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_169
     nMarker1::Cint
     nMarker2::Cint
     nMarker3::Cint
 end
 
-struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2a731bf3b40f2c522b4b2ba/include/ogr_core.h:954:5)"
+function Base.getproperty(x::Ptr{__JL_Ctag_169}, f::Symbol)
+    f === :nMarker1 && return Ptr{Cint}(x + 0)
+    f === :nMarker2 && return Ptr{Cint}(x + 4)
+    f === :nMarker3 && return Ptr{Cint}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_169, f::Symbol)
+    r = Ref{__JL_Ctag_169}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_169}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_169}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct __JL_Ctag_170
     Year::GInt16
     Month::GByte
     Day::GByte
@@ -37946,11 +38694,34 @@ struct var"struct (unnamed at /Users/evetion/.julia/artifacts/892de7c7303ac328b2
     Second::Cfloat
 end
 
+function Base.getproperty(x::Ptr{__JL_Ctag_170}, f::Symbol)
+    f === :Year && return Ptr{GInt16}(x + 0)
+    f === :Month && return Ptr{GByte}(x + 2)
+    f === :Day && return Ptr{GByte}(x + 3)
+    f === :Hour && return Ptr{GByte}(x + 4)
+    f === :Minute && return Ptr{GByte}(x + 5)
+    f === :TZFlag && return Ptr{GByte}(x + 6)
+    f === :Reserved && return Ptr{GByte}(x + 7)
+    f === :Second && return Ptr{Cfloat}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_170, f::Symbol)
+    r = Ref{__JL_Ctag_170}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_170}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_170}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 const GDAL_PREFIX = "/workspace/destdir"
 
 const SIZEOF_INT = 4
 
-const SIZEOF_UNSIGNED_LONG = 8
+const SIZEOF_UNSIGNED_LONG = 4
 
 const SIZEOF_VOIDP = 8
 
@@ -38016,7 +38787,7 @@ const GINT64_MAX = GINTBIG_MAX
 
 const GUINT64_MAX = GUINTBIG_MAX
 
-const CPL_FRMT_GB_WITHOUT_PREFIX = "ll"
+const CPL_FRMT_GB_WITHOUT_PREFIX = "I64"
 
 const CPL_IS_LSB = 1
 
@@ -38038,9 +38809,9 @@ const VSI_STAT_CACHE_ONLY = 0x10
 
 const GDAL_VERSION_MAJOR = 3
 
-const GDAL_VERSION_MINOR = 9
+const GDAL_VERSION_MINOR = 10
 
-const GDAL_VERSION_REV = 1
+const GDAL_VERSION_REV = 0
 
 const GDAL_VERSION_BUILD = 0
 
@@ -38048,11 +38819,19 @@ const GDAL_VERSION_NUM =
     GDAL_COMPUTE_VERSION(GDAL_VERSION_MAJOR, GDAL_VERSION_MINOR, GDAL_VERSION_REV) +
     GDAL_VERSION_BUILD
 
-const GDAL_RELEASE_DATE = 20240623
+const GDAL_RELEASE_DATE = 20241101
 
-const GDAL_RELEASE_NAME = "3.9.1"
+const GDAL_RELEASE_NAME = "3.10.0"
 
 const RASTERIO_EXTRA_ARG_CURRENT_VERSION = 1
+
+const GCI_IR_Start = 20
+
+const GCI_IR_End = 29
+
+const GCI_SAR_Start = 30
+
+const GCI_SAR_End = 39
 
 const GDALMD_AREA_OR_POINT = "AREA_OR_POINT"
 
@@ -38247,6 +39026,8 @@ const GDAL_OF_RESERVED_1 = 0x0300
 const GDAL_OF_BLOCK_ACCESS_MASK = 0x0300
 
 const GDAL_OF_FROM_GDALOPEN = 0x0400
+
+const GDAL_OF_THREAD_SAFE = 0x0800
 
 const GDAL_DS_LAYER_CREATIONOPTIONLIST = "DS_LAYER_CREATIONOPTIONLIST"
 

--- a/test/gdal_utils.jl
+++ b/test/gdal_utils.jl
@@ -79,19 +79,22 @@ ds_dempr = GDAL.gdaldemprocessing(
 )
 GDAL.gdaldemprocessingoptionsfree(options)
 GDAL.gdalclose(ds_dempr)
-@test replace(replace(read("data/utmtiny-hillshade.asc", String), "\r" => ""), " \n" => "\n") == """
-    ncols        5
-    nrows        5
-    xllcorner    440720.000000000000
-    yllcorner    3745320.000000000000
-    cellsize     1200.000000000000
-    NODATA_value 0
-    0 0 0 0 0
-    0 183 184 183 0
-    0 180 182 181 0
-    0 181 181 177 0
-    0 0 0 0 0
-    """
+@test replace(
+    replace(read("data/utmtiny-hillshade.asc", String), "\r" => ""),
+    " \n" => "\n",
+) == """
+ncols        5
+nrows        5
+xllcorner    440720.000000000000
+yllcorner    3745320.000000000000
+cellsize     1200.000000000000
+NODATA_value 0
+0 0 0 0 0
+0 183 184 183 0
+0 180 182 181 0
+0 181 181 177 0
+0 0 0 0 0
+"""
 rm("data/utmtiny-hillshade.asc")
 rm("data/utmtiny-hillshade.prj")
 


### PR DESCRIPTION
Since the shared library major version is bumped, this is GDAL_jll v302. This is dropping support for older GDAL releases as we now wrap functions available from 3.10 onwards, and those need to be present.
