### PR TITLE
Fix CA certificate fallback for GDAL HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ you set two things:
 Inside of julia (2) is always the case, and (1) happens on loading the `GDAL` module, in its
 `__init__` function.
 
+GDAL's HTTPS support uses the certificate roots selected by Julia's `NetworkOptions`.
+On systems where the platform roots are not available as a file, this uses Julia's bundled
+certificate roots. Set `GDAL_CURL_CA_BUNDLE`, `CURL_CA_BUNDLE`, `SSL_CERT_FILE`, or
+`GDAL_HTTP_CAPATH` before loading GDAL to use custom certificate roots.
+
 ## Missing driver to support a format
 
 If you get an error such as the one below:

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -32,6 +32,13 @@ function _set_ca_roots!()
     any(option -> cplgetconfigoption(option, C_NULL) !== nothing,
         _GDAL_CA_CONFIG_OPTIONS) && return
 
+    # On Windows, GDAL's C runtime may not see changes made through Julia's ENV.
+    for option in _GDAL_CA_CONFIG_OPTIONS
+        haskey(ENV, option) || continue
+        cplsetconfigoption(option, ENV[option])
+        return
+    end
+
     ca_path = ca_roots_path()
     is_ca_directory =
         isdir(ca_path) || get(ENV, "SSL_CERT_DIR", nothing) == ca_path

--- a/src/GDAL.jl
+++ b/src/GDAL.jl
@@ -3,7 +3,7 @@ module GDAL
 using CEnum
 using GDAL_jll
 using PROJ_jll
-using NetworkOptions: ca_roots
+using NetworkOptions: ca_roots_path
 
 # some manual replacements for generated code in libgdal.jl
 const stat = Cvoid
@@ -21,6 +21,25 @@ const GDALVERSION = Ref{VersionNumber}()
 const GDAL_DATA = Ref{String}()
 const PROJ_LIB = Ref{String}()
 
+const _GDAL_CA_CONFIG_OPTIONS = (
+    "GDAL_CURL_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "GDAL_HTTP_CAPATH",
+)
+
+function _set_ca_roots!()
+    any(option -> cplgetconfigoption(option, C_NULL) !== nothing,
+        _GDAL_CA_CONFIG_OPTIONS) && return
+
+    ca_path = ca_roots_path()
+    is_ca_directory =
+        isdir(ca_path) || get(ENV, "SSL_CERT_DIR", nothing) == ca_path
+    option = is_ca_directory ? "GDAL_HTTP_CAPATH" : "CURL_CA_BUNDLE"
+    cplsetconfigoption(option, ca_path)
+    return
+end
+
 function __init__()
     # register custom error handler
     funcptr = @cfunction(gdaljl_errorhandler, Ptr{Cvoid}, (CPLErr, Cint, Cstring))
@@ -35,10 +54,7 @@ function __init__()
     cplsetconfigoption("GDAL_DATA", GDAL_DATA[])
 
     # set path to CA certificates
-    ca_path = ca_roots()
-    if ca_path !== nothing
-        cplsetconfigoption("CURL_CA_BUNDLE", ca_path)
-    end
+    _set_ca_roots!()
 
     # set PROJ_LIB location, this overrides setting the environment variable
     PROJ_LIB[] = joinpath(PROJ_jll.artifact_dir, "share", "proj")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,62 @@ import Aqua
     @test n_gdal_driver > 0
     @test n_ogr_driver > 0
 
+    @testset "CA certificate configuration" begin
+        ca_options = GDAL._GDAL_CA_CONFIG_OPTIONS
+        original_options =
+            Dict(option => GDAL.cplgetglobalconfigoption(option, C_NULL)
+                 for option in ca_options)
+        withenv((option => nothing for option in ca_options)...) do
+            try
+                foreach(option -> GDAL.cplsetconfigoption(option, C_NULL), ca_options)
+                withenv("JULIA_SSL_CA_ROOTS_PATH" => "",
+                        "SSL_CERT_FILE" => nothing,
+                        "SSL_CERT_DIR" => nothing) do
+                    GDAL._set_ca_roots!()
+                    ca_path = GDAL.ca_roots_path()
+                    option = isdir(ca_path) ? "GDAL_HTTP_CAPATH" : "CURL_CA_BUNDLE"
+                    @test GDAL.cplgetconfigoption(option, C_NULL) == ca_path
+                end
+
+                foreach(option -> GDAL.cplsetconfigoption(option, C_NULL), ca_options)
+                mktempdir() do ca_directory
+                    withenv("JULIA_SSL_CA_ROOTS_PATH" => nothing,
+                            "SSL_CERT_FILE" => nothing,
+                            "SSL_CERT_DIR" => ca_directory) do
+                        GDAL._set_ca_roots!()
+                        @test GDAL.cplgetconfigoption("GDAL_HTTP_CAPATH", C_NULL) ==
+                              ca_directory
+                        @test GDAL.cplgetconfigoption("CURL_CA_BUNDLE", C_NULL) ===
+                              nothing
+                    end
+                end
+
+                for preserved_option in ca_options
+                    foreach(option -> GDAL.cplsetconfigoption(option, C_NULL), ca_options)
+                    GDAL.cplsetconfigoption(preserved_option, "custom-ca-setting")
+                    GDAL._set_ca_roots!()
+                    @test GDAL.cplgetconfigoption(preserved_option, C_NULL) ==
+                          "custom-ca-setting"
+                    @test count(option ->
+                                    GDAL.cplgetconfigoption(option, C_NULL) !== nothing,
+                                ca_options) == 1
+                end
+
+                foreach(option -> GDAL.cplsetconfigoption(option, C_NULL), ca_options)
+                withenv("GDAL_CURL_CA_BUNDLE" => "custom-ca-from-env") do
+                    GDAL._set_ca_roots!()
+                    @test GDAL.cplgetconfigoption("GDAL_CURL_CA_BUNDLE", C_NULL) ==
+                          "custom-ca-from-env"
+                    @test GDAL.cplgetconfigoption("CURL_CA_BUNDLE", C_NULL) === nothing
+                end
+            finally
+                for (option, value) in original_options
+                    GDAL.cplsetconfigoption(option, something(value, C_NULL))
+                end
+            end
+        end
+    end
+
     srs = GDAL.osrnewspatialreference(C_NULL)
     GDAL.osrimportfromepsg(srs, 4326) # fails if GDAL_DATA is not set correctly
 


### PR DESCRIPTION
Fixes #203.

On macOS with Julia 1.12, `NetworkOptions.ca_roots()` returns `nothing` because Julia's own TLS stack can use the Keychain. GDAL's libcurl build still needs a filesystem path, so `/vsicurl/` HTTPS requests fail with `SSL certificate problem: unable to get local issuer certificate`.

Use `NetworkOptions.ca_roots_path()` to provide GDAL with a filesystem fallback. Existing GDAL/libcurl certificate settings remain authoritative, certificate directories are passed through `GDAL_HTTP_CAPATH` rather than as a CA bundle file, and Julia environment settings are copied into GDAL config when Windows' separate C runtime cannot see them.

Validation:

- Full test suite on macOS aarch64, Julia 1.12.7: 170 passed
- Existing `/vsicurl/` HTTPS test succeeds against the Sentinel S3 URL
- Added coverage for default fallback, CA directories, existing GDAL configuration, and environment configuration
- [Core CI](https://github.com/JuliaGeo/GDAL.jl/actions/runs/34009233863) passes on all seven Julia/OS jobs
- The ArchGDAL downstream integration passes
- At the time of this update, the GeoDataFrames and Rasters downstream integrations are still running

The GADM downstream integration currently fails an unrelated table-schema assertion (13 columns returned, 12 expected). This change only affects CA configuration during initialization and does not touch dataset or schema handling.
