### PR TITLE
Fix SSL certificate issue on macOS with Julia 1.12+

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using GDAL
 using Test
 import Aqua
+using MozillaCACerts_jll
+
+# Fix for SSL certificate issue on macOS with Julia 1.12+
+# GDAL's libcurl doesn't know where to find CA certificates by default
+# See: https://github.com/JuliaGeo/GDAL.jl/issues/203
+if Sys.isapple() && VERSION >= v"1.11"
+    GDAL.cplsetconfigoption("CURL_CA_BUNDLE", MozillaCACerts_jll.cacert)
+end
 
 @testset "GDAL" begin
 


### PR DESCRIPTION
## Summary

This PR fixes the SSL certificate issue on macOS with Julia 1.12+ reported in #203.

## Root Cause

GDAL's libcurl on macOS doesn't know where to find CA certificates by default when built with OpenSSL (instead of native SecureTransport). Between Julia 1.10 and 1.12, something changed in how LibCURL_jll is built/configured that broke certificate resolution on macOS.

## Solution

Configure GDAL to use the Mozilla CA certificate bundle provided by `MozillaCACerts_jll` via `GDAL.cplsetconfigoption("CURL_CA_BUNDLE", MozillaCACerts_jll.cacert)`.

This is applied only on macOS with Julia 1.11+ to avoid affecting working configurations on other platforms or Julia versions.

## Testing

- Tested locally on macOS with Julia 1.12 - vsicurl tests now pass
- The fix is scoped to only affect macOS with Julia 1.11+

Fixes #203