### PR TITLE
Generate and require GDAL 3.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "add2ef01-049f-52c4-9ee2-e494f65e021a"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "Wrapper for GDAL - Geospatial Data Abstraction Library"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -14,7 +14,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 [compat]
 Aqua = "0.8"
 CEnum = "0.2, 0.3, 0.4, 0.5"
-GDAL_jll = "304.1200"
+GDAL_jll = "305.1300"
 NetworkOptions = "1.2"
 PROJ_jll = "902"
 Test = "<0.0.1,1"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.3"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "d3fb5d354c0dd41c6ba04619267a742a45345dca"
 
@@ -9,10 +9,10 @@ uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.2"
 
 [[deps.Arrow_jll]]
-deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Lz4_jll", "Thrift_jll", "Zlib_jll", "Zstd_jll", "boost_jll", "brotli_jll", "snappy_jll"]
-git-tree-sha1 = "55ecf3d16295c26e96d2f0b65386d1a8414e2283"
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Lz4_jll", "Thrift_jll", "Zlib_jll", "Zstd_jll", "boost_jll", "brotli_jll", "rapidjson_jll", "snappy_jll"]
+git-tree-sha1 = "776ed1d3fe0cff2166d0cb731fda3fce1cf6ce37"
 uuid = "8ce61222-c28f-5041-a97a-c2198fb817bf"
-version = "19.0.1+0"
+version = "24.0.0+0"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -47,9 +47,9 @@ version = "0.19.0"
 
 [[deps.Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
-git-tree-sha1 = "f85df021a5fd31ac59ea7126232b2875a848544f"
+git-tree-sha1 = "b8074057fb094f6f9f80bc1499c33d91b98c8a63"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "18.1.7+4"
+version = "18.1.7+5"
 
 [[deps.CommonMark]]
 deps = ["PrecompileTools"]
@@ -60,7 +60,7 @@ version = "0.9.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.3.1+2"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -74,9 +74,9 @@ version = "1.7.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "27af30de8b5445644e8ffe3bcb0d72049c089cf1"
+git-tree-sha1 = "2bfb1e047e2ad0a5ca94365340bde8005d637568"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.7.3+0"
+version = "2.8.4+0"
 
 [[deps.EzXML]]
 deps = ["Printf", "XML2_jll"]
@@ -88,11 +88,17 @@ version = "1.2.3"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 version = "1.11.0"
 
+[[deps.Fmt_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "38ac3c197b18d75111a531bf7faa83519cdfff02"
+uuid = "5dc1e892-f187-50dd-85f3-7dff85c47fc5"
+version = "11.1.1+0"
+
 [[deps.GDAL_jll]]
-deps = ["Arrow_jll", "Artifacts", "Blosc_jll", "Expat_jll", "GEOS_jll", "HDF4_jll", "HDF5_jll", "JLLWrappers", "LERC_jll", "LibCURL_jll", "LibPQ_jll", "Libdl", "Libtiff_jll", "Lz4_jll", "NetCDF_jll", "OpenJpeg_jll", "PCRE2_jll", "PROJ_jll", "Qhull_jll", "SQLite_jll", "XML2_jll", "XZ_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "libpng_jll", "libwebp_jll", "muparser_jll"]
-git-tree-sha1 = "b58b81514fd80fe30856746bba3b7f3253a232ca"
+deps = ["Arrow_jll", "Artifacts", "Blosc_jll", "CompilerSupportLibraries_jll", "Expat_jll", "GEOS_jll", "HDF4_jll", "HDF5_jll", "JLLWrappers", "LERC_jll", "LibCURL_jll", "LibPQ_jll", "Libdl", "Libtiff_jll", "Lz4_jll", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "NetCDF_jll", "OpenJpeg_jll", "OpenMPI_jll", "PCRE2_jll", "PROJ_jll", "Qhull_jll", "SQLite_jll", "TOML", "XML2_jll", "XZ_jll", "Zlib_jll", "Zstd_jll", "grok_jll", "libgeotiff_jll", "libpng_jll", "libwebp_jll", "muparser_jll"]
+git-tree-sha1 = "53545c56f90636f09e8dcee93259b7e26c9174fa"
 uuid = "a7073274-a066-55f0-b90d-d619367d196c"
-version = "304.1200.100+0"
+version = "305.1300.301+0"
 
 [[deps.GEOS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -107,9 +113,9 @@ uuid = "59f7168a-df46-5410-90c8-f2779963d0ec"
 version = "5.2.3+0"
 
 [[deps.Glob]]
-git-tree-sha1 = "83cb0092e2792b9e3a865b6655e88f5b862607e2"
+git-tree-sha1 = "246c628cec062230b7d183aab88841fa94fcabe9"
 uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
-version = "1.4.0"
+version = "1.5.0"
 
 [[deps.HDF4_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Zlib_jll", "libaec_jll"]
@@ -118,16 +124,16 @@ uuid = "818ab7a1-5177-5f44-ba99-6e845030c6cb"
 version = "4.3.2+0"
 
 [[deps.HDF5_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
-git-tree-sha1 = "e94f84da9af7ce9c6be049e9067e511e17ff89ec"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "aws_c_s3_jll", "dlfcn_win32_jll", "libaec_jll", "mpif_jll"]
+git-tree-sha1 = "8dd4e7d13617134fccede29e5b576380ab5d9199"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.14.6+0"
+version = "2.2.1+0"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
-git-tree-sha1 = "3d468106a05408f9f7b6f161d9e7715159af247b"
+git-tree-sha1 = "c35847ca5b4997fc8418836354a56c459bcf48d8"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.12.2+0"
+version = "2.14.0+0"
 
 [[deps.ICU_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -137,15 +143,15 @@ version = "76.2.0+0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.1"
+version = "1.8.0"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "b6893345fd6658c8e475d40155789f4860ac3b21"
+git-tree-sha1 = "037babc10853eeb8e585418922246cb97b8e5b74"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.1.4+0"
+version = "3.2.0+1"
 
 [[deps.JuliaFormatter]]
 deps = ["CommonMark", "Glob", "JuliaSyntax", "PrecompileTools", "TOML"]
@@ -171,15 +177,15 @@ version = "1.21.3+0"
 
 [[deps.LERC_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "aaafe88dccbd957a8d82f7d05be9b69172e0cee3"
+git-tree-sha1 = "39bca05343661c347aae0bca57a5994a0bf4f08d"
 uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
-version = "4.0.1+0"
+version = "4.2.0+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "eb62a3deb62fc6d8822c0c4bef73e4412419c5d8"
+git-tree-sha1 = "e5b100780d4d30d63b4618d7930d48af409c1772"
 uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
-version = "18.1.8+0"
+version = "23.1.1+0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -208,9 +214,9 @@ version = "1.9.0+0"
 
 [[deps.LibPQ_jll]]
 deps = ["Artifacts", "ICU_jll", "JLLWrappers", "Kerberos_krb5_jll", "Libdl", "OpenSSL_jll", "Zstd_jll"]
-git-tree-sha1 = "7757f54f007cc0eb516a5000fb9a6fc19a49da7e"
+git-tree-sha1 = "c692057e05ba6da348bc45d5dab8c7a2c88da518"
 uuid = "08be9ffa-1c94-5ee5-a977-46a84ec9b350"
-version = "16.8.0+0"
+version = "16.14.0+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
@@ -235,15 +241,15 @@ version = "1.18.0+0"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "f04133fe05eff1667d2054c53d59f9122383fe05"
+git-tree-sha1 = "aebd334d06cee9f24cea70bd19a39749daf73881"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.7.2+0"
+version = "4.7.3+0"
 
 [[deps.LittleCMS_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll"]
-git-tree-sha1 = "8e6a74641caf3b84800f2ccd55dc7ab83893c10b"
+git-tree-sha1 = "38928f7999753af13d4e13966ae15958ff3a917a"
 uuid = "d3a379c0-f9a3-5b72-a4c0-6bf4d2e8af0f"
-version = "2.17.0+0"
+version = "2.19.1+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -255,23 +261,29 @@ git-tree-sha1 = "191686b1ac1ea9c89fc52e996ad15d1d241d1e33"
 uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
 version = "1.10.1+0"
 
+[[deps.MPIABI_jll]]
+deps = ["Artifacts", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "c0ab44a826d1a8219715078f79c265a11292db86"
+uuid = "b5ada748-db0f-5fc0-8972-9331c762740c"
+version = "1.0.0+0"
+
 [[deps.MPICH_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "9341048b9f723f2ae2a72a5269ac2f15f80534dc"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "07dbec8aab01696edc0151a401a6cdfe95b9b885"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.3.2+0"
+version = "5.0.1+0"
 
 [[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
-git-tree-sha1 = "c105fe467859e7f6e9a852cb15cb4301126fac07"
+git-tree-sha1 = "8e98d5d80b87403c311fd51e8455d4546ba7a5f8"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
-version = "0.1.11"
+version = "0.1.12"
 
 [[deps.MPItrampoline_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "e214f2a20bdd64c04cd3e4ff62d3c9be7e969a59"
+git-tree-sha1 = "675df097f8eeb28998b2cfe3b25655af73d5f7df"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.5.4+0"
+version = "5.5.6+0"
 
 [[deps.MacroTools]]
 git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
@@ -294,10 +306,10 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2025.11.4"
 
 [[deps.NetCDF_jll]]
-deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libaec_jll", "libzip_jll"]
-git-tree-sha1 = "d574803b6055116af212434460adf654ce98e345"
+deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libaec_jll", "libzip_jll"]
+git-tree-sha1 = "bbd7ae15594503021b388a1090cca6ea431e0a8f"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
-version = "401.900.300+0"
+version = "401.1000.101+0"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -311,14 +323,14 @@ version = "2.5.5+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
-git-tree-sha1 = "ab6596a9d8236041dcd59b5b69316f28a8753592"
+git-tree-sha1 = "6d6c0ca4824268c1a7dca1f4721c535ac63d9074"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "5.0.9+0"
+version = "5.0.11+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -327,9 +339,9 @@ version = "10.44.0+1"
 
 [[deps.PROJ_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "Libtiff_jll", "SQLite_jll"]
-git-tree-sha1 = "817778f5802156bff35b472c73b0c4e611bd23c3"
+git-tree-sha1 = "fbfbc14815c5f5375abc971321aa5f468e715a38"
 uuid = "58948b4f-47e0-5654-a9ad-f609743f8632"
-version = "902.700.0+0"
+version = "902.800.100+0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -344,15 +356,15 @@ version = "1.12.1"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.3.3"
+version = "1.3.4"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.5.1"
+version = "1.5.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -375,10 +387,10 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
 [[deps.SQLite_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "9a325057cdb9b066f1f96dc77218df60fe3007cb"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll", "dlfcn_win32_jll"]
+git-tree-sha1 = "324744e40b84e6dc2cfaa4122ce969a083c40a6f"
 uuid = "76ed43ae-9a5d-5a62-8c75-30186b810ce8"
-version = "3.48.0+0"
+version = "3.53.2+0"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -417,15 +429,15 @@ version = "2.13.9+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "fee71455b0aaa3440dfdd54a9a36ccef829be7d4"
+git-tree-sha1 = "e52eca002a11c30a858185efdfb15311e1c7a6bf"
 uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
-version = "5.8.1+0"
+version = "5.8.4+0"
 
 [[deps.Xorg_libX11_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
-git-tree-sha1 = "b5899b25d17bf1889d25906fb9deed5da0c15b3b"
+git-tree-sha1 = "808090ede1d41644447dd5cbafced4731c56bd2f"
 uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
-version = "1.8.12+0"
+version = "1.8.13+0"
 
 [[deps.Xorg_libXau_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -441,15 +453,15 @@ version = "1.1.6+0"
 
 [[deps.Xorg_libXext_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
-git-tree-sha1 = "a4c0ee07ad36bf8bbce1c3bb52d21fb1e0b987fb"
+git-tree-sha1 = "1a4a26870bf1e5d26cd585e38038d399d7e65706"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
-version = "1.3.7+0"
+version = "1.3.8+0"
 
 [[deps.Xorg_libpciaccess_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "4909eb8f1cbf6bd4b1c30dd18b2ead9019ef2fad"
+git-tree-sha1 = "58972370b81423fc546c56a60ed1a009450177c3"
 uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
-version = "0.18.1+0"
+version = "0.19.0+0"
 
 [[deps.Xorg_libxcb_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
@@ -474,6 +486,60 @@ git-tree-sha1 = "446b23e73536f84e8037f5dce465e92275f6a308"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.7+1"
 
+[[deps.aws_c_auth_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_cal_jll", "aws_c_http_jll", "aws_c_sdkutils_jll"]
+git-tree-sha1 = "8cab83c96af80a1be968251ce1a0548a7545484d"
+uuid = "2b3700d1-4306-52e2-a478-c162f0c514be"
+version = "0.9.6+0"
+
+[[deps.aws_c_cal_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "22c0f42f4a1f0dc5dcfa8fd267c4ac407c455e7a"
+uuid = "70f11efc-bab2-57f1-b0f3-22aad4e67c4b"
+version = "0.9.13+0"
+
+[[deps.aws_c_common_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a759cb9bf456ad792cc7898a81ae333cce9ef02a"
+uuid = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
+version = "0.12.6+0"
+
+[[deps.aws_c_compression_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "7910c72f45f44afd297c39fe43b99c56d5ed22ec"
+uuid = "73a04cd5-f3d7-5bac-9290-e8adb709f224"
+version = "0.3.2+0"
+
+[[deps.aws_c_http_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_compression_jll", "aws_c_io_jll"]
+git-tree-sha1 = "3fb8685778068de502c72fec5dd8075e037cee15"
+uuid = "3254fc65-9028-534d-aa9d-d76d128babc6"
+version = "0.10.15+0"
+
+[[deps.aws_c_io_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_cal_jll", "aws_c_common_jll", "s2n_tls_jll"]
+git-tree-sha1 = "7e481d474b2087ee8bbf55b81bf9119f21e396d9"
+uuid = "13c41daa-f319-5298-b5eb-5754e0170d52"
+version = "0.26.3+0"
+
+[[deps.aws_c_s3_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_auth_jll", "aws_c_common_jll", "aws_c_http_jll", "aws_checksums_jll", "s2n_tls_jll"]
+git-tree-sha1 = "3e9917ab25114feba657e71be41cad068b9f6595"
+uuid = "bd1f34fb-993f-5903-a121-aaf302eed6d4"
+version = "0.11.5+0"
+
+[[deps.aws_c_sdkutils_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "c43dfba2c1ab9ea9f02f2c80e86fa16f6460244e"
+uuid = "1282aa60-004d-510b-9f52-12498d409daa"
+version = "0.2.4+1"
+
+[[deps.aws_checksums_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_common_jll"]
+git-tree-sha1 = "2570c8e23f4771a087b12a47edcaaa670ac05a01"
+uuid = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
+version = "0.2.10+0"
+
 [[deps.boost_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
 git-tree-sha1 = "25fb6ecbb784a45f8ea74584fa631a9e85393dd0"
@@ -486,6 +552,18 @@ git-tree-sha1 = "46fda47f4215c957bc92fd5fbb5ad04fee1e3743"
 uuid = "4611771a-a7d2-5e23-8d00-b1becdba1aae"
 version = "1.2.0+0"
 
+[[deps.dlfcn_win32_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e141d67ffe550eadfb5af1bdbdaf138031e4805f"
+uuid = "c4b69c83-5512-53e3-94e6-de98773c479f"
+version = "1.4.2+0"
+
+[[deps.grok_jll]]
+deps = ["Artifacts", "Fmt_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "LittleCMS_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "cd143eb1444b3512c2a0757fab41461808f5ae2a"
+uuid = "0cd81ddb-c824-5a44-8fef-56db1943f23c"
+version = "20.3.7+0"
+
 [[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
@@ -493,9 +571,9 @@ version = "18.1.7+5"
 
 [[deps.libaec_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1aa23f01927b2dac46db77a56b31088feee0a491"
+git-tree-sha1 = "60f4792734488db6f42e2c7699f1d4594780bd03"
 uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
-version = "1.1.4+0"
+version = "1.1.7+0"
 
 [[deps.libgeotiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LibCURL_jll", "Libdl", "Libtiff_jll", "PROJ_jll", "Zlib_jll"]
@@ -505,9 +583,9 @@ version = "100.702.400+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "de8ab4f01cb2d8b41702bab9eaad9e8b7d352f73"
+git-tree-sha1 = "e51150d5ab85cee6fc36726850f0e627ad2e4aba"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.53+0"
+version = "1.6.58+0"
 
 [[deps.libwebp_jll]]
 deps = ["Artifacts", "Giflib_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libglvnd_jll", "Libtiff_jll", "libpng_jll"]
@@ -517,9 +595,15 @@ version = "1.6.0+0"
 
 [[deps.libzip_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "OpenSSL_jll", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "86addc139bca85fdf9e7741e10977c45785727b7"
+git-tree-sha1 = "363a1c43b8cb92e7b3ff7f504ef9a0a83c548e97"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
-version = "1.11.3+0"
+version = "1.11.4+0"
+
+[[deps.mpif_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML"]
+git-tree-sha1 = "a06fcd368cfe6fe2c0eb7b63320d4d27ddcd010d"
+uuid = "9aeb927a-4695-514f-a259-621a69f20ec0"
+version = "1.0.0+0"
 
 [[deps.muparser_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
@@ -536,6 +620,18 @@ version = "1.64.0+1"
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 version = "17.7.0+0"
+
+[[deps.rapidjson_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ea9bafbf42a1adba0ae73aa972bd42bce38578b5"
+uuid = "17fc61dc-9d6f-534d-91bb-5213c1b476d9"
+version = "1.1.1+0"
+
+[[deps.s2n_tls_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a968513a5d3b3f3c6e9cbc73edb0d9c05b9fe77e"
+uuid = "cddc5d3d-934d-5d3a-9747-62fc12ea3f48"
+version = "1.7.9+0"
 
 [[deps.snappy_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/src/libgdal.jl
+++ b/src/libgdal.jl
@@ -49,9 +49,8 @@ end
 
 """
     CPLGetThreadLocalConfigOption(const char * pszKey,
-                                  const char * pszDefault) -> const char *
-
-Same as CPLGetConfigOption() but only with options set with CPLSetThreadLocalConfigOption()
+                                  const char * pszDefault,
+                                  bool bSubstituteNullValueMarkerWithNull) -> const char *
 """
 function cplgetthreadlocalconfigoption(arg1, arg2)
     aftercare(
@@ -68,9 +67,8 @@ end
 
 """
     CPLGetGlobalConfigOption(const char * pszKey,
-                             const char * pszDefault) -> const char *
-
-Same as CPLGetConfigOption() but excludes environment variables and options set with CPLSetThreadLocalConfigOption().
+                             const char * pszDefault,
+                             bool bSubstituteNullValueMarkerWithNull) -> const char *
 """
 function cplgetglobalconfigoption(arg1, arg2)
     aftercare(
@@ -93,7 +91,7 @@ Set a configuration option for GDAL/OGR use.
 
 ### Parameters
 * **pszKey**: the key of the option
-* **pszValue**: the value of the option, or NULL to clear a setting.
+* **pszValue**: the value of the option, NULL to clear a setting, or macro CPL_NULL_VALUE.
 """
 function cplsetconfigoption(arg1, arg2)
     aftercare(ccall((:CPLSetConfigOption, libgdal), Cvoid, (Cstring, Cstring), arg1, arg2))
@@ -107,7 +105,7 @@ Set a configuration option for GDAL/OGR use.
 
 ### Parameters
 * **pszKey**: the key of the option
-* **pszValue**: the value of the option, or NULL to clear a setting.
+* **pszValue**: the value of the option, NULL to clear a setting, or macro CPL_NULL_VALUE.
 """
 function cplsetthreadlocalconfigoption(pszKey, pszValue)
     aftercare(
@@ -159,7 +157,7 @@ const CPLSetConfigOptionSubscriber = Ptr{Cvoid}
     CPLSubscribeToSetConfigOption(CPLSetConfigOptionSubscriber pfnCallback,
                                   void * pUserData) -> int
 
-Install a callback that will be notified of calls to CPLSetConfigOption()/ CPLSetThreadLocalConfigOption()
+Install a callback that will be notified of calls to CPLSetConfigOption()/ CPLSetThreadLocalConfigOption().
 
 ### Parameters
 * **pfnCallback**: Callback. Must not be NULL
@@ -183,7 +181,7 @@ end
 """
     CPLUnsubscribeToSetConfigOption(int nId) -> void
 
-Remove a subscriber installed with CPLSubscribeToSetConfigOption()
+Remove a subscriber installed with CPLSubscribeToSetConfigOption().
 
 ### Parameters
 * **nId**: Subscriber id returned by CPLSubscribeToSetConfigOption()
@@ -816,19 +814,9 @@ function cplscanpointer(arg1, arg2)
 end
 
 """
-    CPLPrintString(char * pszDest,
-                   const char * pszSrc,
-                   int nMaxLen) -> int
-
-Copy the string pointed to by pszSrc, NOT including the terminating \\0 character, to the array pointed to by pszDest.
-
-### Parameters
-* **pszDest**: Pointer to the destination string buffer. Should be large enough to hold the resulting string.
-* **pszSrc**: Pointer to the source buffer.
-* **nMaxLen**: Maximum length of the resulting string. If string length is greater than nMaxLen, it will be truncated.
-
-### Returns
-Number of characters printed.
+    CPLPrintString(char *,
+                   const char *,
+                   int) -> int
 """
 function cplprintstring(arg1, arg2, arg3)
     aftercare(
@@ -837,19 +825,9 @@ function cplprintstring(arg1, arg2, arg3)
 end
 
 """
-    CPLPrintStringFill(char * pszDest,
-                       const char * pszSrc,
-                       int nMaxLen) -> int
-
-Copy the string pointed to by pszSrc, NOT including the terminating \\0 character, to the array pointed to by pszDest.
-
-### Parameters
-* **pszDest**: Pointer to the destination string buffer. Should be large enough to hold the resulting string.
-* **pszSrc**: Pointer to the source buffer.
-* **nMaxLen**: Maximum length of the resulting string. If string length is greater than nMaxLen, it will be truncated.
-
-### Returns
-Number of characters printed.
+    CPLPrintStringFill(char *,
+                       const char *,
+                       int) -> int
 """
 function cplprintstringfill(arg1, arg2, arg3)
     aftercare(
@@ -872,15 +850,21 @@ const GInt32 = Cint
                   GInt32 iValue,
                   int nMaxLen) -> int
 
-Print GInt32 value into specified string buffer.
+Copy the string pointed to by pszSrc, NOT including the terminating `\\0' character, to the array pointed to by pszDest.
 
 ### Parameters
+* **pszDest**: Pointer to the destination string buffer. Should be large enough to hold the resulting string.
+* **pszSrc**: Pointer to the source buffer.
+* **nMaxLen**: Maximum length of the resulting string. If string length is greater than nMaxLen, it will be truncated.
+* **pszDest**: Pointer to the destination string buffer. Should be large enough to hold the resulting string.
+* **pszSrc**: Pointer to the source buffer.
+* **nMaxLen**: Maximum length of the resulting string. If string length is greater than nMaxLen, it will be truncated.
 * **pszBuffer**: Pointer to the destination string buffer. Should be large enough to hold the resulting string. Note, that the string will not be NULL-terminated, so user should do this himself, if needed.
 * **iValue**: Numerical value to print.
 * **nMaxLen**: Maximum length of the resulting string. If string length is greater than nMaxLen, it will be truncated.
 
 ### Returns
-Number of characters printed.
+Number of characters printed. */
 """
 function cplprintint32(arg1, arg2, arg3)
     aftercare(
@@ -1357,7 +1341,7 @@ end
 """
     CPLCorrespondingPaths(const char * pszOldFilename,
                           const char * pszNewFilename,
-                          char ** papszFileList) -> char **
+                          CSLConstList papszFileList) -> char **
 
 Identify corresponding paths.
 
@@ -1374,7 +1358,7 @@ function cplcorrespondingpaths(pszOldFilename, pszNewFilename, papszFileList)
         ccall(
             (:CPLCorrespondingPaths, libgdal),
             Ptr{Cstring},
-            (Cstring, Cstring, Ptr{Cstring}),
+            (Cstring, Cstring, CSLConstList),
             pszOldFilename,
             pszNewFilename,
             papszFileList,
@@ -1706,7 +1690,17 @@ end
 """
     CPLErr
 
-Error category
+Error category / error level.
+
+Can be used either as return code for a number of functions of the GDAL API, or as the error level in warning/errors raised by [`CPLError`](@ref)().
+
+| Enumerator   | Note                                                                                                                                     |
+| :----------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| CE\\_None    | No error. Only used as the return value of a function                                                                                    |
+| CE\\_Debug   | Debug message. Emitted through [`CPLDebug`](@ref)().                                                                                     |
+| CE\\_Warning | Non-nominal situation that is worth bringing to the attention of the user, but that does not prevent the ongoing operation to complete.  |
+| CE\\_Failure | Error that prevents the current operation to succeed. Other following GDAL operations might succeed.                                     |
+| CE\\_Fatal   | Fatal unrecoverable error. The process is terminated with abort() after it is emitted.                                                   |
 """
 @cenum CPLErr::UInt32 begin
     CE_None = 0
@@ -1899,9 +1893,11 @@ function cplcreatezip(pszZipFilename, papszOptions)
 end
 
 """
-    CPLCreateFileInZip(void *,
-                       const char *,
-                       char **) -> CPLErr
+    CPLCreateFileInZip(void * hZip,
+                       const char * pszFilename,
+                       char ** papszOptions) -> CPLErr
+
+Create a file in a ZIP file.
 """
 function cplcreatefileinzip(hZip, pszFilename, papszOptions)
     aftercare(
@@ -1917,9 +1913,11 @@ function cplcreatefileinzip(hZip, pszFilename, papszOptions)
 end
 
 """
-    CPLWriteFileInZip(void *,
-                      const void *,
-                      int) -> CPLErr
+    CPLWriteFileInZip(void * hZip,
+                      const void * pBuffer,
+                      int nBufferSize) -> CPLErr
+
+Write in current file inside a ZIP file.
 """
 function cplwritefileinzip(hZip, pBuffer, nBufferSize)
     aftercare(
@@ -1935,7 +1933,9 @@ function cplwritefileinzip(hZip, pBuffer, nBufferSize)
 end
 
 """
-    CPLCloseFileInZip(void *) -> CPLErr
+    CPLCloseFileInZip(void * hZip) -> CPLErr
+
+Close current file inside ZIP file.
 """
 function cplclosefileinzip(hZip)
     aftercare(ccall((:CPLCloseFileInZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
@@ -2000,19 +2000,34 @@ function cpladdfileinzip(
 end
 
 """
-    CPLCloseZip(void *) -> CPLErr
+    CPLCloseZip(void * hZip) -> CPLErr
+
+Close ZIP file.
 """
 function cplclosezip(hZip)
     aftercare(ccall((:CPLCloseZip, libgdal), CPLErr, (Ptr{Cvoid},), hZip))
 end
 
 """
-    CPLZLibDeflate(const void *,
-                   size_t,
-                   int,
-                   void *,
-                   size_t,
+    CPLZLibDeflate(const void * ptr,
+                   size_t nBytes,
+                   int nLevel,
+                   void * outptr,
+                   size_t nOutAvailableBytes,
                    size_t * pnOutBytes) -> void *
+
+Compress a buffer with ZLib compression.
+
+### Parameters
+* **ptr**: input buffer.
+* **nBytes**: size of input buffer in bytes.
+* **nLevel**: ZLib compression level (-1 for default).
+* **outptr**: output buffer, or NULL to let the function allocate it.
+* **nOutAvailableBytes**: size of output buffer if provided, or ignored.
+* **pnOutBytes**: pointer to a size_t, where to store the size of the output buffer.
+
+### Returns
+the output buffer (to be freed with VSIFree() if not provided) or NULL in case of error.
 """
 function cplzlibdeflate(ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBytes)
     aftercare(
@@ -2031,11 +2046,23 @@ function cplzlibdeflate(ptr, nBytes, nLevel, outptr, nOutAvailableBytes, pnOutBy
 end
 
 """
-    CPLZLibInflate(const void *,
-                   size_t,
-                   void *,
-                   size_t,
+    CPLZLibInflate(const void * ptr,
+                   size_t nBytes,
+                   void * outptr,
+                   size_t nOutAvailableBytes,
                    size_t * pnOutBytes) -> void *
+
+Uncompress a buffer compressed with ZLib compression.
+
+### Parameters
+* **ptr**: input buffer.
+* **nBytes**: size of input buffer in bytes.
+* **outptr**: output buffer, or NULL to let the function allocate it.
+* **nOutAvailableBytes**: size of output buffer if provided, or ignored.
+* **pnOutBytes**: pointer to a size_t, where to store the size of the output buffer.
+
+### Returns
+the output buffer (to be freed with VSIFree() if not provided) or NULL in case of error.
 """
 function cplzlibinflate(ptr, nBytes, outptr, nOutAvailableBytes, pnOutBytes)
     aftercare(
@@ -3413,7 +3440,7 @@ end
                                 const char * pszFile,
                                 int nLine) -> void *
 
-See VSIMallocAlignedAuto()
+See VSIMallocAlignedAuto().
 """
 function vsimallocalignedautoverbose(nSize, pszFile, nLine)
     aftercare(
@@ -3814,7 +3841,7 @@ Seek to requested offset.
 * **nWhence**: one of SEEK_SET, SEEK_CUR or SEEK_END.
 
 ### Returns
-0 on success or -1 one failure.
+0 on success or -1 on failure.
 """
 function vsifseekl(arg1, arg2, arg3)
     aftercare(
@@ -4149,8 +4176,10 @@ function vsioverwritefile(fpTarget, pszSourceFilename)
     )
 end
 
+const stat64 = Cvoid
+
 "Type for [`VSIStatL`](@ref)()"
-const VSIStatBufL = _stat64
+const VSIStatBufL = stat64
 
 """
     VSIStatL(const char * pszFilename,
@@ -4563,7 +4592,7 @@ end
 """
     VSIClearPathSpecificOptions(const char * pszPathPrefix) -> void
 
-Clear path specific options set with VSISetPathSpecificOption()
+Clear path specific options set with VSISetPathSpecificOption().
 
 ### Parameters
 * **pszPathPrefix**: If set to NULL, all path specific options are cleared. If set to not-NULL, only those set with VSISetPathSpecificOption(pszPathPrefix, ...) will be cleared.
@@ -4618,7 +4647,7 @@ end
 """
     VSIClearCredentials(const char * pszPathPrefix) -> void
 
-Clear path specific options set with VSISetPathSpecificOption()
+Clear path specific options set with VSISetPathSpecificOption().
 """
 function vsiclearcredentials(pszPathPrefix)
     aftercare(ccall((:VSIClearCredentials, libgdal), Cvoid, (Cstring,), pszPathPrefix))
@@ -5592,7 +5621,7 @@ end
 """
     VSIInstallCurlFileHandler(void) -> void
 
-Install /vsicurl/ HTTP/FTP file system handler (requires libcurl)
+Install /vsicurl/ HTTP/FTP file system handler (requires libcurl).
 """
 function vsiinstallcurlfilehandler()
     aftercare(ccall((:VSIInstallCurlFileHandler, libgdal), Cvoid, ()))
@@ -5601,7 +5630,7 @@ end
 """
     VSICurlClearCache(void) -> void
 
-Clean local cache associated with /vsicurl/ (and related file systems)
+Clean local cache associated with /vsicurl/ (and related file systems).
 """
 function vsicurlclearcache()
     aftercare(ccall((:VSICurlClearCache, libgdal), Cvoid, ()))
@@ -5610,7 +5639,7 @@ end
 """
     VSICurlPartialClearCache(const char * pszFilenamePrefix) -> void
 
-Clean local cache associated with /vsicurl/ (and related file systems) for a given filename (and its subfiles and subdirectories if it is a directory)
+Clean local cache associated with /vsicurl/ (and related file systems) for a given filename (and its subfiles and subdirectories if it is a directory).
 
 ### Parameters
 * **pszFilenamePrefix**: Filename prefix
@@ -5633,7 +5662,7 @@ end
 """
     VSIInstallS3FileHandler(void) -> void
 
-Install /vsis3/ Amazon S3 file system handler (requires libcurl)
+Install /vsis3/ Amazon S3 file system handler (requires libcurl).
 """
 function vsiinstalls3filehandler()
     aftercare(ccall((:VSIInstallS3FileHandler, libgdal), Cvoid, ()))
@@ -5651,7 +5680,7 @@ end
 """
     VSIInstallGSFileHandler(void) -> void
 
-Install /vsigs/ Google Cloud Storage file system handler (requires libcurl)
+Install /vsigs/ Google Cloud Storage file system handler (requires libcurl).
 """
 function vsiinstallgsfilehandler()
     aftercare(ccall((:VSIInstallGSFileHandler, libgdal), Cvoid, ()))
@@ -5660,7 +5689,7 @@ end
 """
     VSIInstallGSStreamingFileHandler(void) -> void
 
-Install /vsigs_streaming/ Google Cloud Storage file system handler (requires libcurl)
+Install /vsigs_streaming/ Google Cloud Storage file system handler (requires libcurl).
 """
 function vsiinstallgsstreamingfilehandler()
     aftercare(ccall((:VSIInstallGSStreamingFileHandler, libgdal), Cvoid, ()))
@@ -5669,7 +5698,7 @@ end
 """
     VSIInstallAzureFileHandler(void) -> void
 
-Install /vsiaz/ Microsoft Azure Blob file system handler (requires libcurl)
+Install /vsiaz/ Microsoft Azure Blob file system handler (requires libcurl).
 """
 function vsiinstallazurefilehandler()
     aftercare(ccall((:VSIInstallAzureFileHandler, libgdal), Cvoid, ()))
@@ -5678,7 +5707,7 @@ end
 """
     VSIInstallAzureStreamingFileHandler(void) -> void
 
-Install /vsiaz_streaming/ Microsoft Azure Blob file system handler (requires libcurl)
+Install /vsiaz_streaming/ Microsoft Azure Blob file system handler (requires libcurl).
 """
 function vsiinstallazurestreamingfilehandler()
     aftercare(ccall((:VSIInstallAzureStreamingFileHandler, libgdal), Cvoid, ()))
@@ -5687,7 +5716,7 @@ end
 """
     VSIInstallADLSFileHandler(void) -> void
 
-Install /vsiaz/ Microsoft Azure Data Lake Storage Gen2 file system handler (requires libcurl)
+Install /vsiaz/ Microsoft Azure Data Lake Storage Gen2 file system handler (requires libcurl).
 """
 function vsiinstalladlsfilehandler()
     aftercare(ccall((:VSIInstallADLSFileHandler, libgdal), Cvoid, ()))
@@ -5696,7 +5725,7 @@ end
 """
     VSIInstallOSSFileHandler(void) -> void
 
-Install /vsioss/ Alibaba Cloud Object Storage Service (OSS) file system handler (requires libcurl)
+Install /vsioss/ Alibaba Cloud Object Storage Service (OSS) file system handler (requires libcurl).
 """
 function vsiinstallossfilehandler()
     aftercare(ccall((:VSIInstallOSSFileHandler, libgdal), Cvoid, ()))
@@ -5705,7 +5734,7 @@ end
 """
     VSIInstallOSSStreamingFileHandler(void) -> void
 
-Install /vsiaz_streaming/ Alibaba Cloud Object Storage Service (OSS) (requires libcurl)
+Install /vsiaz_streaming/ Alibaba Cloud Object Storage Service (OSS) (requires libcurl).
 """
 function vsiinstallossstreamingfilehandler()
     aftercare(ccall((:VSIInstallOSSStreamingFileHandler, libgdal), Cvoid, ()))
@@ -5714,7 +5743,7 @@ end
 """
     VSIInstallSwiftFileHandler(void) -> void
 
-Install /vsiswift/ OpenStack Swif Object Storage (Swift) file system handler (requires libcurl)
+Install /vsiswift/ OpenStack Swif Object Storage (Swift) file system handler (requires libcurl).
 """
 function vsiinstallswiftfilehandler()
     aftercare(ccall((:VSIInstallSwiftFileHandler, libgdal), Cvoid, ()))
@@ -5723,7 +5752,7 @@ end
 """
     VSIInstallSwiftStreamingFileHandler(void) -> void
 
-Install /vsiswift_streaming/ OpenStack Swif Object Storage (Swift) file system handler (requires libcurl)
+Install /vsiswift_streaming/ OpenStack Swif Object Storage (Swift) file system handler (requires libcurl).
 """
 function vsiinstallswiftstreamingfilehandler()
     aftercare(ccall((:VSIInstallSwiftStreamingFileHandler, libgdal), Cvoid, ()))
@@ -5732,7 +5761,7 @@ end
 """
     VSIInstall7zFileHandler(void) -> void
 
-Install /vsi7z/ 7zip file system handler (requires libarchive)
+Install /vsi7z/ 7zip file system handler (requires libarchive).
 """
 function vsiinstall7zfilehandler()
     aftercare(ccall((:VSIInstall7zFileHandler, libgdal), Cvoid, ()))
@@ -5741,7 +5770,7 @@ end
 """
     VSIInstallRarFileHandler(void) -> void
 
-Install /vsirar/ RAR file system handler (requires libarchive)
+Install /vsirar/ RAR file system handler (requires libarchive).
 """
 function vsiinstallrarfilehandler()
     aftercare(ccall((:VSIInstallRarFileHandler, libgdal), Cvoid, ()))
@@ -5777,7 +5806,7 @@ end
 """
     VSIInstallHdfsHandler() -> void
 
-Install /vsihdfs/ file system handler (requires JVM and HDFS support)
+Install /vsihdfs/ file system handler (requires JVM and HDFS support).
 """
 function vsiinstallhdfshandler()
     aftercare(ccall((:VSIInstallHdfsHandler, libgdal), Cvoid, ()))
@@ -5786,7 +5815,7 @@ end
 """
     VSIInstallWebHdfsHandler(void) -> void
 
-Install /vsiwebhdfs/ WebHDFS (Hadoop File System) REST API file system handler (requires libcurl)
+Install /vsiwebhdfs/ WebHDFS (Hadoop File System) REST API file system handler (requires libcurl).
 """
 function vsiinstallwebhdfshandler()
     aftercare(ccall((:VSIInstallWebHdfsHandler, libgdal), Cvoid, ()))
@@ -5831,7 +5860,7 @@ end
 """
     VSIInstallCryptFileHandler() -> void
 
-Install /vsicrypt/ encrypted file system handler (requires libcrypto++)
+Install /vsicrypt/ encrypted file system handler (requires libcrypto++).
 """
 function vsiinstallcryptfilehandler()
     aftercare(ccall((:VSIInstallCryptFileHandler, libgdal), Cvoid, ()))
@@ -6525,30 +6554,30 @@ const GNMGenericNetworkH = Ptr{Cvoid}
 
 Pixel data types
 
-| Enumerator      | Note                                   |
-| :-------------- | :------------------------------------- |
-| GDT\\_Unknown   | Unknown or unspecified type            |
-| GDT\\_Byte      | Eight bit unsigned integer             |
-| GDT\\_Int8      | 8-bit signed integer (GDAL >= 3.7)     |
-| GDT\\_UInt16    | Sixteen bit unsigned integer           |
-| GDT\\_Int16     | Sixteen bit signed integer             |
-| GDT\\_UInt32    | Thirty two bit unsigned integer        |
-| GDT\\_Int32     | Thirty two bit signed integer          |
-| GDT\\_UInt64    | 64 bit unsigned integer (GDAL >= 3.5)  |
-| GDT\\_Int64     | 64 bit signed integer (GDAL >= 3.5)    |
-| GDT\\_Float16   | Sixteen bit floating point             |
-| GDT\\_Float32   | Thirty two bit floating point          |
-| GDT\\_Float64   | Sixty four bit floating point          |
-| GDT\\_CInt16    | Complex Int16                          |
-| GDT\\_CInt32    | Complex Int32                          |
-| GDT\\_CFloat16  | Complex Float16                        |
-| GDT\\_CFloat32  | Complex Float32                        |
-| GDT\\_CFloat64  | Complex Float64                        |
-| GDT\\_TypeCount |                                        |
+| Enumerator      | Note                                                        |
+| :-------------- | :---------------------------------------------------------- |
+| GDT\\_Unknown   | Unknown or unspecified type                                 |
+| GDT\\_UInt8     | 8-bit unsigned integer ([`GDT_Byte`](@ref) in GDAL < 3.13)  |
+| GDT\\_Int8      | 8-bit signed integer (GDAL >= 3.7)                          |
+| GDT\\_UInt16    | 16-bit unsigned integer                                     |
+| GDT\\_Int16     | 16-bit signed integer                                       |
+| GDT\\_UInt32    | 32-bit unsigned integer                                     |
+| GDT\\_Int32     | 32-bit signed integer                                       |
+| GDT\\_UInt64    | 64 bit unsigned integer (GDAL >= 3.5)                       |
+| GDT\\_Int64     | 64 bit signed integer (GDAL >= 3.5)                         |
+| GDT\\_Float16   | 16-bit floating point                                       |
+| GDT\\_Float32   | 32-bit floating point                                       |
+| GDT\\_Float64   | 64-bit floating point                                       |
+| GDT\\_CInt16    | Complex Int16                                               |
+| GDT\\_CInt32    | Complex Int32                                               |
+| GDT\\_CFloat16  | Complex Float16                                             |
+| GDT\\_CFloat32  | Complex Float32                                             |
+| GDT\\_CFloat64  | Complex Float64                                             |
+| GDT\\_TypeCount |                                                             |
 """
 @cenum GDALDataType::UInt32 begin
     GDT_Unknown = 0
-    GDT_Byte = 1
+    GDT_UInt8 = 1
     GDT_Int8 = 14
     GDT_UInt16 = 2
     GDT_Int16 = 3
@@ -6573,7 +6602,7 @@ end
 Get data type size in bits.
 
 ### Parameters
-* **eDataType**: type, such as GDT_Byte.
+* **eDataType**: type, such as GDT_UInt8.
 
 ### Returns
 the number of bits or zero if it is not recognised.
@@ -6588,7 +6617,7 @@ end
 Get data type size in bits.
 
 ### Parameters
-* **eDataType**: type, such as GDT_Byte.
+* **eDataType**: type, such as GDT_UInt8.
 
 ### Returns
 the number of bits or zero if it is not recognised.
@@ -6603,7 +6632,7 @@ end
 Get data type size in bytes.
 
 ### Parameters
-* **eDataType**: type, such as GDT_Byte.
+* **eDataType**: type, such as GDT_UInt8.
 
 ### Returns
 the number of bytes or zero if it is not recognised.
@@ -6630,7 +6659,7 @@ end
 Is data type integer?
 
 ### Returns
-TRUE if the passed type is integer (one of GDT_Byte, GDT_Int16, GDT_UInt16, GDT_Int32, GDT_UInt32, GDT_CInt16, GDT_CInt32).
+TRUE if the passed type is integer (one of GDT_UInt8, GDT_Int16, GDT_UInt16, GDT_Int32, GDT_UInt32, GDT_CInt16, GDT_CInt32).
 """
 function gdaldatatypeisinteger(arg1)
     aftercare(ccall((:GDALDataTypeIsInteger, libgdal), Cint, (GDALDataType,), arg1))
@@ -7044,18 +7073,19 @@ end
 
 Structure to pass extra arguments to RasterIO() method, must be initialized with [`INIT_RASTERIO_EXTRA_ARG`](@ref)
 
-| Field                        | Note                                                                                                                                                                                                                                                             |
-| :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| nVersion                     | Version of structure (to allow future extensions of the structure)                                                                                                                                                                                               |
-| eResampleAlg                 | Resampling algorithm                                                                                                                                                                                                                                             |
-| pfnProgress                  | Progress callback                                                                                                                                                                                                                                                |
-| pProgressData                | Progress callback user data                                                                                                                                                                                                                                      |
-| bFloatingPointWindowValidity | Indicate if dfXOff, dfYOff, dfXSize and dfYSize are set. Mostly reserved from the VRT driver to communicate a more precise source window. Must be such that dfXOff - nXOff < 1.0 and dfYOff - nYOff < 1.0 and nXSize - dfXSize < 1.0 and nYSize - dfYSize < 1.0  |
-| dfXOff                       | Pixel offset to the top left corner. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                 |
-| dfYOff                       | Line offset to the top left corner. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                  |
-| dfXSize                      | Width in pixels of the area of interest. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                             |
-| dfYSize                      | Height in pixels of the area of interest. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                            |
-| bUseOnlyThisScale            | Indicate if overviews should be considered. Tested in GDALBandGetBestOverviewLevel(), mostly reserved for use by GDALRegenerateOverviewsMultiBand() Only available if [`RASTERIO_EXTRA_ARG_CURRENT_VERSION`](@ref) >= 2                                          |
+| Field                        | Note                                                                                                                                                                                                                                                                                                                                                                                                 |
+| :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| nVersion                     | Version of structure (to allow future extensions of the structure)                                                                                                                                                                                                                                                                                                                                   |
+| eResampleAlg                 | Resampling algorithm                                                                                                                                                                                                                                                                                                                                                                                 |
+| pfnProgress                  | Progress callback                                                                                                                                                                                                                                                                                                                                                                                    |
+| pProgressData                | Progress callback user data                                                                                                                                                                                                                                                                                                                                                                          |
+| bFloatingPointWindowValidity | Indicate if dfXOff, dfYOff, dfXSize and dfYSize are set. Mostly reserved from the VRT driver to communicate a more precise source window. Must be such that dfXOff - nXOff < 1.0 and dfYOff - nYOff < 1.0 and nXSize - dfXSize < 1.0 and nYSize - dfYSize < 1.0                                                                                                                                      |
+| dfXOff                       | Pixel offset to the top left corner. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                                                                                                                                                     |
+| dfYOff                       | Line offset to the top left corner. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                                                                                                                                                      |
+| dfXSize                      | Width in pixels of the area of interest. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                                                                                                                                                 |
+| dfYSize                      | Height in pixels of the area of interest. Only valid if bFloatingPointWindowValidity = [`TRUE`](@ref)                                                                                                                                                                                                                                                                                                |
+| bUseOnlyThisScale            | Indicate if overviews should be considered. Tested in GDALBandGetBestOverviewLevel(), mostly reserved for use by GDALRegenerateOverviewsMultiBand() Only available if [`RASTERIO_EXTRA_ARG_CURRENT_VERSION`](@ref) >= 2                                                                                                                                                                              |
+| bOperateInBufType            | Indicate if operations (typically non-nearest resampling) should be done in the eBufType data type of the RasterIO() request rather than the band data type. Only available if [`RASTERIO_EXTRA_ARG_CURRENT_VERSION`](@ref) >= 3 (GDAL >= 3.13) Defaults to [`TRUE`](@ref) in GDAL >= 3.13 (behavior in previous version was mostly, but not always corresponding to setting it to [`FALSE`](@ref))  |
 """
 struct GDALRasterIOExtraArg
     nVersion::Cint
@@ -7068,6 +7098,7 @@ struct GDALRasterIOExtraArg
     dfXSize::Cdouble
     dfYSize::Cdouble
     bUseOnlyThisScale::Cint
+    bOperateInBufType::Cint
 end
 
 """
@@ -7210,6 +7241,28 @@ function gdalgetcolorinterpretationbyname(pszName)
             GDALColorInterp,
             (Cstring,),
             pszName,
+        ),
+    )
+end
+
+"""
+    GDALGetColorInterpretationList(int * pnCount) -> const GDALColorInterp *
+
+Get the list of valid color interpretations.
+
+### Parameters
+* **pnCount**: Pointer to an integer that will be set to the number of values of the returned array. It must not be null.
+
+### Returns
+array of *pnCount values
+"""
+function gdalgetcolorinterpretationlist(pnCount)
+    aftercare(
+        ccall(
+            (:GDALGetColorInterpretationList, libgdal),
+            Ptr{GDALColorInterp},
+            (Ptr{Cint},),
+            pnCount,
         ),
     )
 end
@@ -7523,7 +7576,7 @@ Thread safe mode: GDAL_OF_THREAD_SAFE (added in 3.10). This must be use in combi
 
 
 Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file will lead to an error message to be reported.
-* **papszAllowedDrivers**: NULL to consider all candidate drivers, or a NULL terminated list of strings with the driver short names that must be considered.
+* **papszAllowedDrivers**: NULL to consider all candidate drivers, or a NULL terminated list of strings with the driver short names that must be considered. Starting with GDAL 3.13, a string starting with the dash (-) character followed by the driver short name can be used to exclude a driver.
 * **papszOpenOptions**: NULL, or a NULL terminated list of strings with open options passed to candidate drivers. An option exists for all drivers, OVERVIEW_LEVEL=level, to select a particular overview level of a dataset. The level index starts at 0. The level number can be suffixed by "only" to specify that only this overview level must be visible, and not sub-levels. Open options are validated by default, and a warning is emitted in case the option is not recognized. In some scenarios, it might be not desirable (e.g. when not knowing which driver will open the file), so the special open option VALIDATE_OPEN_OPTIONS can be set to NO to avoid such warnings. Alternatively, that it may not cause a warning if the driver doesn't declare this option. Starting with GDAL 3.3, OVERVIEW_LEVEL=NONE is supported to indicate that no overviews should be exposed.
 * **papszSiblingFiles**: NULL, or a NULL terminated list of strings that are filenames that are auxiliary to the main filename. If NULL is passed, a probing of the file system will be done.
 
@@ -7633,6 +7686,15 @@ Destroy the driver manager.
 """
 function gdaldestroydrivermanager()
     aftercare(ccall((:GDALDestroyDriverManager, libgdal), Cvoid, ()))
+end
+
+"""
+    GDALClearMemoryCaches() -> void
+
+Clear all GDAL-controlled in-memory caches.
+"""
+function gdalclearmemorycaches()
+    aftercare(ccall((:GDALClearMemoryCaches, libgdal), Cvoid, ()))
 end
 
 """
@@ -7897,7 +7959,7 @@ end
     GDALDeinitGCPs(int nCount,
                    GDAL_GCP * psGCP) -> void
 
-De-initialize an array of GCPs (initialized with GDALInitGCPs())
+De-initialize an array of GCPs (initialized with GDALInitGCPs()).
 
 ### Parameters
 * **nCount**: number of GCPs in psGCP
@@ -8171,7 +8233,7 @@ end
 
 """
     GDALGetMetadata(GDALMajorObjectH hObject,
-                    const char * pszDomain) -> char **
+                    const char * pszDomain) -> CSLConstList
 
 Fetch metadata.
 """
@@ -8179,7 +8241,7 @@ function gdalgetmetadata(arg1, arg2)
     aftercare(
         ccall(
             (:GDALGetMetadata, libgdal),
-            Ptr{Cstring},
+            CSLConstList,
             (GDALMajorObjectH, Cstring),
             arg1,
             arg2,
@@ -8315,13 +8377,58 @@ end
 Close GDAL dataset.
 
 ### Parameters
-* **hDS**: The dataset to close. May be cast from a "GDALDataset *".
+* **hDS**: The dataset to close, or nullptr.
 
 ### Returns
 CE_None in case of success (return value since GDAL 3.7). On a shared dataset whose reference count is not dropped below 1, CE_None will be returned.
 """
 function gdalclose(arg1)
     aftercare(ccall((:GDALClose, libgdal), CPLErr, (GDALDatasetH,), arg1))
+end
+
+"""
+    GDALCloseEx(GDALDatasetH hDS,
+                GDALProgressFunc pfnProgress,
+                void * pProgressData) -> CPLErr
+
+Close GDAL dataset.
+
+### Parameters
+* **hDS**: The dataset to close, or nullptr
+* **pfnProgress**: Progress callback, or nullptr
+* **pProgressData**: User data of progress callback, or nullptr
+
+### Returns
+CE_None in case of success. On a shared dataset whose reference count is not dropped below 1, CE_None will be returned.
+"""
+function gdalcloseex(hDS, pfnProgress, pProgressData)
+    aftercare(
+        ccall(
+            (:GDALCloseEx, libgdal),
+            CPLErr,
+            (GDALDatasetH, GDALProgressFunc, Any),
+            hDS,
+            pfnProgress,
+            pProgressData,
+        ),
+    )
+end
+
+"""
+    GDALDatasetGetCloseReportsProgress(GDALDatasetH hDS) -> bool
+
+Returns whether the Close() operation will report progress / is a potential lengthy operation.
+
+### Parameters
+* **hDS**: dataset handle.
+
+### Returns
+CE_None if no error
+"""
+function gdaldatasetgetclosereportsprogress(hDS)
+    aftercare(
+        ccall((:GDALDatasetGetCloseReportsProgress, libgdal), Bool, (GDALDatasetH,), hDS),
+    )
 end
 
 """
@@ -8342,6 +8449,34 @@ function gdaldatasetrunclosewithoutdestroying(hDS)
             CPLErr,
             (GDALDatasetH,),
             hDS,
+        ),
+    )
+end
+
+"""
+    GDALDatasetRunCloseWithoutDestroyingEx(GDALDatasetH hDS,
+                                           GDALProgressFunc pfnProgress,
+                                           void * pProgressData) -> CPLErr
+
+Run the Close() method, without running destruction of the object.
+
+### Parameters
+* **hDS**: dataset handle.
+* **pfnProgress**: Progress callback, or nullptr
+* **pProgressData**: User data of progress callback, or nullptr
+
+### Returns
+CE_None if no error
+"""
+function gdaldatasetrunclosewithoutdestroyingex(hDS, pfnProgress, pProgressData)
+    aftercare(
+        ccall(
+            (:GDALDatasetRunCloseWithoutDestroyingEx, libgdal),
+            CPLErr,
+            (GDALDatasetH, GDALProgressFunc, Any),
+            hDS,
+            pfnProgress,
+            pProgressData,
         ),
     )
 end
@@ -9114,6 +9249,153 @@ function gdaldatasetgeolocationtopixelline(
 end
 
 """
+    GDALDatasetGetInterBandCovarianceMatrix(GDALDatasetH hDS,
+                                            double * padfCovMatrix,
+                                            size_t nSize,
+                                            int nBandCount,
+                                            const int * panBandList,
+                                            bool bApproxOK,
+                                            bool bForce,
+                                            bool bWriteIntoMetadata,
+                                            int nDeltaDegreeOfFreedom,
+                                            GDALProgressFunc pfnProgress,
+                                            void * pProgressData) -> CPLErr
+
+Fetch or compute the covariance matrix between bands of this dataset.
+
+### Parameters
+* **hDS**: Dataset handle.
+* **padfCovMatrix**: Pointer to an already allocated output array, of size at least nBandCount * nBandCount.
+* **nSize**: Number of elements in output array.
+* **nBandCount**: Zero for all bands, or number of values in panBandList. Defaults to 0.
+* **panBandList**: nullptr for all bands if nBandCount == 0, or array of nBandCount values such as panBandList[i] is the index between 1 and GetRasterCount() of a band that must be used in the covariance computation. Defaults to nullptr.
+* **bApproxOK**: Whether it is acceptable to use a subsample of values in GDALDatasetComputeInterBandCovarianceMatrix(). Defaults to false.
+* **bForce**: Whether GDALDatasetComputeInterBandCovarianceMatrix() should be called when the STATISTICS_COVARIANCES metadata items are missing. Defaults to false.
+* **bWriteIntoMetadata**: Whether GDALDatasetComputeInterBandCovarianceMatrix() must write STATISTICS_COVARIANCES band metadata items. Defaults to true.
+* **nDeltaDegreeOfFreedom**: Correction term to subtract in the final averaging phase of the covariance computation. Defaults to 1.
+* **pfnProgress**: a function to call to report progress, or NULL.
+* **pProgressData**: application data to pass to the progress function.
+
+### Returns
+CE_None if successful, CE_Warning if values are not available in metadata and bForce is false, or CE_Failure in case of failure
+"""
+function gdaldatasetgetinterbandcovariancematrix(
+    hDS,
+    padfCovMatrix,
+    nSize,
+    nBandCount,
+    panBandList,
+    bApproxOK,
+    bForce,
+    bWriteIntoMetadata,
+    nDeltaDegreeOfFreedom,
+    pfnProgress,
+    pProgressData,
+)
+    aftercare(
+        ccall(
+            (:GDALDatasetGetInterBandCovarianceMatrix, libgdal),
+            CPLErr,
+            (
+                GDALDatasetH,
+                Ptr{Cdouble},
+                Csize_t,
+                Cint,
+                Ptr{Cint},
+                Bool,
+                Bool,
+                Bool,
+                Cint,
+                GDALProgressFunc,
+                Any,
+            ),
+            hDS,
+            padfCovMatrix,
+            nSize,
+            nBandCount,
+            panBandList,
+            bApproxOK,
+            bForce,
+            bWriteIntoMetadata,
+            nDeltaDegreeOfFreedom,
+            pfnProgress,
+            pProgressData,
+        ),
+    )
+end
+
+"""
+    GDALDatasetComputeInterBandCovarianceMatrix(GDALDatasetH hDS,
+                                                double * padfCovMatrix,
+                                                size_t nSize,
+                                                int nBandCount,
+                                                const int * panBandList,
+                                                bool bApproxOK,
+                                                bool bWriteIntoMetadata,
+                                                int nDeltaDegreeOfFreedom,
+                                                GDALProgressFunc pfnProgress,
+                                                void * pProgressData) -> CPLErr
+
+Compute the covariance matrix between bands of this dataset.
+
+### Parameters
+* **hDS**: Dataset handle.
+* **padfCovMatrix**: Pointer to an already allocated output array, of size at least nBandCount * nBandCount.
+* **nSize**: Number of elements in output array.
+* **nBandCount**: Zero for all bands, or number of values in panBandList. Defaults to 0.
+* **panBandList**: nullptr for all bands if nBandCount == 0, or array of nBandCount values such as panBandList[i] is the index between 1 and GetRasterCount() of a band that must be used in the covariance computation. Defaults to nullptr.
+* **bApproxOK**: Whether it is acceptable to use a subsample of values. Defaults to false.
+* **bWriteIntoMetadata**: Whether this method must write STATISTICS_COVARIANCES band metadata items. Defaults to true.
+* **nDeltaDegreeOfFreedom**: Correction term to subtract in the final averaging phase of the covariance computation. Defaults to 1.
+* **pfnProgress**: a function to call to report progress, or NULL.
+* **pProgressData**: application data to pass to the progress function.
+
+### Returns
+CE_None if successful, or CE_Failure in case of failure
+"""
+function gdaldatasetcomputeinterbandcovariancematrix(
+    hDS,
+    padfCovMatrix,
+    nSize,
+    nBandCount,
+    panBandList,
+    bApproxOK,
+    bWriteIntoMetadata,
+    nDeltaDegreeOfFreedom,
+    pfnProgress,
+    pProgressData,
+)
+    aftercare(
+        ccall(
+            (:GDALDatasetComputeInterBandCovarianceMatrix, libgdal),
+            CPLErr,
+            (
+                GDALDatasetH,
+                Ptr{Cdouble},
+                Csize_t,
+                Cint,
+                Ptr{Cint},
+                Bool,
+                Bool,
+                Cint,
+                GDALProgressFunc,
+                Any,
+            ),
+            hDS,
+            padfCovMatrix,
+            nSize,
+            nBandCount,
+            panBandList,
+            bApproxOK,
+            bWriteIntoMetadata,
+            nDeltaDegreeOfFreedom,
+            pfnProgress,
+            pProgressData,
+        ),
+    )
+end
+
+"""
     GDALGetGCPCount(GDALDatasetH hDS) -> int
 
 Get number of GCPs.
@@ -9258,7 +9540,7 @@ end
                        GDALProgressFunc pfnProgress,
                        void * pProgressData) -> CPLErr
 
-Build raster overview(s)
+Build raster overview(s).
 """
 function gdalbuildoverviews(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
     aftercare(
@@ -9298,7 +9580,7 @@ end
                          void * pProgressData,
                          CSLConstList papszOptions) -> CPLErr
 
-Build raster overview(s)
+Build raster overview(s).
 """
 function gdalbuildoverviewsex(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, papszOptions)
     aftercare(
@@ -15847,7 +16129,7 @@ end
 """
     GDALExtendedDataTypeGetNumericDataType(GDALExtendedDataTypeH hEDT) -> GDALDataType
 
-Return numeric data type (only valid when GetClass() == GEDTC_NUMERIC)
+Return numeric data type (only valid when GetClass() == GEDTC_NUMERIC).
 """
 function gdalextendeddatatypegetnumericdatatype(hEDT)
     aftercare(
@@ -15896,7 +16178,7 @@ end
     GDALExtendedDataTypeGetComponents(GDALExtendedDataTypeH hEDT,
                                       size_t * pnCount) -> GDALEDTComponentH *
 
-Return the components of the data type (only valid when GetClass() == GEDTC_COMPOUND)
+Return the components of the data type (only valid when GetClass() == GEDTC_COMPOUND).
 
 ### Parameters
 * **hEDT**: Data type
@@ -17690,7 +17972,7 @@ end
                                 size_t iXDim,
                                 size_t iYDim) -> GDALDatasetH
 
-Return a view of this array as a "classic" GDALDataset (ie 2D)
+Return a view of this array as a "classic" GDALDataset (ie 2D).
 
 ### Parameters
 * **hArray**: Array.
@@ -17720,7 +18002,7 @@ end
                                   GDALGroupH hRootGroup,
                                   CSLConstList papszOptions) -> GDALDatasetH
 
-Return a view of this array as a "classic" GDALDataset (ie 2D)
+Return a view of this array as a "classic" GDALDataset (ie 2D).
 
 ### Parameters
 * **hArray**: Array.
@@ -18123,10 +18405,86 @@ function gdalmdarraygetrawblockinfo(hArray, panBlockCoordinates, psBlockInfo)
 end
 
 """
+    GDALMDArrayGetOverviewCount(GDALMDArrayH hArray) -> int
+
+Return the number of overview arrays available.
+
+### Parameters
+* **hArray**: Array.
+
+### Returns
+overview count, zero if none.
+"""
+function gdalmdarraygetoverviewcount(hArray)
+    aftercare(ccall((:GDALMDArrayGetOverviewCount, libgdal), Cint, (GDALMDArrayH,), hArray))
+end
+
+"""
+    GDALMDArrayGetOverview(GDALMDArrayH hArray,
+                           int nIdx) -> GDALMDArrayH
+
+Get overview array object.
+
+### Parameters
+* **hArray**: Array.
+* **nIdx**: overview index between 0 and GDALMDArrayGetOverviewCount()-1.
+
+### Returns
+overview GDALMDArray, or nullptr. Must be released with GDALMDArrayRelease()
+"""
+function gdalmdarraygetoverview(hArray, nIdx)
+    aftercare(
+        ccall(
+            (:GDALMDArrayGetOverview, libgdal),
+            GDALMDArrayH,
+            (GDALMDArrayH, Cint),
+            hArray,
+            nIdx,
+        ),
+    )
+end
+
+"""
+    GDALMDArrayBuildOverviews(GDALMDArrayH hArray,
+                              const char * pszResampling,
+                              int nOverviews,
+                              const int * panOverviewList,
+                              GDALProgressFunc pfnProgress,
+                              void * pProgressData,
+                              CSLConstList papszOptions) -> CPLErr
+
+Build overviews for a multidimensional array.
+"""
+function gdalmdarraybuildoverviews(
+    hArray,
+    pszResampling,
+    nOverviews,
+    panOverviewList,
+    pfnProgress,
+    pProgressData,
+    papszOptions,
+)
+    aftercare(
+        ccall(
+            (:GDALMDArrayBuildOverviews, libgdal),
+            CPLErr,
+            (GDALMDArrayH, Cstring, Cint, Ptr{Cint}, GDALProgressFunc, Any, CSLConstList),
+            hArray,
+            pszResampling,
+            nOverviews,
+            panOverviewList,
+            pfnProgress,
+            pProgressData,
+            papszOptions,
+        ),
+    )
+end
+
+"""
     GDALReleaseArrays(GDALMDArrayH * arrays,
                       size_t nCount) -> void
 
-Free the return of GDALMDArrayGetCoordinateVariables()
+Free the return of GDALMDArrayGetCoordinateVariables().
 
 ### Parameters
 * **arrays**: return pointer of above methods
@@ -18230,7 +18588,7 @@ end
     GDALReleaseAttributes(GDALAttributeH * attributes,
                           size_t nCount) -> void
 
-Free the return of GDALGroupGetAttributes() or GDALMDArrayGetAttributes()
+Free the return of GDALGroupGetAttributes() or GDALMDArrayGetAttributes().
 
 ### Parameters
 * **attributes**: return pointer of above methods
@@ -18375,7 +18733,7 @@ end
                                GByte * raw,
                                size_t nSize) -> void
 
-Free the return of GDALAttributeAsRaw()
+Free the return of GDALAttributeAsRaw().
 """
 function gdalattributefreerawresult(hAttr, raw, nSize)
     aftercare(
@@ -18539,7 +18897,7 @@ end
                           const void * pabyValue,
                           size_t nLength) -> int
 
-Write an attribute from raw values expressed in GetDataType()
+Write an attribute from raw values expressed in GetDataType().
 
 ### Parameters
 * **hAttr**: Attribute
@@ -18799,7 +19157,7 @@ end
     GDALReleaseDimensions(GDALDimensionH * dims,
                           size_t nCount) -> void
 
-Free the return of GDALGroupGetDimensions() or GDALMDArrayGetDimensions()
+Free the return of GDALGroupGetDimensions() or GDALMDArrayGetDimensions().
 
 ### Parameters
 * **dims**: return pointer of above methods
@@ -18976,7 +19334,7 @@ Compute optimal PCT for RGB image.
 * **hRed**: Red input band.
 * **hGreen**: Green input band.
 * **hBlue**: Blue input band.
-* **pfnIncludePixel**: function used to test which pixels should be included in the analysis. At this time this argument is ignored and all pixels are utilized. This should normally be NULL.
+* **pfnIncludePixel**: function used to test which pixels should be included in the analysis. At this time this argument is ignored. This should normally be NULL.
 * **nColors**: the desired number of colors to be returned (2-256).
 * **hColorTable**: the colors will be returned in this color table object.
 * **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
@@ -20896,7 +21254,21 @@ Create viewshed from raster DEM.
 * **pfnProgress**: A GDALProgressFunc that may be used to report progress to the user, or to interrupt the algorithm. May be NULL if not required.
 * **pProgressArg**: The callback data for the pfnProgress function.
 * **heightMode**: Type of information contained in output raster. Possible values GVOT_NORMAL = 1 (default), GVOT_MIN_TARGET_HEIGHT_FROM_DEM = 2, GVOT_MIN_TARGET_HEIGHT_FROM_GROUND = 3
-* **papszExtraOptions**: Future extra options. Must be set to NULL currently.
+* **papszExtraOptions**: Extra options to control the viewshed analysis. This is a NULL-terminated list of strings in "KEY=VALUE" format, or NULL for no options. The following keys are supported: 
+
+START_ANGLE: Mask all cells outside of the arc ('start-angle', 'end-angle'). Clockwise degrees from north. Also used to clamp the extent of the output raster. 
+
+
+END_ANGLE: Mask all cells outside of the arc ('start-angle', 'end-angle'). Clockwise degrees from north. Also used to clamp the extent of the output raster. 
+
+
+LOW_PITCH: Bound observable height to be no lower than the 'low-pitch' angle from the observer. Degrees from horizontal - positive is up. Must be less than 'high-pitch'. 
+
+
+HIGH_PITCH: Mark all cells out-of-range where the observable height would be higher than the 'high-pitch' angle from the observer. Degrees from horizontal - positive is up. Must be greater than 'low-pitch'. 
+
+
+If NULL, a 360-degree viewshed is calculated.
 
 ### Returns
 not NULL output dataset on success (to be closed with GDALClose()) or NULL if an error occurs.
@@ -21704,7 +22076,7 @@ end
 """
     GDALGridContextFree(GDALGridContext * psContext) -> void
 
-Free a context used created by GDALGridContextCreate()
+Free a context used created by GDALGridContextCreate().
 
 ### Parameters
 * **psContext**: the context.
@@ -21871,7 +22243,7 @@ struct GDALTriangulation
 end
 
 """
-    GDALHasTriangulation() -> int
+    GDALHasTriangulation(void) -> int
 
 Returns if GDAL is built with Delaunay triangulation support.
 
@@ -22152,6 +22524,31 @@ function gdalzonalstats(
             papszOptions,
             pfnProgress,
             pProgressArg,
+        ),
+    )
+end
+
+"""
+    gdalhilbertcode(poDomain, dfX, dfY)
+
+Provides a Hilbert code describing the location of a specified point within a specified spatial extent.
+
+# Arguments
+* `poDomain`: The domain to be covered by the Hilbert curve.
+* `dfX`: X coordinate of the point to encode
+* `dfY`: Y coordinate of the point to encode
+# Returns
+Hilbert-encoded point.
+"""
+function gdalhilbertcode(poDomain, dfX, dfY)
+    aftercare(
+        ccall(
+            (:GDALHilbertCode, libgdal),
+            UInt32,
+            (Ptr{OGREnvelope}, Cdouble, Cdouble),
+            poDomain,
+            dfX,
+            dfY,
         ),
     )
 end
@@ -23804,14 +24201,14 @@ end
 """
     VRTAddBand(VRTDatasetH hDataset,
                GDALDataType eType,
-               char ** papszOptions) -> int
+               CSLConstList papszOptions) -> int
 """
 function vrtaddband(arg1, arg2, arg3)
     aftercare(
         ccall(
             (:VRTAddBand, libgdal),
             Cint,
-            (VRTDatasetH, GDALDataType, Ptr{Cstring}),
+            (VRTDatasetH, GDALDataType, CSLConstList),
             arg1,
             arg2,
             arg3,
@@ -26248,7 +26645,7 @@ end
 """
     OGR_G_ForceTo(OGRGeometryH hGeom,
                   OGRwkbGeometryType eTargetType,
-                  char ** papszOptions) -> OGRGeometryH
+                  CSLConstList papszOptions) -> OGRGeometryH
 
 Convert to another geometry type.
 
@@ -26265,7 +26662,7 @@ function ogr_g_forceto(hGeom, eTargetType, papszOptions)
         ccall(
             (:OGR_G_ForceTo, libgdal),
             OGRGeometryH,
-            (OGRGeometryH, OGRwkbGeometryType, Ptr{Cstring}),
+            (OGRGeometryH, OGRwkbGeometryType, CSLConstList),
             hGeom,
             eTargetType,
             papszOptions,
@@ -26602,7 +26999,7 @@ end
 """
     OGRwkbExportOptionsDestroy(OGRwkbExportOptions * psOptions) -> void
 
-Destroy object returned by OGRwkbExportOptionsCreate()
+Destroy object returned by OGRwkbExportOptionsCreate().
 
 ### Parameters
 * **psOptions**: WKB export options
@@ -26954,7 +27351,7 @@ end
 
 """
     OGR_G_ExportToGMLEx(OGRGeometryH hGeometry,
-                        char ** papszOptions) -> char *
+                        CSLConstList papszOptions) -> char *
 
 Convert a geometry into GML format.
 
@@ -26970,7 +27367,7 @@ function ogr_g_exporttogmlex(arg1, papszOptions)
         ccall(
             (:OGR_G_ExportToGMLEx, libgdal),
             Cstring,
-            (OGRGeometryH, Ptr{Cstring}),
+            (OGRGeometryH, CSLConstList),
             arg1,
             papszOptions,
         ),
@@ -27059,7 +27456,7 @@ end
 
 """
     OGR_G_ExportToJsonEx(OGRGeometryH hGeometry,
-                         char ** papszOptions) -> char *
+                         CSLConstList papszOptions) -> char *
 
 Convert a geometry into GeoJSON-style format.
 
@@ -27075,7 +27472,7 @@ function ogr_g_exporttojsonex(arg1, papszOptions)
         ccall(
             (:OGR_G_ExportToJsonEx, libgdal),
             Cstring,
-            (OGRGeometryH, Ptr{Cstring}),
+            (OGRGeometryH, CSLConstList),
             arg1,
             papszOptions,
         ),
@@ -27252,7 +27649,7 @@ end
 """
     OGR_GeomTransformer_Destroy(OGRGeomTransformerH hTransformer) -> void
 
-Destroy a geometry transformer allocated with OGR_GeomTransformer_Create()
+Destroy a geometry transformer allocated with OGR_GeomTransformer_Create().
 
 ### Parameters
 * **hTransformer**: transformer object.
@@ -27577,7 +27974,7 @@ end
                       double dfRatio,
                       bool bAllowHoles) -> OGRGeometryH
 
-Compute "concave hull" of a geometry.
+Compute the concave hull of a geometry.
 
 ### Parameters
 * **hTarget**: The Geometry to calculate the concave hull of.
@@ -27595,6 +27992,37 @@ function ogr_g_concavehull(arg1, dfRatio, bAllowHoles)
             (OGRGeometryH, Cdouble, Bool),
             arg1,
             dfRatio,
+            bAllowHoles,
+        ),
+    )
+end
+
+"""
+    OGR_G_ConcaveHullOfPolygons(OGRGeometryH hTarget,
+                                double dfLengthRatio,
+                                bool bIsTight,
+                                bool bAllowHoles) -> OGRGeometryH
+
+Compute the concave hull of a set of polygons, respecting the polygons as constraints.
+
+### Parameters
+* **hTarget**: The Geometry to calculate the concave hull of.
+* **dfLengthRatio**: Specifies the Maximum Edge Length as a fraction of the difference between the longest and shortest edge lengths between the polygons. This normalizes the Maximum Edge Length to be scale-free. A value of 1 produces the convex hull; a value of 0 produces the original polygons.
+* **bIsTight**: Whether the hull must follow the outer boundaries of the input polygons.
+* **bAllowHoles**: Whether the concave hull is allowed to contain holes
+
+### Returns
+a new geometry to be freed by the caller with OGR_G_DestroyGeometry, or NULL if an error occurs.
+"""
+function ogr_g_concavehullofpolygons(arg1, dfLengthRatio, bIsTight, bAllowHoles)
+    aftercare(
+        ccall(
+            (:OGR_G_ConcaveHullOfPolygons, libgdal),
+            OGRGeometryH,
+            (OGRGeometryH, Cdouble, Bool, Bool),
+            arg1,
+            dfLengthRatio,
+            bIsTight,
             bAllowHoles,
         ),
     )
@@ -27914,7 +28342,7 @@ end
 """
     OGR_G_IsClockwise(OGRGeometryH hGeom) -> bool
 
-Returns true if the ring has clockwise winding (or less than 2 points)
+Returns true if the ring has clockwise winding (or less than 2 points).
 
 ### Parameters
 * **hGeom**: handle to a curve geometry
@@ -27999,10 +28427,28 @@ Test if the geometry is valid.
 * **hGeom**: The Geometry to test.
 
 ### Returns
-TRUE if the geometry has no points, otherwise FALSE.
+TRUE if the geometry is valid, otherwise FALSE.
 """
 function ogr_g_isvalid(arg1)
     aftercare(ccall((:OGR_G_IsValid, libgdal), Cint, (OGRGeometryH,), arg1))
+end
+
+"""
+    OGR_G_GetInvalidityReason(OGRGeometryH hGeom) -> char *
+
+Test if the geometry is valid and, if not, return the invalidity reason.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+a string with the invalidity reason, to free with CPLFree(), if the geometry is invalid, or nullptr if the geometry is valid.
+"""
+function ogr_g_getinvalidityreason(arg1)
+    aftercare(
+        ccall((:OGR_G_GetInvalidityReason, libgdal), Cstring, (OGRGeometryH,), arg1),
+        false,
+    )
 end
 
 """
@@ -28169,7 +28615,7 @@ end
     OGR_G_SymmetricDifference(OGRGeometryH hThis,
                               OGRGeometryH hOther) -> OGRGeometryH
 
-Compute symmetric difference (deprecated)
+Compute symmetric difference (deprecated).
 """
 function ogr_g_symmetricdifference(arg1, arg2)
     aftercare(
@@ -28186,7 +28632,7 @@ end
 """
     OGR_G_GetArea(OGRGeometryH hGeom) -> double
 
-Compute geometry area (deprecated)
+Compute geometry area (deprecated).
 """
 function ogr_g_getarea(arg1)
     aftercare(ccall((:OGR_G_GetArea, libgdal), Cdouble, (OGRGeometryH,), arg1))
@@ -28195,7 +28641,7 @@ end
 """
     OGR_G_GetBoundary(OGRGeometryH hTarget) -> OGRGeometryH
 
-Compute boundary (deprecated)
+Compute boundary (deprecated).
 """
 function ogr_g_getboundary(arg1)
     aftercare(ccall((:OGR_G_GetBoundary, libgdal), OGRGeometryH, (OGRGeometryH,), arg1))
@@ -28451,19 +28897,22 @@ end
 
 """
     OGR_G_SetPointCount(OGRGeometryH hGeom,
-                        int nNewPointCount) -> void
+                        int nNewPointCount) -> OGRErr
 
 Set number of points in a geometry.
 
 ### Parameters
 * **hGeom**: handle to the geometry.
 * **nNewPointCount**: the new number of points for geometry.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpointcount(hGeom, nNewPointCount)
     aftercare(
         ccall(
             (:OGR_G_SetPointCount, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint),
             hGeom,
             nNewPointCount,
@@ -28476,7 +28925,7 @@ end
                    int i,
                    double dfX,
                    double dfY,
-                   double dfZ) -> void
+                   double dfZ) -> OGRErr
 
 Set the location of a vertex in a point or linestring geometry.
 
@@ -28486,12 +28935,15 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfX**: input X coordinate to assign.
 * **dfY**: input Y coordinate to assign.
 * **dfZ**: input Z coordinate to assign (defaults to zero).
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpoint(arg1, iPoint, arg3, arg4, arg5)
     aftercare(
         ccall(
             (:OGR_G_SetPoint, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble),
             arg1,
             iPoint,
@@ -28506,7 +28958,7 @@ end
     OGR_G_SetPoint_2D(OGRGeometryH hGeom,
                       int i,
                       double dfX,
-                      double dfY) -> void
+                      double dfY) -> OGRErr
 
 Set the location of a vertex in a point or linestring geometry.
 
@@ -28515,12 +28967,15 @@ Set the location of a vertex in a point or linestring geometry.
 * **i**: the index of the vertex to assign (zero based) or zero for a point.
 * **dfX**: input X coordinate to assign.
 * **dfY**: input Y coordinate to assign.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpoint_2d(arg1, iPoint, arg3, arg4)
     aftercare(
         ccall(
             (:OGR_G_SetPoint_2D, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint, Cdouble, Cdouble),
             arg1,
             iPoint,
@@ -28535,7 +28990,7 @@ end
                     int i,
                     double dfX,
                     double dfY,
-                    double dfM) -> void
+                    double dfM) -> OGRErr
 
 Set the location of a vertex in a point or linestring geometry.
 
@@ -28545,12 +29000,15 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfX**: input X coordinate to assign.
 * **dfY**: input Y coordinate to assign.
 * **dfM**: input M coordinate to assign.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpointm(arg1, iPoint, arg3, arg4, arg5)
     aftercare(
         ccall(
             (:OGR_G_SetPointM, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble),
             arg1,
             iPoint,
@@ -28567,7 +29025,7 @@ end
                      double dfX,
                      double dfY,
                      double dfZ,
-                     double dfM) -> void
+                     double dfM) -> OGRErr
 
 Set the location of a vertex in a point or linestring geometry.
 
@@ -28578,12 +29036,15 @@ Set the location of a vertex in a point or linestring geometry.
 * **dfY**: input Y coordinate to assign.
 * **dfZ**: input Z coordinate to assign.
 * **dfM**: input M coordinate to assign.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpointzm(arg1, iPoint, arg3, arg4, arg5, arg6)
     aftercare(
         ccall(
             (:OGR_G_SetPointZM, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint, Cdouble, Cdouble, Cdouble, Cdouble),
             arg1,
             iPoint,
@@ -28599,7 +29060,7 @@ end
     OGR_G_AddPoint(OGRGeometryH hGeom,
                    double dfX,
                    double dfY,
-                   double dfZ) -> void
+                   double dfZ) -> OGRErr
 
 Add a point to a geometry (line string or point).
 
@@ -28608,12 +29069,15 @@ Add a point to a geometry (line string or point).
 * **dfX**: x coordinate of point to add.
 * **dfY**: y coordinate of point to add.
 * **dfZ**: z coordinate of point to add.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_addpoint(arg1, arg2, arg3, arg4)
     aftercare(
         ccall(
             (:OGR_G_AddPoint, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cdouble, Cdouble, Cdouble),
             arg1,
             arg2,
@@ -28626,7 +29090,7 @@ end
 """
     OGR_G_AddPoint_2D(OGRGeometryH hGeom,
                       double dfX,
-                      double dfY) -> void
+                      double dfY) -> OGRErr
 
 Add a point to a geometry (line string or point).
 
@@ -28634,12 +29098,15 @@ Add a point to a geometry (line string or point).
 * **hGeom**: handle to the geometry to add a point to.
 * **dfX**: x coordinate of point to add.
 * **dfY**: y coordinate of point to add.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_addpoint_2d(arg1, arg2, arg3)
     aftercare(
         ccall(
             (:OGR_G_AddPoint_2D, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cdouble, Cdouble),
             arg1,
             arg2,
@@ -28652,7 +29119,7 @@ end
     OGR_G_AddPointM(OGRGeometryH hGeom,
                     double dfX,
                     double dfY,
-                    double dfM) -> void
+                    double dfM) -> OGRErr
 
 Add a point to a geometry (line string or point).
 
@@ -28661,12 +29128,15 @@ Add a point to a geometry (line string or point).
 * **dfX**: x coordinate of point to add.
 * **dfY**: y coordinate of point to add.
 * **dfM**: m coordinate of point to add.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_addpointm(arg1, arg2, arg3, arg4)
     aftercare(
         ccall(
             (:OGR_G_AddPointM, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cdouble, Cdouble, Cdouble),
             arg1,
             arg2,
@@ -28681,7 +29151,7 @@ end
                      double dfX,
                      double dfY,
                      double dfZ,
-                     double dfM) -> void
+                     double dfM) -> OGRErr
 
 Add a point to a geometry (line string or point).
 
@@ -28691,12 +29161,15 @@ Add a point to a geometry (line string or point).
 * **dfY**: y coordinate of point to add.
 * **dfZ**: z coordinate of point to add.
 * **dfM**: m coordinate of point to add.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_addpointzm(arg1, arg2, arg3, arg4, arg5)
     aftercare(
         ccall(
             (:OGR_G_AddPointZM, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cdouble, Cdouble, Cdouble, Cdouble),
             arg1,
             arg2,
@@ -28715,7 +29188,7 @@ end
                     const void * pabyY,
                     int nYStride,
                     const void * pabyZ,
-                    int nZStride) -> void
+                    int nZStride) -> OGRErr
 
 Assign all points in a point or a line string geometry.
 
@@ -28728,6 +29201,9 @@ Assign all points in a point or a line string geometry.
 * **nYStride**: the number of bytes between 2 elements of pabyY.
 * **pabyZ**: list of Z coordinates (double values) of points being assigned (defaults to NULL for 2D objects).
 * **nZStride**: the number of bytes between 2 elements of pabyZ.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpoints(
     hGeom,
@@ -28742,7 +29218,7 @@ function ogr_g_setpoints(
     aftercare(
         ccall(
             (:OGR_G_SetPoints, libgdal),
-            Cvoid,
+            OGRErr,
             (OGRGeometryH, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}, Cint),
             hGeom,
             nPointsIn,
@@ -28766,7 +29242,7 @@ end
                       const void * pZ,
                       int nZStride,
                       const void * pM,
-                      int nMStride) -> void
+                      int nMStride) -> OGRErr
 
 Assign all points in a point or a line string geometry.
 
@@ -28781,6 +29257,9 @@ Assign all points in a point or a line string geometry.
 * **nZStride**: the number of bytes between 2 elements of pZ.
 * **pM**: list of M coordinates (double values) of points being assigned (if not NULL, upgrades the geometry to have M coordinate).
 * **nMStride**: the number of bytes between 2 elements of pM.
+
+### Returns
+(since 3.13) OGRERR_NONE in case of success, OGRERR_FAILURE in case of error.
 """
 function ogr_g_setpointszm(
     hGeom,
@@ -28797,7 +29276,7 @@ function ogr_g_setpointszm(
     aftercare(
         ccall(
             (:OGR_G_SetPointsZM, libgdal),
-            Cvoid,
+            OGRErr,
             (
                 OGRGeometryH,
                 Cint,
@@ -28982,7 +29461,7 @@ end
 """
     OGR_G_GetLinearGeometry(OGRGeometryH hGeom,
                             double dfMaxAngleStepSizeDegrees,
-                            char ** papszOptions) -> OGRGeometryH
+                            CSLConstList papszOptions) -> OGRGeometryH
 
 Return, possibly approximate, linear version of this geometry.
 
@@ -28999,7 +29478,7 @@ function ogr_g_getlineargeometry(hGeom, dfMaxAngleStepSizeDegrees, papszOptions)
         ccall(
             (:OGR_G_GetLinearGeometry, libgdal),
             OGRGeometryH,
-            (OGRGeometryH, Cdouble, Ptr{Cstring}),
+            (OGRGeometryH, Cdouble, CSLConstList),
             hGeom,
             dfMaxAngleStepSizeDegrees,
             papszOptions,
@@ -29009,7 +29488,7 @@ end
 
 """
     OGR_G_GetCurveGeometry(OGRGeometryH hGeom,
-                           char ** papszOptions) -> OGRGeometryH
+                           CSLConstList papszOptions) -> OGRGeometryH
 
 Return curve version of this geometry.
 
@@ -29025,7 +29504,7 @@ function ogr_g_getcurvegeometry(hGeom, papszOptions)
         ccall(
             (:OGR_G_GetCurveGeometry, libgdal),
             OGRGeometryH,
-            (OGRGeometryH, Ptr{Cstring}),
+            (OGRGeometryH, CSLConstList),
             hGeom,
             papszOptions,
         ),
@@ -31076,13 +31555,13 @@ function Base.getproperty(x::Ptr{OGRField}, f::Symbol)
     f === :Integer64 && return Ptr{GIntBig}(x + 0)
     f === :Real && return Ptr{Cdouble}(x + 0)
     f === :String && return Ptr{Cstring}(x + 0)
-    f === :IntegerList && return Ptr{__JL_Ctag_1}(x + 0)
-    f === :Integer64List && return Ptr{__JL_Ctag_2}(x + 0)
-    f === :RealList && return Ptr{__JL_Ctag_3}(x + 0)
-    f === :StringList && return Ptr{__JL_Ctag_4}(x + 0)
-    f === :Binary && return Ptr{__JL_Ctag_5}(x + 0)
-    f === :Set && return Ptr{__JL_Ctag_6}(x + 0)
-    f === :Date && return Ptr{__JL_Ctag_7}(x + 0)
+    f === :IntegerList && return Ptr{__JL_Ctag_55}(x + 0)
+    f === :Integer64List && return Ptr{__JL_Ctag_56}(x + 0)
+    f === :RealList && return Ptr{__JL_Ctag_57}(x + 0)
+    f === :StringList && return Ptr{__JL_Ctag_58}(x + 0)
+    f === :Binary && return Ptr{__JL_Ctag_59}(x + 0)
+    f === :Set && return Ptr{__JL_Ctag_60}(x + 0)
+    f === :Date && return Ptr{__JL_Ctag_61}(x + 0)
     return getfield(x, f)
 end
 
@@ -32365,7 +32844,7 @@ end
 """
     OGR_F_FillUnsetWithDefault(OGRFeatureH hFeat,
                                int bNotNullableOnly,
-                               char ** papszOptions) -> void
+                               CSLConstList papszOptions) -> void
 
 Fill unset fields with default values that might be defined.
 
@@ -32379,7 +32858,7 @@ function ogr_f_fillunsetwithdefault(hFeat, bNotNullableOnly, papszOptions)
         ccall(
             (:OGR_F_FillUnsetWithDefault, libgdal),
             Cvoid,
-            (OGRFeatureH, Cint, Ptr{Cstring}),
+            (OGRFeatureH, Cint, CSLConstList),
             hFeat,
             bNotNullableOnly,
             papszOptions,
@@ -33167,6 +33646,21 @@ function ogr_l_setattributefilter(arg1, arg2)
     )
 end
 
+"""
+    OGR_L_GetAttributeFilter(OGRLayerH hLayer) -> const char *
+
+Fetch the current attribute query string.
+
+### Returns
+the current attribute query string, or NULL if no attribute query is currently installed. The returned string is short lived and owned by the layer and should not be modified or freed by the caller.
+"""
+function ogr_l_getattributefilter(arg1)
+    aftercare(
+        ccall((:OGR_L_GetAttributeFilter, libgdal), Cstring, (OGRLayerH,), arg1),
+        false,
+    )
+end
+
 struct ArrowArrayStream
     get_schema::Ptr{Cvoid}
     get_next::Ptr{Cvoid}
@@ -33178,7 +33672,7 @@ end
 """
     OGR_L_GetArrowStream(OGRLayerH hLayer,
                          struct ArrowArrayStream * out_stream,
-                         char ** papszOptions) -> bool
+                         CSLConstList papszOptions) -> bool
 
 Get a Arrow C stream.
 
@@ -33195,7 +33689,7 @@ function ogr_l_getarrowstream(hLayer, out_stream, papszOptions)
         ccall(
             (:OGR_L_GetArrowStream, libgdal),
             Bool,
-            (OGRLayerH, Ptr{ArrowArrayStream}, Ptr{Cstring}),
+            (OGRLayerH, Ptr{ArrowArrayStream}, CSLConstList),
             hLayer,
             out_stream,
             papszOptions,
@@ -33218,7 +33712,7 @@ end
 """
     OGR_L_IsArrowSchemaSupported(OGRLayerH hLayer,
                                  const struct ArrowSchema * schema,
-                                 char ** papszOptions,
+                                 CSLConstList papszOptions,
                                  char ** ppszErrorMsg) -> bool
 
 Returns whether the provided ArrowSchema is supported for writing.
@@ -33237,7 +33731,7 @@ function ogr_l_isarrowschemasupported(hLayer, schema, papszOptions, ppszErrorMsg
         ccall(
             (:OGR_L_IsArrowSchemaSupported, libgdal),
             Bool,
-            (OGRLayerH, Ptr{ArrowSchema}, Ptr{Cstring}, Ptr{Cstring}),
+            (OGRLayerH, Ptr{ArrowSchema}, CSLConstList, Ptr{Cstring}),
             hLayer,
             schema,
             papszOptions,
@@ -33249,7 +33743,7 @@ end
 """
     OGR_L_CreateFieldFromArrowSchema(OGRLayerH hLayer,
                                      const struct ArrowSchema * schema,
-                                     char ** papszOptions) -> bool
+                                     CSLConstList papszOptions) -> bool
 
 Creates a field from an ArrowSchema.
 
@@ -33266,7 +33760,7 @@ function ogr_l_createfieldfromarrowschema(hLayer, schema, papszOptions)
         ccall(
             (:OGR_L_CreateFieldFromArrowSchema, libgdal),
             Bool,
-            (OGRLayerH, Ptr{ArrowSchema}, Ptr{Cstring}),
+            (OGRLayerH, Ptr{ArrowSchema}, CSLConstList),
             hLayer,
             schema,
             papszOptions,
@@ -33291,7 +33785,7 @@ end
     OGR_L_WriteArrowBatch(OGRLayerH hLayer,
                           const struct ArrowSchema * schema,
                           struct ArrowArray * array,
-                          char ** papszOptions) -> bool
+                          CSLConstList papszOptions) -> bool
 
 Writes a batch of rows from an ArrowArray.
 
@@ -33309,7 +33803,7 @@ function ogr_l_writearrowbatch(hLayer, schema, array, papszOptions)
         ccall(
             (:OGR_L_WriteArrowBatch, libgdal),
             Bool,
-            (OGRLayerH, Ptr{ArrowSchema}, Ptr{ArrowArray}, Ptr{Cstring}),
+            (OGRLayerH, Ptr{ArrowSchema}, Ptr{ArrowArray}, CSLConstList),
             hLayer,
             schema,
             array,
@@ -34120,7 +34614,7 @@ end
     OGR_L_Intersection(OGRLayerH pLayerInput,
                        OGRLayerH pLayerMethod,
                        OGRLayerH pLayerResult,
-                       char ** papszOptions,
+                       CSLConstList papszOptions,
                        GDALProgressFunc pfnProgress,
                        void * pProgressArg) -> OGRErr
 
@@ -34142,7 +34636,7 @@ function ogr_l_intersection(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Intersection, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34157,7 +34651,7 @@ end
     OGR_L_Union(OGRLayerH pLayerInput,
                 OGRLayerH pLayerMethod,
                 OGRLayerH pLayerResult,
-                char ** papszOptions,
+                CSLConstList papszOptions,
                 GDALProgressFunc pfnProgress,
                 void * pProgressArg) -> OGRErr
 
@@ -34179,7 +34673,7 @@ function ogr_l_union(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Union, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34194,7 +34688,7 @@ end
     OGR_L_SymDifference(OGRLayerH pLayerInput,
                         OGRLayerH pLayerMethod,
                         OGRLayerH pLayerResult,
-                        char ** papszOptions,
+                        CSLConstList papszOptions,
                         GDALProgressFunc pfnProgress,
                         void * pProgressArg) -> OGRErr
 
@@ -34216,7 +34710,7 @@ function ogr_l_symdifference(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_SymDifference, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34231,7 +34725,7 @@ end
     OGR_L_Identity(OGRLayerH pLayerInput,
                    OGRLayerH pLayerMethod,
                    OGRLayerH pLayerResult,
-                   char ** papszOptions,
+                   CSLConstList papszOptions,
                    GDALProgressFunc pfnProgress,
                    void * pProgressArg) -> OGRErr
 
@@ -34253,7 +34747,7 @@ function ogr_l_identity(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Identity, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34268,7 +34762,7 @@ end
     OGR_L_Update(OGRLayerH pLayerInput,
                  OGRLayerH pLayerMethod,
                  OGRLayerH pLayerResult,
-                 char ** papszOptions,
+                 CSLConstList papszOptions,
                  GDALProgressFunc pfnProgress,
                  void * pProgressArg) -> OGRErr
 
@@ -34290,7 +34784,7 @@ function ogr_l_update(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Update, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34305,7 +34799,7 @@ end
     OGR_L_Clip(OGRLayerH pLayerInput,
                OGRLayerH pLayerMethod,
                OGRLayerH pLayerResult,
-               char ** papszOptions,
+               CSLConstList papszOptions,
                GDALProgressFunc pfnProgress,
                void * pProgressArg) -> OGRErr
 
@@ -34327,7 +34821,7 @@ function ogr_l_clip(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Clip, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34342,7 +34836,7 @@ end
     OGR_L_Erase(OGRLayerH pLayerInput,
                 OGRLayerH pLayerMethod,
                 OGRLayerH pLayerResult,
-                char ** papszOptions,
+                CSLConstList papszOptions,
                 GDALProgressFunc pfnProgress,
                 void * pProgressArg) -> OGRErr
 
@@ -34364,7 +34858,7 @@ function ogr_l_erase(arg1, arg2, arg3, arg4, arg5, arg6)
         ccall(
             (:OGR_L_Erase, libgdal),
             OGRErr,
-            (OGRLayerH, OGRLayerH, OGRLayerH, Ptr{Cstring}, GDALProgressFunc, Any),
+            (OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList, GDALProgressFunc, Any),
             arg1,
             arg2,
             arg3,
@@ -34909,7 +35403,7 @@ end
                   int bUpdate,
                   OGRSFDriverH * pahDriverList) -> OGRDataSourceH
 
-Open a file / data source with one of the registered drivers if not already opened, or increment reference count of already opened data source previously opened with OGROpenShared()
+Open a file / data source with one of the registered drivers if not already opened, or increment reference count of already opened data source previously opened with OGROpenShared().
 
 ### Parameters
 * **pszName**: the name of the file, or data source to open.
@@ -38311,7 +38805,7 @@ end
 
 """
     OSRFindMatches(OGRSpatialReferenceH hSRS,
-                   char ** papszOptions,
+                   CSLConstList papszOptions,
                    int * pnEntries,
                    int ** ppanMatchConfidence) -> OGRSpatialReferenceH *
 
@@ -38331,7 +38825,7 @@ function osrfindmatches(hSRS, papszOptions, pnEntries, ppanMatchConfidence)
         ccall(
             (:OSRFindMatches, libgdal),
             Ptr{OGRSpatialReferenceH},
-            (OGRSpatialReferenceH, Ptr{Cstring}, Ptr{Cint}, Ptr{Ptr{Cint}}),
+            (OGRSpatialReferenceH, CSLConstList, Ptr{Cint}, Ptr{Ptr{Cint}}),
             hSRS,
             papszOptions,
             pnEntries,
@@ -38343,7 +38837,7 @@ end
 """
     OSRFreeSRSArray(OGRSpatialReferenceH * pahSRS) -> void
 
-Free return of OSRIdentifyMatches()
+Free return of OSRIdentifyMatches().
 
 ### Parameters
 * **pahSRS**: array of SRS (must be NULL terminated)
@@ -38803,7 +39297,7 @@ end
 """
     osrsetgs(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
 
-Gall Stereograpic
+Gall Stereographic
 """
 function osrsetgs(hSRS, dfCentralMeridian, dfFalseEasting, dfFalseNorthing)
     aftercare(
@@ -40464,141 +40958,141 @@ function octtransformbounds(
     )
 end
 
-struct __JL_Ctag_1
+struct __JL_Ctag_55
     nCount::Cint
     paList::Ptr{Cint}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_1}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_55}, f::Symbol)
     f === :nCount && return Ptr{Cint}(x + 0)
     f === :paList && return Ptr{Ptr{Cint}}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1, f::Symbol)
-    r = Ref{__JL_Ctag_1}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1}, r)
+function Base.getproperty(x::__JL_Ctag_55, f::Symbol)
+    r = Ref{__JL_Ctag_55}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_55}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_55}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_2
+struct __JL_Ctag_56
     nCount::Cint
     paList::Ptr{GIntBig}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_2}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :nCount && return Ptr{Cint}(x + 0)
     f === :paList && return Ptr{Ptr{GIntBig}}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_2, f::Symbol)
-    r = Ref{__JL_Ctag_2}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_2}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_2}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_3
+struct __JL_Ctag_57
     nCount::Cint
     paList::Ptr{Cdouble}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_3}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :nCount && return Ptr{Cint}(x + 0)
     f === :paList && return Ptr{Ptr{Cdouble}}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_3, f::Symbol)
-    r = Ref{__JL_Ctag_3}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_3}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_3}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_4
+struct __JL_Ctag_58
     nCount::Cint
     paList::Ptr{Cstring}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_4}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :nCount && return Ptr{Cint}(x + 0)
     f === :paList && return Ptr{Ptr{Cstring}}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_4, f::Symbol)
-    r = Ref{__JL_Ctag_4}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_4}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_4}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_5
+struct __JL_Ctag_59
     nCount::Cint
     paData::Ptr{GByte}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_5}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :nCount && return Ptr{Cint}(x + 0)
     f === :paData && return Ptr{Ptr{GByte}}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_5, f::Symbol)
-    r = Ref{__JL_Ctag_5}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_5}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_5}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_6
+struct __JL_Ctag_60
     nMarker1::Cint
     nMarker2::Cint
     nMarker3::Cint
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_6}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
     f === :nMarker1 && return Ptr{Cint}(x + 0)
     f === :nMarker2 && return Ptr{Cint}(x + 4)
     f === :nMarker3 && return Ptr{Cint}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_6, f::Symbol)
-    r = Ref{__JL_Ctag_6}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_6}, r)
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_6}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
-struct __JL_Ctag_7
+struct __JL_Ctag_61
     Year::GInt16
     Month::GByte
     Day::GByte
@@ -40609,7 +41103,7 @@ struct __JL_Ctag_7
     Second::Cfloat
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_7}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_61}, f::Symbol)
     f === :Year && return Ptr{GInt16}(x + 0)
     f === :Month && return Ptr{GByte}(x + 2)
     f === :Day && return Ptr{GByte}(x + 3)
@@ -40621,14 +41115,14 @@ function Base.getproperty(x::Ptr{__JL_Ctag_7}, f::Symbol)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_7, f::Symbol)
-    r = Ref{__JL_Ctag_7}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_7}, r)
+function Base.getproperty(x::__JL_Ctag_61, f::Symbol)
+    r = Ref{__JL_Ctag_61}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_61}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_7}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_61}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -40636,7 +41130,7 @@ const GDAL_PREFIX = "/workspace/destdir"
 
 const SIZEOF_INT = 4
 
-const SIZEOF_UNSIGNED_LONG = 4
+const SIZEOF_UNSIGNED_LONG = 8
 
 const SIZEOF_VOIDP = 8
 
@@ -40645,6 +41139,8 @@ const SIZEOF_SIZE_T = 8
 const USE_GCC_VISIBILITY_FLAG = 1
 
 const HAVE_GCC_ATOMIC_BUILTINS = 1
+
+const CPL_NULL_VALUE = "__CPL_NULL_VALUE__"
 
 const CPLE_None = 0
 
@@ -40710,7 +41206,7 @@ const GINT64_MAX = GINTBIG_MAX
 
 const GUINT64_MAX = GUINTBIG_MAX
 
-const CPL_FRMT_GB_WITHOUT_PREFIX = "I64"
+const CPL_FRMT_GB_WITHOUT_PREFIX = "ll"
 
 const CPL_IS_LSB = 1
 
@@ -40732,9 +41228,9 @@ const VSI_STAT_CACHE_ONLY = 0x10
 
 const GDAL_VERSION_MAJOR = 3
 
-const GDAL_VERSION_MINOR = 12
+const GDAL_VERSION_MINOR = 13
 
-const GDAL_VERSION_REV = 1
+const GDAL_VERSION_REV = 3
 
 const GDAL_VERSION_BUILD = 0
 
@@ -40742,13 +41238,15 @@ const GDAL_VERSION_NUM =
     GDAL_COMPUTE_VERSION(GDAL_VERSION_MAJOR, GDAL_VERSION_MINOR, GDAL_VERSION_REV) +
     GDAL_VERSION_BUILD
 
-const GDAL_RELEASE_DATE = 20251212
+const GDAL_RELEASE_DATE = 20260813
 
-const GDAL_RELEASE_NAME = "3.12.1"
+const GDAL_RELEASE_NAME = "3.13.3"
 
-const GDAL_RELEASE_NICKNAME = "Chicoutimi"
+const GDAL_RELEASE_NICKNAME = "Iowa City"
 
-const RASTERIO_EXTRA_ARG_CURRENT_VERSION = 2
+const GDT_Byte = GDT_UInt8
+
+const RASTERIO_EXTRA_ARG_CURRENT_VERSION = 3
 
 const GCI_IR_Start = 20
 
@@ -40885,6 +41383,8 @@ const GDAL_DCAP_FEATURE_STYLES_WRITE = "DCAP_FEATURE_STYLES_WRITE"
 const GDAL_DCAP_COORDINATE_EPOCH = "DCAP_COORDINATE_EPOCH"
 
 const GDAL_DCAP_MULTIPLE_VECTOR_LAYERS = "DCAP_MULTIPLE_VECTOR_LAYERS"
+
+const GDAL_DCAP_MULTIPLE_VECTOR_LAYERS_IN_DIRECTORY = "GDAL_DCAP_MULTIPLE_VECTOR_LAYERS_IN_DIRECTORY"
 
 const GDAL_DCAP_FIELD_DOMAINS = "DCAP_FIELD_DOMAINS"
 


### PR DESCRIPTION
Regenerates the wrappers against GDAL_jll 305.1300.301 (GDAL 3.13.3), bumps the compat bound to `GDAL_jll = "305.1300"`, and bumps the package version to 1.13.0, following the same pattern as #202 (3.12) and #194 (3.11).

## Wrapper changes

- New functions: `GDALCloseEx`, `GDALClearMemoryCaches`, dataset inter-band covariance matrix functions, mdarray overviews, `GDALHilbertCode`, `OGR_G_GetInvalidityReason`, `OGR_G_ConcaveHullOfPolygons`, `OGR_L_GetAttributeFilter`, `GDALGetColorInterpretationList`.
- Upstream renamed `GDT_Byte` to `GDT_UInt8`. The enum member is now `GDT_UInt8`; `GDT_Byte` remains available as a `const` alias, so ArchGDAL's `convert` tables keep working unchanged.
- `RASTERIO_EXTRA_ARG_CURRENT_VERSION` is now 3.
- A few platform-dependent constants (`CPL_FRMT_GB_WITHOUT_PREFIX`, `SIZEOF_UNSIGNED_LONG`, `VSIStatBufL`) reflect a Linux generation host. They were last generated on Windows in #190, so this returns them to the values they had before 3.10.

`gen/doxygen.xml` was regenerated from the v3.13.3 source with doxygen 1.15. Note for whoever runs the generator next: doxygen ≥ 1.9 emits a `Doxyfile.xml` alongside the per-file XML, and `combine_gdal_doxygen_xml.py` does not exclude it, so it has to be moved aside before combining or it can end up as the merged root.

## Testing

- GDAL.jl test suite: 157/157 on Julia 1.12, Linux x86_64.
- ArchGDAL 0.10.12 test suite against this branch: all functional tests pass. The only failure is Aqua's persistent-tasks check, which builds a fresh environment that resolves the *registered* GDAL.jl 1.12 and GDAL_jll 304, so it cannot pass until this release exists.
- Also exercised against a locally built GDAL 3.13.3 from the Yggdrasil recipe: new wrappers bind correctly, GeoTIFF write/read, warp via PROJ, and GeoPackage write/read all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRfocB47kS3dTCihR1P16C
