### PR TITLE
Run CI on x86 as well

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,8 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
+          - os: macOS-latest
+            arch: x64
         include:
           - os: macos-latest
             arch: aarch64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,24 +14,29 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - 'lts'
           - '1'
+          - 'pre'
         os:
           - ubuntu-latest
+          - macOS-latest
           - windows-latest
         arch:
           - x64
+          - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86
         include:
-          - os: macOS-latest
+          - os: macos-latest
             arch: aarch64
-            version: '1.10'
-          - os: macOS-latest
+            version: 'lts'
+          - os: macos-latest
             arch: aarch64
             version: '1'
-          - os: ubuntu-latest
-            arch: x64
+          - os: macos-latest
+            arch: aarch64
             version: 'pre'
-
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
Copying the https://github.com/JuliaGeo/Proj.jl/pull/129 setup.

We already had a Linux only Julia pre-release build, but given CI is fast and we don't run it too often, it is probably better, we might have caught https://github.com/JuliaGeo/GDAL.jl/issues/203 before the Julia 1.12 release.